### PR TITLE
Add router to single registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'null_logger'
 gem 'exception_notification'
 
 gem 'gds-api-adapters'
-gem 'router-client', "3.0.2"
+gem 'router-client', "3.1.0"
 
 gem 'aws-ses', require: 'aws/ses'
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'null_logger'
 gem 'exception_notification'
 
 gem 'gds-api-adapters'
+gem 'router-client', "3.0.2"
 
 gem 'aws-ses', require: 'aws/ses'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    router-client (3.0.2)
+    router-client (3.1.0)
       activesupport
       builder
       null_logger
@@ -306,7 +306,7 @@ DEPENDENCIES
   rack (= 1.3.5)
   rails (~> 3.1.1)
   rake (= 0.9.2)
-  router-client (= 3.0.2)
+  router-client (= 3.1.0)
   rummageable (~> 0.3.0)
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,10 @@ GEM
       json (~> 1.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    router-client (3.0.2)
+      activesupport
+      builder
+      null_logger
     rubyzip (0.9.5)
     rummageable (0.3.0)
       json
@@ -302,6 +306,7 @@ DEPENDENCIES
   rack (= 1.3.5)
   rails (~> 3.1.1)
   rake (= 0.9.2)
+  router-client (= 3.0.2)
   rummageable (~> 0.3.0)
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -3,5 +3,5 @@ require "artefact"
 class Artefact
   # Add a non-field attribute so we can pass indexable content over to Rummager
   # without persisting it
-  attr_accessor :indexable_content
+  attr_accessor :indexable_content, :paths, :prefixes
 end

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -21,6 +21,13 @@ class RoutableArtefact
 
   def submit
     ensure_application_exists
-    @router.create_route(@artefact.slug, "full", @artefact.owning_app)
+    paths = (@artefact.paths || [])
+    paths << @artefact.slug
+    paths.uniq.each do |path|
+      @router.create_route(path, "full", @artefact.owning_app)
+    end
+    (@artefact.prefixes || []).each do |prefix|
+      @router.create_route(prefix, "prefix", @artefact.owning_app)
+    end
   end
 end

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -22,11 +22,14 @@ class RoutableArtefact
   def submit
     ensure_application_exists
     paths = (@artefact.paths || [])
-    paths << @artefact.slug
+    prefixes = (@artefact.prefixes || [])
+    unless prefixes.include?(@artefact.slug)
+      paths << @artefact.slug
+    end
     paths.uniq.each do |path|
       @router.create_route(path, "full", @artefact.owning_app)
     end
-    (@artefact.prefixes || []).each do |prefix|
+    prefixes.each do |prefix|
       @router.create_route(prefix, "prefix", @artefact.owning_app)
     end
   end

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -11,7 +11,7 @@ class RoutableArtefact
   end
 
   def router
-    @router ||= Router.new("http://router.cluster:8080/router")
+    @router ||= Router.new("http://router.cluster:8080")
   end
 
   def ensure_application_exists

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -11,7 +11,7 @@ class RoutableArtefact
   end
 
   def router
-    @router ||= Router.new("http://router.cluster:8080")
+    @router ||= Router.new
   end
 
   def ensure_application_exists

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -1,0 +1,26 @@
+require 'router'
+
+class RoutableArtefact
+
+  def initialize(artefact)
+    @artefact = artefact
+  end
+
+  def logger
+    Rails.logger
+  end
+
+  def router
+    @router ||= Router.new("http://router.cluster:8080/router")
+  end
+
+  def ensure_application_exists
+    backend_url = Plek.current.find(@artefact.owning_app)
+    router.update_application(@artefact.owning_app, backend_url)
+  end
+
+  def submit
+    ensure_application_exists
+    @router.create_route(@artefact.slug, "full", @artefact.owning_app)
+  end
+end

--- a/app/observers/update_router_observer.rb
+++ b/app/observers/update_router_observer.rb
@@ -2,6 +2,6 @@ class UpdateRouterObserver < Mongoid::Observer
   observe :artefact
 
   def after_save(artefact)
-    RouteableArtefact.new(artefact).submit if artefact.live?
+    RoutableArtefact.new(artefact).submit if artefact.live?
   end
 end

--- a/app/observers/update_router_observer.rb
+++ b/app/observers/update_router_observer.rb
@@ -1,0 +1,7 @@
+class UpdateRouterObserver < Mongoid::Observer
+  observe :artefact
+
+  def after_save(artefact)
+    RouteableArtefact.new(artefact).submit if artefact.live?
+  end
+end

--- a/config/initializers/router_callback.rb
+++ b/config/initializers/router_callback.rb
@@ -1,0 +1,18 @@
+# In development environments we don't want to depend on Router unless
+# explicitly told to do so
+unless Rails.env.development?
+  update_router = true
+else
+  update_router = ENV['UPDATE_ROUTER'].present?
+end
+
+if update_router
+  Rails.logger.info "Registering router observer for artefacts"
+  # Use to_prepare so this gets reloaded with the app when in development
+  # In production, it will only be called once
+  ActionDispatch::Callbacks.to_prepare do
+    Panopticon::Application.config.mongoid.observers << :update_router_observer
+  end
+else
+  Rails.logger.info "In development/test mode: not registering router observer"
+end

--- a/features/editing.feature
+++ b/features/editing.feature
@@ -5,6 +5,7 @@ Feature: Editing artefacts
   Background:
     Given I am an admin
       And I have stubbed search
+      And I have stubbed the router
 
   Scenario: Editing an artefact and changing the slug
     Given two artefacts exist

--- a/features/registering_resources.feature
+++ b/features/registering_resources.feature
@@ -7,17 +7,20 @@ Feature: Registering resources
     When I put a new smart answer's details into panopticon
     Then a new artefact should be created
       And rummager should be notified
+      And the router should be notified
 
   Scenario: Updating a smart answer
     When I put updated smart answer details into panopticon
     Then the relevant artefact should be updated
       And the API should reflect the change
       And rummager should be notified
+      And the router should be notified
 
   Scenario: Creating a draft item
     When I put a draft smart answer's details into panopticon
     Then a new artefact should be created
       And rummager should not be notified
+      And the router should not be notified
 
   Scenario: Putting an item whose slug is owned by another app
     When I put a new item into panopticon whose slug is already taken

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -2,6 +2,10 @@ Given /^I have stubbed search$/ do
   stub_search
 end
 
+Given /^I have stubbed the router$/ do
+  stub_router
+end
+
 When /^I put a new smart answer's details into panopticon$/ do
   prepare_registration_environment
 
@@ -64,6 +68,20 @@ end
 
 Then /^rummager should be notified$/ do
   assert_requested @fake_search, times: 1  # The default, but let's be explicit
+end
+
+Then /^the router should be notified$/ do
+  assert ! @fake_routers.blank?, "No router requests registered to assert on"
+  @fake_routers.each do |fake_router|
+    assert_requested fake_router, times: 1
+  end
+end
+
+Then /^the router should not be notified$/ do
+  assert ! @fake_routers.blank?, "No router requests registered to assert on"
+  @fake_routers.each do |fake_router|
+    assert_not_requested fake_router
+  end
 end
 
 Then /^rummager should be told to do a partial update$/ do

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -39,18 +39,18 @@ module RegistrationInfo
   end
 
   def stub_router
-    WebMock.stub_request(:put, %r{^#{ROUTER_ROOT}/router/applications/.*$}).
+    WebMock.stub_request(:put, %r{^#{ROUTER_ROOT}/applications/.*$}).
         with(:body => { "backend_url" => %r{^.*.test.gov.uk:80$} }).
         to_return(:status => 200, :body => "{}", :headers => {})
 
     # catch-all
-    WebMock.stub_request(:put, %r{^#{ROUTER_ROOT}/router/routes/.*$}).
+    WebMock.stub_request(:put, %r{^#{ROUTER_ROOT}/routes/.*$}).
           with(:body => {"application_id" => /.+/, "route_type" => "full"}).
           to_return(:status => 200, :body => "{}", :headers => {})
 
     # so that we can assert on them later
     @fake_routers = [OpenStruct.new(example_smart_answer), @artefact, @related_artefact].reject(&:nil?).map do |artefact|
-      WebMock.stub_request(:put, "#{ROUTER_ROOT}/router/routes/#{artefact.slug}").
+      WebMock.stub_request(:put, "#{ROUTER_ROOT}/routes/#{artefact.slug}").
             with(:body => { "application_id" => artefact.owning_app, "route_type" => "full"}).
             to_return(:status => 200, :body => "{}", :headers => {})
     end

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -65,10 +65,8 @@ module RegistrationInfo
   end
 
   def setup_existing_artefact
-    Artefact.observers.disable :update_search_observer do
-      Artefact.observers.disable :update_router_observer do
-        @artefact = Artefact.create!(example_smart_answer)
-      end
+    Artefact.observers.disable :update_search_observer, :update_router_observer do
+      @artefact = Artefact.create!(example_smart_answer)
     end
   end
 end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -47,4 +47,16 @@ class RoutableArtefactTest < ActiveSupport::TestCase
     Router.any_instance.expects(:create_route).with("re", "prefix", "bee")
     @routable.submit
   end
+
+  context "the slug is also a prefix" do
+    setup do
+      @artefact.prefixes = [@artefact.slug]
+    end
+
+    should "send it as a prefix, and not send a full route" do
+      Router.any_instance.stubs(:update_application)
+      Router.any_instance.expects(:create_route).with(@artefact.slug, "prefix", "bee")
+      @routable.submit
+    end
+  end
 end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class RouteableArtefactTest < ActiveSupport::TestCase
+  setup do
+    @artefact = FactoryGirl.create(:artefact, owning_app: "bee")
+    @routable = RoutableArtefact.new(@artefact)
+  end
+
+  should "ensure that the application exists in the router" do
+    Router.any_instance.expects(:update_application).with("bee", "http://bee.test.gov.uk")
+    Router.any_instance.stubs(:create_route)
+    @routable.submit
+  end
+
+  should "create a full route for the slug" do
+    Router.any_instance.stubs(:update_application)
+    Router.any_instance.expects(:create_route).with(@artefact.slug, "full", "bee")
+    @routable.submit
+  end
+end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RouteableArtefactTest < ActiveSupport::TestCase
+class RoutableArtefactTest < ActiveSupport::TestCase
   setup do
     @artefact = FactoryGirl.create(:artefact, owning_app: "bee")
     @routable = RoutableArtefact.new(@artefact)

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -17,4 +17,34 @@ class RouteableArtefactTest < ActiveSupport::TestCase
     Router.any_instance.expects(:create_route).with(@artefact.slug, "full", "bee")
     @routable.submit
   end
+
+  should "create full routes for paths" do
+    @artefact.paths = ["#{@artefact.slug}.json", "#{@artefact.slug}.ics"]
+    Router.any_instance.stubs(:update_application)
+    Router.any_instance.stubs(:create_route).with(@artefact.slug, "full", "bee")
+    Router.any_instance.expects(:create_route).with("#{@artefact.slug}.json", "full", "bee")
+    Router.any_instance.expects(:create_route).with("#{@artefact.slug}.ics", "full", "bee")
+    @routable.submit
+  end
+
+  context "the slug is repeated in one of the paths" do
+    setup do
+      @artefact.paths = [@artefact.slug]
+    end
+
+    should "not (attempt to) register duplicate full routes" do
+      Router.any_instance.stubs(:update_application)
+      Router.any_instance.expects(:create_route).with(@artefact.slug, "full", "bee")
+      @routable.submit
+    end
+  end
+
+  should "create prefix routes for prefixes" do
+    @artefact.prefixes = ["un", "re"]
+    Router.any_instance.stubs(:update_application)
+    Router.any_instance.stubs(:create_route).with(@artefact.slug, "full", "bee")
+    Router.any_instance.expects(:create_route).with("un", "prefix", "bee")
+    Router.any_instance.expects(:create_route).with("re", "prefix", "bee")
+    @routable.submit
+  end
 end


### PR DESCRIPTION
Panopticon currently handles registration of content with search (rummager). This adds responsibility for registering with the router.

We should be able to safely merge and roll this out, and then update the apps at our leisure. Double-registrations shouldn't cost us anything.

We should probably store the router URL in Plek, but hardcoding it is how it is done in e.g. calendars.

https://www.pivotaltracker.com/story/show/31828041
