### PR TITLE
Don't allow editing of names/titles via the web form

### DIFF
--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -12,6 +12,6 @@ module ArtefactsHelper
   end
 
   def name_hint_for(artefact)
-    artefact.persisted? ? "A name/title for the item" : "This should be edited in #{artefact.owning_app}"
+    artefact.persisted? ? "This should be edited in #{artefact.owning_app}" : "A name/title for the item"
   end
 end

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -10,4 +10,8 @@ module ArtefactsHelper
   def human_timestamp(timestamp)
     timestamp ? timestamp.strftime("%d/%m/%Y %R") : "(no timestamp)"
   end
+
+  def name_hint_for(artefact)
+    artefact.persisted? ? "A name/title for the item" : "This should be edited in #{artefact.owning_app}"
+  end
 end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -20,7 +20,7 @@
   <div class="well">
     <%= semantic_form_for(artefact, :html => { :class => '', :id => 'edit_artefact'}) do |f| %>
       <%= f.inputs do %>
-        <%= f.input :name, :input_html => { :class => "span6" } %>
+        <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?, :hint => name_hint_for(f.object) } %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -20,7 +20,7 @@
   <div class="well">
     <%= semantic_form_for(artefact, :html => { :class => '', :id => 'edit_artefact'}) do |f| %>
       <%= f.inputs do %>
-        <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?, :hint => name_hint_for(f.object) } %>
+        <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?}, :hint => name_hint_for(f.object) %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>

--- a/features/editing.feature
+++ b/features/editing.feature
@@ -51,8 +51,8 @@ Feature: Editing artefacts
     Then rummager should not be notified
 
   Scenario: Editing a live item
-    Given two artefacts exist
+    Given an artefact exists
       And the first artefact is live
-    When I change the title of the first artefact
-      And I save
+      And a section exists
+    When I add the section to the artefact
     Then rummager should be told to do a partial update

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -101,9 +101,9 @@ end
 
 Then /^rummager should be told to do a partial update$/ do
   amendments = {
-    title: @new_name,
+    title: "Child Benefit rates",
     format: "answer",
-    section: "",
+    section: @section.tag_id,
     subsection: ""
   }
   assert_requested :post, artefact_search_url(@artefact), body: amendments

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -190,6 +190,12 @@ class ArtefactsControllerTest < ActionController::TestCase
 
           assert_equal ['fooey', 'gooey', 'kablooey'], assigns["tag_collection"].map(&:tag_id)
         end
+
+        should "disable the name field as it's managed by the owning app" do
+          artefact = FactoryGirl.create(:artefact)
+          get :edit, id: artefact.id, format: :html
+          assert_select 'input[id=artefact_name][disabled=disabled]'
+        end
       end
 
     end


### PR DESCRIPTION
The title belongs to the owning_app and so should only be updated via the API.

This should only be merged and deployed in conjunction with the associated change to publisher to avoid confusion.
