### PR TITLE
Remove reference to 'authentication' when calling Plek

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -3,7 +3,7 @@ GDS::SSO.config do |config|
   config.oauth_id     = 'abcdefgh12345678pan'
   config.oauth_secret = 'secret'
   config.default_scope = "Panopticon"
-  config.oauth_root_url = Plek.current.find("authentication")
+  config.oauth_root_url = Plek.current.find("signon")
   config.basic_auth_user = 'api'
   config.basic_auth_password = 'defined_on_rollout_not'
 end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -9,5 +9,5 @@ Before do
   # Mock out all publisher URLs
   stub_request(:get, %r{^#{Regexp.escape Plek.current.find('publisher')}/}).to_return(status: 200)
 
-  stub_request(:get, "#{Plek.current.find('data')}/data_sets/public_bodies.json").to_return(body: [].to_json)
+  stub_request(:get, "#{Plek.current.find('imminence')}/data_sets/public_bodies.json").to_return(body: [].to_json)
 end


### PR DESCRIPTION
This was more unnecessary indirection, let's just use signon.
