### PR TITLE
Artefact audit trail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "~> 0.2.4"
+  gem "govuk_content_models", "0.3.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       json
     gherkin (2.7.3)
       json (>= 1.4.6)
-    govuk_content_models (0.2.5)
+    govuk_content_models (0.3.0)
       bson_ext
       differ
       gds-api-adapters
@@ -297,7 +297,7 @@ DEPENDENCIES
   gds-sso (~> 1.2.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (~> 0.2.4)
+  govuk_content_models (= 0.3.0)
   launchy
   lograge
   minitest

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -26,6 +26,14 @@ class ArtefactsController < ApplicationController
   end
 
   def edit
+    # Construct a list of actions, with embedded diffs
+    # The reason for appending the nil is so that the initial action is
+    # included: the DiffEnabledAction class handles the case where the previous
+    # action does not exist
+    reverse_actions = @artefact.actions.reverse
+    @actions = (reverse_actions + [nil]).each_cons(2).map { |action, previous|
+      DiffEnabledAction.new(action, previous)
+    }
   end
 
   def create

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -29,7 +29,7 @@ class ArtefactsController < ApplicationController
   end
 
   def create
-    @artefact.save
+    @artefact.save_as current_user
     respond_with @artefact, location: @artefact.admin_url(params.slice(:return_to))
   end
 
@@ -54,7 +54,7 @@ class ArtefactsController < ApplicationController
       return
     end
 
-    saved = @artefact.update_attributes(parameters_to_use)
+    saved = @artefact.update_attributes_as(current_user, parameters_to_use)
     flash[:notice] = saved ? 'Panopticon item updated' : 'Failed to save item'
 
     if saved && params[:commit] == 'Save and continue editing'

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -6,4 +6,8 @@ module ArtefactsHelper
   def published_url(artefact)
     Plek.current.find('www') + "/#{artefact.slug}"
   end
+
+  def human_timestamp(timestamp)
+    timestamp ? timestamp.strftime("%d/%m/%Y %R") : "(no timestamp)"
+  end
 end

--- a/app/models/diff_enabled_action.rb
+++ b/app/models/diff_enabled_action.rb
@@ -1,0 +1,32 @@
+class DiffEnabledAction
+
+  # Decorator for the ArtefactAction class, which can express what has changed.
+
+  extend Forwardable
+
+  def_delegators :@action, :action_type, :snapshot, :created_at, :user
+
+  def initialize(action, previous = nil)
+    @action, @previous = action, previous
+  end
+
+  def initial?
+    ! @previous
+  end
+
+  def changes
+    return @action.snapshot unless @previous
+
+    changed_keys.reduce({}) { |changes, key|
+      changes.merge key => [@previous, @action].map { |a| a.snapshot[key] }
+    }
+  end
+
+  def changed_keys
+    return @action.snapshot.keys unless @previous
+
+    (@action.snapshot.keys | @previous.snapshot.keys).reject { |key|
+      @action.snapshot[key] == @previous.snapshot[key]
+    }
+  end
+end

--- a/app/models/diff_enabled_action.rb
+++ b/app/models/diff_enabled_action.rb
@@ -15,10 +15,13 @@ class DiffEnabledAction
   end
 
   def changes
-    return @action.snapshot unless @previous
+    # If this is an initial action, fake out the previous snapshot as an empty
+    # hash, for consistency with the general case
+    previous_snapshot = @previous ? @previous.snapshot : {}
+    snapshots = [previous_snapshot, @action.snapshot]
 
     changed_keys.reduce({}) { |changes, key|
-      changes.merge key => [@previous, @action].map { |a| a.snapshot[key] }
+      changes.merge key => snapshots.map { |snapshot| snapshot[key] }
     }
   end
 

--- a/app/views/artefacts/_history.html.erb
+++ b/app/views/artefacts/_history.html.erb
@@ -1,8 +1,9 @@
 <div class="well">
   <dl class="dl-horizontal">
-  <% artefact.actions.each do |action| %>
+  <% actions.each do |action| %>
     <dt><%= human_timestamp(action.created_at) %></dt>
     <dd>
+      <p>
       <%= action.user || "An unknown user" %>
       <% case action.action_type %>
       <% when "create" %>
@@ -11,6 +12,20 @@
         updated this artefact
       <% else %>
         did a "<%= action.action_type %>" action
+      <% end %>
+      </p>
+      <% unless action.initial? %>
+        <% if action.changes.empty? %>
+        No changes
+        <% else %>
+        Changed fields:
+        <ul>
+          <% action.changes.each do |key, values| %>
+            <li><code><%= key %></code>
+              from <%= values[0].inspect %> to <%= values[1].inspect %></li>
+          <% end %>
+        </ul>
+        <% end %>
       <% end %>
     </dd>
   <% end %>

--- a/app/views/artefacts/_history.html.erb
+++ b/app/views/artefacts/_history.html.erb
@@ -1,0 +1,18 @@
+<div class="well">
+  <dl class="dl-horizontal">
+  <% artefact.actions.each do |action| %>
+    <dt><%= human_timestamp(action.created_at) %></dt>
+    <dd>
+      <%= action.user || "An unknown user" %>
+      <% case action.action_type %>
+      <% when "create" %>
+        created this artefact
+      <% when "update" %>
+        updated this artefact
+      <% else %>
+        did a "<%= action.action_type %>" action
+      <% end %>
+    </dd>
+  <% end %>
+  </dl>
+</div>

--- a/app/views/artefacts/_history.html.erb
+++ b/app/views/artefacts/_history.html.erb
@@ -4,14 +4,18 @@
     <dt><%= human_timestamp(action.created_at) %></dt>
     <dd>
       <p>
-      <%= action.user || "An unknown user" %>
-      <% case action.action_type %>
-      <% when "create" %>
-        created this artefact
-      <% when "update" %>
-        updated this artefact
+      <% if ! action.user and action.action_type == "snapshot" %>
+        Automatic snapshot
       <% else %>
-        did a "<%= action.action_type %>" action
+        <%= action.user || "An unknown user" %>
+        <% case action.action_type %>
+        <% when "create" %>
+          created this artefact
+        <% when "update" %>
+          updated this artefact
+        <% else %>
+          did a "<%= action.action_type %>" action
+        <% end %>
       <% end %>
       </p>
       <% unless action.initial? %>

--- a/app/views/artefacts/edit.html.erb
+++ b/app/views/artefacts/edit.html.erb
@@ -2,4 +2,17 @@
 <div class="page-header">
   <h1>Editing <%= @artefact.name %></h1>
 </div>
-<%= render 'form', artefact: @artefact %>
+<div class="tabbable">
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#edit" data-toggle="tab">Edit</a></li>
+    <li><a href="#history" data-toggle="tab">History</a></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane active" id="edit">
+      <%= render 'form', artefact: @artefact %>
+    </div>
+    <div class="tab-pane" id="history">
+      <%= render 'history', artefact: @artefact %>
+    </div>
+  </div>
+</div>

--- a/app/views/artefacts/edit.html.erb
+++ b/app/views/artefacts/edit.html.erb
@@ -12,7 +12,7 @@
       <%= render 'form', artefact: @artefact %>
     </div>
     <div class="tab-pane" id="history">
-      <%= render 'history', artefact: @artefact %>
+      <%= render 'history', actions: @actions %>
     </div>
   </div>
 </div>

--- a/lib/tasks/snapshots.rake
+++ b/lib/tasks/snapshots.rake
@@ -1,0 +1,23 @@
+namespace :actions do
+  task :create_snapshots => :environment do
+    success_count = failure_count = skip_count = 0
+    Artefact.all.each do |artefact|
+      if artefact.actions.empty?
+        artefact.record_action "snapshot"
+        if artefact.save
+          STDERR.puts "Recorded snapshot for '#{artefact.name}'" if verbose
+          success_count += 1
+        else
+          STDERR.puts "Failed to save '#{artefact.name}'" if verbose
+          failure_count += 1
+        end
+      else
+        STDERR.puts "Skipping snapshot for '#{artefact.name}'" if verbose
+        skip_count += 1
+      end
+    end
+    STDERR.puts "#{success_count} succeeded"
+    STDERR.puts "#{failure_count} failed"
+    STDERR.puts "#{skip_count} skipped"
+  end
+end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -105,6 +105,27 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal 404, response.code.to_i
       end
 
+      context "GET /artefacts/:id/edit" do
+        should "Include history" do
+          # Create and update the artefact to set up some actions
+          artefact = Artefact.create!(
+            :slug => 'whatever',
+            :kind => 'guide',
+            :owning_app => 'publisher',
+            :name => 'Whatever',
+            :need_id => 1,
+          )
+          artefact.update_attributes_as stub_user, name: "Changed"
+
+          get :edit, id: artefact.id, format: :html
+
+          # Check the actions: note reverse order
+          actions = assigns["actions"]
+          assert_equal ["update", "create"], actions.map(&:action_type)
+          assert_equal [false, true], actions.map(&:initial?)
+        end
+      end
+
     end
 
     context "PUT /artefacts/:id" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,9 +36,16 @@ class ActiveSupport::TestCase
     Panopticon::Application
   end
 
+  def stub_user
+    @stub_user ||= FactoryGirl.create(:user, :name => 'Stub User')
+  end
+
   def login_as_stub_user
-    temp_user = FactoryGirl.create(:user, :name => 'Stub User')
-    request.env['warden'] = stub(:authenticate! => true, :authenticated? => true, :user => temp_user)
+    request.env['warden'] = stub(
+      :authenticate! => true,
+      :authenticated? => true,
+      :user => stub_user
+    )
   end
 
   def teardown

--- a/test/unit/diff_enabled_action_test.rb
+++ b/test/unit/diff_enabled_action_test.rb
@@ -11,6 +11,18 @@ class DiffEnabledActionTest < ActiveSupport::TestCase
     assert a.initial?
   end
 
+  test "should report changes on an initial action" do
+    action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"fish" => 1, "badger" => true, "walrus" => "yes"}
+    )
+    a = DiffEnabledAction.new(action, nil)
+    assert_equal(
+      {"fish" => [nil, 1], "badger" => [nil, true], "walrus" => [nil, "yes"]},
+      a.changes
+    )
+  end
+
   test "should show no changes from itself" do
     action = ArtefactAction.new(
       action_type: "update",

--- a/test/unit/diff_enabled_action_test.rb
+++ b/test/unit/diff_enabled_action_test.rb
@@ -1,0 +1,76 @@
+require_relative '../test_helper'
+
+class DiffEnabledActionTest < ActiveSupport::TestCase
+
+  test "should report being an initial action" do
+    action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {}
+    )
+    a = DiffEnabledAction.new(action, nil)
+    assert a.initial?
+  end
+
+  test "should show no changes from itself" do
+    action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {}
+    )
+    a = DiffEnabledAction.new(action, action)
+    refute a.initial?
+    assert a.changed_keys.empty?
+    assert a.changes.empty?
+  end
+
+  test "should show changes" do
+    first_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1, "walrus" => "I am a string"}
+    )
+    second_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1, "walrus" => "I am another string"}
+    )
+    a = DiffEnabledAction.new(second_action, first_action)
+    assert_equal ["walrus"], a.changed_keys
+    assert_equal(
+      {"walrus" => ["I am a string", "I am another string"]},
+      a.changes
+    )
+  end
+
+  test "should handle removed keys" do
+    first_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1, "walrus" => "I am a string"}
+    )
+    second_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1}
+    )
+    a = DiffEnabledAction.new(second_action, first_action)
+    assert_equal ["walrus"], a.changed_keys
+    assert_equal(
+      {"walrus" => ["I am a string", nil]},
+      a.changes
+    )
+  end
+
+  test "should handle added keys" do
+    first_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1}
+    )
+    second_action = ArtefactAction.new(
+      action_type: "update",
+      snapshot: {"cheese" => 1, "walrus" => "I am a string"}
+    )
+    a = DiffEnabledAction.new(second_action, first_action)
+    assert_equal ["walrus"], a.changed_keys
+    assert_equal(
+      {"walrus" => [nil, "I am a string"]},
+      a.changes
+    )
+  end
+
+end


### PR DESCRIPTION
Add a record of all historical changes to the artefact edit view.

This will only apply for changes from when this feature is deployed, so we have to force snapshots of every artefact when we first deploy.
