### PR TITLE
Dont register business support in search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ end
 group :test do
   # Pretty printed test output
   gem 'turn', require: false
-  gem 'sqlite3-ruby', require: false
   gem 'simplecov', '~> 0.6.4'
   gem 'simplecov-rcov'
   gem 'ci_reporter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,9 +257,6 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.6)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
     state_machine (1.1.2)
     stomp (1.2.5)
     therubyracer (0.9.10)
@@ -333,7 +330,6 @@ DEPENDENCIES
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)
   simplecov-rcov
-  sqlite3-ruby
   stomp
   therubyracer (~> 0.9.4)
   turn

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -1,5 +1,7 @@
 class RummageableArtefact
 
+  FORMATS_NOT_TO_INDEX = %W(business_support)
+
   def initialize(artefact)
     @artefact = artefact
   end
@@ -9,7 +11,7 @@ class RummageableArtefact
   end
 
   def should_be_indexed?
-    @artefact.live?
+    @artefact.live? && ! FORMATS_NOT_TO_INDEX.include?(@artefact.kind)
   end
 
   def submit

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -8,6 +8,10 @@ class RummageableArtefact
     Rails.logger
   end
 
+  def should_be_indexed?
+    @artefact.live?
+  end
+
   def submit
     return if %w[ completed_transaction ].include?(@artefact.kind)
 

--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -2,9 +2,10 @@ class UpdateSearchObserver < Mongoid::Observer
   observe :artefact
 
   def after_save(artefact)
-    RummageableArtefact.new(artefact).submit if artefact.live?
+    rummageable_artefact = RummageableArtefact.new(artefact)
+    rummageable_artefact.submit if rummageable_artefact.should_be_indexed?
     # Relying on current behaviour where this does not raise errors
     # if done more than once, or done on artefacts never put live
-    RummageableArtefact.new(artefact).delete if artefact.archived?
+    rummageable_artefact.delete if artefact.archived?
   end
 end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -21,6 +21,7 @@
     <%= semantic_form_for(artefact, :html => { :class => '', :id => 'edit_artefact'}) do |f| %>
       <%= f.inputs do %>
         <%= f.input :name, :input_html => { :class => "span6" } %>
+        <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>

--- a/app/views/curated_list/index.html.erb
+++ b/app/views/curated_list/index.html.erb
@@ -30,7 +30,6 @@
 </div><!-- ./row-fluid-->
 
 <%= content_for :extra_javascript do %>
-  <%= javascript_include_tag 'jquery.tablesorter.min.js' %>
   <script type="text/javascript">
   $(function () {
     $('#curated-list').tablesorter();

--- a/data/slugs_to_migrate.json
+++ b/data/slugs_to_migrate.json
@@ -115,5 +115,9 @@
   "monitored-at-work-your-rights": "monitoring-work-workers-rights",
   "business-transfers-and-takeovers-your-rights": "business-transfers-takeovers-workers-rights",
   "employment-tribunal": "taking-employer-to-employment-tribunal",
-  "report-debris-litter-motorways-main-roads": "report-debris-motorways-main-roads"
+  "report-debris-litter-motorways-main-roads": "report-debris-motorways-main-roads",
+  "change-me-for-need-2242": "caution-warning-penalty",
+  "change-me-for-need-2496": "commemorative-marriage-certificate",
+  "change-me-for-need-2076": "recycling-bin",
+  "bstructive-sleep-apnoea-and-driving": "obstructive-sleep-apnoea-and-driving"
 }

--- a/lib/tasks/add_disabled_sub_category.rake
+++ b/lib/tasks/add_disabled_sub_category.rake
@@ -1,0 +1,25 @@
+# NOTE: This is to specifically create a disabilities sub category
+# then tag all content with disabilities with this new sub category
+
+namespace :migrate do
+  desc "Create sub category and tag all content with disabilities tag_id with new sub cat"
+  task :create_sub_category_and_tag => :environment do |t, args|
+    tag = Tag.where(tag_id: "disabilities").first
+    if tag.nil?
+      raise "Wa? No frakkin' tag with tag_id #{args[:tag_id]}"
+    end
+
+    sub_cat = Tag.new({tag_id: "disabilities/disabled-people",
+      parent_id: "disabilities", description: "Includes your rights, benefits and the Equality Act",
+      tag_type: "section", title: "Disabled people"})
+    sub_cat.save!
+    puts "Created: #{sub_cat.inspect}"
+
+    artefacts = Artefact.any_in(tag_ids: [tag.tag_id])
+    artefacts.each do |a|
+      a.tag_ids = a.tag_ids.append(sub_cat.tag_id)
+      puts "Updating #{a.slug} with #{a.tag_ids}"
+      a.save!
+    end
+  end
+end

--- a/lib/tasks/remove_tag.rake
+++ b/lib/tasks/remove_tag.rake
@@ -1,0 +1,30 @@
+# NOTE: this will only delete tags that have NO pieces of content associated with this tag
+# AND NO CHILDREN TAGS ASSOCIATED
+
+namespace :migrate do
+  desc "Delete the given tag_id"
+  task :delete_tag, [:tag_id] => :environment do |t, args|
+    tag = Tag.where(tag_id: "#{args[:tag_id]}").first
+    if tag.nil?
+      raise "Wa? No frakkin' tag with tag_id #{args[:tag_id]}"
+    end
+
+    if tag.parent.nil?
+      # we're a root section tag
+      # make sure there are no children tags with us as a parent id
+      children_tags = Tag.where(parent_id: tag.tag_id)
+      if children_tags.count > 0
+        tag_ids = children_tags.collect {|x| x.tag_id}
+        raise "STOP! There are children tags #{tag_ids}"
+      end
+    end
+
+    artefacts = Artefact.any_in(tag_ids: [tag.tag_id])
+    if artefacts.count > 0
+      raise "STOP! This has #{artefacts.count} artefacts associated with it"
+    end
+
+    tag.delete!
+    puts "Deleted #{tag.tag_id}"
+  end
+end

--- a/lib/tasks/remove_tag.rake
+++ b/lib/tasks/remove_tag.rake
@@ -24,7 +24,7 @@ namespace :migrate do
       raise "STOP! This has #{artefacts.count} artefacts associated with it"
     end
 
-    tag.delete!
+    tag.delete
     puts "Deleted #{tag.tag_id}"
   end
 end

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -123,4 +123,13 @@ class RummageableArtefactTest < ActiveSupport::TestCase
 
     assert RummageableArtefact.new(artefact).should_be_indexed?
   end
+
+  test "should not index business support content" do
+    artefact = Artefact.new do |artefact|
+      artefact.state = "live"
+      artefact.kind = "business_support"
+    end
+
+    refute RummageableArtefact.new(artefact).should_be_indexed?
+  end
 end

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -115,4 +115,12 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
+
+  test "should consider live items should be indexed" do
+    artefact = Artefact.new do |artefact|
+      artefact.state = "live"
+    end
+
+    assert RummageableArtefact.new(artefact).should_be_indexed?
+  end
 end


### PR DESCRIPTION
Business Support editions aren't meant to be included in search but they were. This change excludes them and also provides a pattern for excluding other formats where appropriate.
