### PR TITLE
Add legacy sources tag collection to artefacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "1.1.0"
+  gem "govuk_content_models", "1.2.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "1.0.0"
+  gem "govuk_content_models", "1.1.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govuk_content_models (1.1.0)
+    govuk_content_models (1.2.0)
       bson_ext
       differ
       gds-api-adapters
@@ -302,7 +302,7 @@ DEPENDENCIES
   gds-sso (~> 1.2.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 1.1.0)
+  govuk_content_models (= 1.2.0)
   launchy
   lograge
   minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govuk_content_models (1.0.0)
+    govuk_content_models (1.1.0)
       bson_ext
       differ
       gds-api-adapters
@@ -302,7 +302,7 @@ DEPENDENCIES
   gds-sso (~> 1.2.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 1.0.0)
+  govuk_content_models (= 1.1.0)
   launchy
   lograge
   minitest

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -132,7 +132,7 @@ class ArtefactsController < ApplicationController
       end
 
       # Strip out the empty submit option for sections
-      ['sections'].each do |param|
+      ['sections', 'legacy_source_ids'].each do |param|
         param_value = parameters_to_use[param]
         param_value.reject!(&:blank?) if param_value
       end

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -14,6 +14,10 @@ module SectionsHelper
     sections.reject { |s| s[1] == options[:except] }
   end
 
+  def options_for_tags_of_type(tag_type)
+    Tag.where(:tag_type => tag_type).order(:title).map {|t| [t.title, t.tag_id]}
+  end
+
   # Convert an array of sections into a nested array suitable for
   # using with the rails form helpers' select box tools.
   #

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -56,6 +56,10 @@
 
     <hr>
 
+    <%= f.input :legacy_source_ids, :label => "Legacy sources", :collection => options_for_tags_of_type('legacy_source'), :input_html => { :multiple => true, :class => "span6 chzn-select" } %>
+
+    <hr>
+
     <%= f.inputs do %>
 
       <%= f.input :department, :label => "Writing team", :input_html => { :disabled => f.object.persisted?, :class => "span6"} %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Dir[File.join(File.dirname(__FILE__),'seeds','*.rb')].each do |f|
+  puts "Seeding from #{ File.basename f }..."
+  load f
+  puts "Done."
+end

--- a/db/seeds/tags.rb
+++ b/db/seeds/tags.rb
@@ -1,0 +1,8 @@
+#######
+#
+# This file will be run on every deploy, so make sure the changes here are non-destructive
+#
+#######
+
+TagRepository.put(:tag_id => 'businesslink', :title => 'Business Link', :tag_type => 'legacy_source')
+TagRepository.put(:tag_id => 'directgov', :title => 'Directgov', :tag_type => 'legacy_source')

--- a/features/support/api.rb
+++ b/features/support/api.rb
@@ -8,7 +8,7 @@ def related_artefact_ids_from_api(artefact)
 end
 
 def tag_ids_from_api(artefact)
-  artefact_data_from_api(artefact)[:tag_ids].map { |tag| tag['id'] }
+  artefact_data_from_api(artefact)[:tag_ids]
 end
 
 def contact_id_from_api(artefact)

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -34,4 +34,16 @@ namespace :migrate do
       end
     end
   end
+
+  desc "Sets the businesslink legacy source on all business proposition content"
+  task :set_businesslink_tag_on_buisiness_artefacts => :environment do
+    Artefact.observers.disable :update_search_observer, :update_router_observer do
+      Artefact.where(:business_proposition => true).each do |artefact|
+        unless artefact.legacy_source_ids.include?('businesslink')
+          artefact.legacy_source_ids += %w(businesslink)
+          artefact.save!
+        end
+      end
+    end
+  end
 end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -120,6 +120,19 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal artefact.section, parsed['section']
       end
 
+      should "Include tag_ids" do
+        TagRepository.put :tag_id => 'crime', :tag_type => 'section', :title => 'Crime'
+        TagRepository.put :tag_id => 'businesslink', :tag_type => 'legacy_source', :title => 'Business Link'
+        artefact = Artefact.create! :slug => 'whatever', :kind => 'guide', :owning_app => 'publisher', :name => 'Whatever', :need_id => 1
+        artefact.sections = ['crime']
+        artefact.legacy_sources = ['businesslink']
+        artefact.save!
+        get :show, id: artefact.id, format: :json
+        parsed = JSON.parse(response.body)
+
+        assert_equal %w(businesslink crime), parsed['tag_ids'].sort
+      end
+
       should "return 404 if the artefact's not found" do
         get :show, id: 'bad-slug', format: :json
         assert_equal 404, response.code.to_i

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -14,4 +14,39 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?("View on site", :href => "http://www.test.gov.uk/alpha")
   end
+
+  context "editing legacy_sources" do
+    setup do
+      @bl   = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
+      @dg   = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'directgov', :title => 'Directgov')
+      @dvla = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'dvla', :title => 'DVLA')
+      @a = FactoryGirl.create(:artefact, :name => "VAT")
+    end
+
+    should "allow adding legacy sources to artefacts" do
+      visit "/artefacts"
+      click_on "VAT"
+
+      select "Business Link", :from => "artefact[legacy_source_ids][]"
+      select "DVLA", :from => "artefact[legacy_source_ids][]"
+      click_on "Save and continue editing"
+
+      @a.reload
+      assert_equal [@bl, @dvla], @a.legacy_sources
+    end
+
+    should "allow removing legacy sources from artefacts" do
+      @a.legacy_source_ids = ['businesslink', 'directgov']
+      @a.save!
+
+      visit "/artefacts"
+      click_on "VAT"
+
+      unselect "Directgov", :from => "artefact[legacy_source_ids][]"
+      click_on "Save and continue editing"
+
+      @a.reload
+      assert_equal [@bl], @a.legacy_sources
+    end
+  end
 end


### PR DESCRIPTION
This will be used to control the appearence of the businesslink and directgov logos on content in the frontend.
