### PR TITLE
Completed transaction format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "1.7.1"
+  gem "govuk_content_models", "1.7.2"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     govspeak (1.0.0)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-    govuk_content_models (1.7.1)
+    govuk_content_models (1.7.2)
       bson_ext
       differ
       gds-api-adapters
@@ -317,7 +317,7 @@ DEPENDENCIES
   gds-sso (~> 1.2.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 1.7.1)
+  govuk_content_models (= 1.7.2)
   launchy
   lograge
   minitest

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -8,4 +8,8 @@ class Artefact
   def archived?
     state == 'archived'
   end
+
+  def self.relatable_items
+    self.in_alphabetical_order.where(:kind.nin => ["completed_transaction"])
+  end
 end

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -9,6 +9,8 @@ class RummageableArtefact
   end
 
   def submit
+    return if %w[ completed_transaction ].include?(@artefact.kind)
+
     # API requests, if they know about the single registration API, will be
     # providing the indexable_content field to update Rummager. UI requests
     # and requests from apps that don't know about single registration, will

--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -2,7 +2,7 @@ class UpdateSearchObserver < Mongoid::Observer
   observe :artefact
 
   def after_save(artefact)
-    RummageableArtefact.new(artefact).submit if artefact.live? and artefact.indexable?
+    RummageableArtefact.new(artefact).submit if artefact.live?
     # Relying on current behaviour where this does not raise errors
     # if done more than once, or done on artefacts never put live
     RummageableArtefact.new(artefact).delete if artefact.archived?

--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -2,7 +2,7 @@ class UpdateSearchObserver < Mongoid::Observer
   observe :artefact
 
   def after_save(artefact)
-    RummageableArtefact.new(artefact).submit if artefact.live?
+    RummageableArtefact.new(artefact).submit if artefact.live? and artefact.indexable?
     # Relying on current behaviour where this does not raise errors
     # if done more than once, or done on artefacts never put live
     RummageableArtefact.new(artefact).delete if artefact.archived?

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -55,7 +55,7 @@
 
       <%= f.inputs do %>
         <input name="artefact[related_artefact_ids][]" type="hidden" value="">
-        <%= f.input :related_artefacts, :label => "Related content", :collection => Artefact.in_alphabetical_order, :input_html => { :multiple => true, :class => "span6 chzn-select" }, :hint => "Start typing in to search for and select related links to be associated with this." %>
+        <%= f.input :related_artefacts, :label => "Related content", :collection => Artefact.relatable_items, :input_html => { :multiple => true, :class => "span6 chzn-select" }, :hint => "Start typing in to search for and select related links to be associated with this." %>
         <%= f.input :relatedness_done, :label => "Is relatedness done?", :as => :boolean %>
       <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Panopticon::Application.routes.draw do
-  resources :artefacts
+  resources :artefacts, :constraints => { :id => /[^\.]+/ }
   resources :tags, :defaults => {:format => 'json'}
 
   resources :curated_lists, only: :index

--- a/features/registering_resources.feature
+++ b/features/registering_resources.feature
@@ -2,7 +2,7 @@ Feature: Registering resources
   In order to introduce new resources into the system
   I want to register artefacts in panopticon
   So that it can co-ordinate the system
-  
+
   Scenario: Creating a smart answer
     When I put a new smart answer's details into panopticon
     Then a new artefact should be created
@@ -21,6 +21,12 @@ Feature: Registering resources
     Then a new artefact should be created
       And rummager should not be notified
       And the router should not be notified
+
+  Scenario: Creating a completed transaction
+    When I put a new completed transaction's details into panopticon
+    Then a new artefact should be created
+      And rummager should not be notified
+      And the router should be notified
 
   Scenario: Putting an item whose slug is owned by another app
     When I put a new item into panopticon whose slug is already taken

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -35,6 +35,12 @@ When /^I put a draft smart answer's details into panopticon$/ do
   put "/artefacts/#{example_smart_answer['slug']}.json", artefact: details
 end
 
+When /^I put a new completed transaction's details into panopticon$/ do
+  prepare_registration_environment(example_completed_transaction)
+
+  put "/artefacts/#{example_completed_transaction['slug']}.json", artefact: example_completed_transaction
+end
+
 When /^I put a new item into panopticon whose slug is already taken$/ do
   prepare_registration_environment
   setup_existing_artefact

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -19,14 +19,30 @@ module RegistrationInfo
     }
   end
 
+  def example_completed_transaction
+    {
+      "need_id"           => 2013,
+      "slug"              => "done/example-transaction",
+      "name"              => "Example Transaction Complete",
+      "description"       => "This transaction is complete.",
+      "kind"              => "completed_transaction",
+      "section"           => "money-and-tax",
+      "subsection"        => "tax",
+      "link"              => "/done/example-transaction",
+      "indexable_content" => "",
+      "owning_app"        => 'publisher',
+      "state"             => "live"
+    }
+  end
+
   def example_smart_answer_json
     {artefact: example_smart_answer}.to_json
   end
 
-  def prepare_registration_environment
+  def prepare_registration_environment(artefact = example_smart_answer)
     setup_user
     stub_search
-    stub_router
+    stub_router(artefact)
   end
 
   def setup_user
@@ -38,7 +54,7 @@ module RegistrationInfo
     @fake_search_amend = WebMock.stub_request(:post, %r{^#{Regexp.escape SEARCH_ROOT}/documents/.*$}).to_return(status: 200)
   end
 
-  def stub_router
+  def stub_router(artefact = nil)
     WebMock.stub_request(:put, %r{^#{ROUTER_ROOT}/router/applications/.*$}).
         with(:body => { "backend_url" => %r{^.*.test.gov.uk$} }).
         to_return(:status => 200, :body => "{}", :headers => {})
@@ -49,7 +65,7 @@ module RegistrationInfo
           to_return(:status => 200, :body => "{}", :headers => {})
 
     # so that we can assert on them later
-    @fake_routers = [OpenStruct.new(example_smart_answer), @artefact, @related_artefact].reject(&:nil?).map do |artefact|
+    @fake_routers = [OpenStruct.new(artefact), @artefact, @related_artefact].reject(&:nil?).map do |artefact|
       WebMock.stub_request(:put, "#{ROUTER_ROOT}/router/routes/#{artefact.slug}").
             with(:body => { "application_id" => artefact.owning_app, "route_type" => "full"}).
             to_return(:status => 200, :body => "{}", :headers => {})

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -119,6 +119,16 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal artefact.owning_app, parsed['owning_app']
       end
 
+      should "Output json for slug with slash in slug" do
+        artefact = Artefact.create! :slug => 'done/whatever', :kind => 'answer', :owning_app => 'publisher', :name => 'Done Whatever', :need_id => 1
+        get :show, id: artefact.id, format: :json
+        parsed = JSON.parse(response.body)
+
+        assert_equal artefact.id.to_s, parsed['id']
+        assert_equal artefact.name, parsed['name']
+        assert_equal artefact.slug, parsed['slug']
+      end
+
       should "Include section ID" do
         TagRepository.put :tag_id => 'crime', :tag_type => 'section', :title => 'Crime'
         artefact = Artefact.create! :slug => 'whatever', :kind => 'guide', :owning_app => 'publisher', :name => 'Whatever', :need_id => 1

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -49,4 +49,16 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       assert_equal [@bl], @a.legacy_sources
     end
   end
+
+  should "not include completed transactions in related item lists" do
+    a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
+    b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')
+    c = FactoryGirl.create(:artefact, :name => "Done", :slug => 'done/completed-example', :kind => 'completed_transaction')
+
+    visit "/artefacts"
+    click_on "Alpha"
+
+    assert page.has_selector?("#artefact_related_artefact_ids option[value='#{b.id}']")
+    assert ! page.has_selector?("#artefact_related_artefact_ids option[value='#{c.id}']")
+  end
 end


### PR DESCRIPTION
Supports the addition of the 'completed transaction' format in govuk_content_models:
- Supports slashes in slugs for artefacts#show
- RummageableArtefact doesn't add completed transactions to the search or browse index.
- Completed transactions don't show in the list of related items to select from when editing an artefact
