### PR TITLE
Tag short descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "2.0.0"
+  gem "govuk_content_models", "2.1.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,11 +119,11 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.2.0)
+    govspeak (1.2.2)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.0.0)
+    govuk_content_models (2.1.0)
       bson_ext
       differ
       gds-api-adapters
@@ -322,7 +322,7 @@ DEPENDENCIES
   gds-sso (= 2.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 2.0.0)
+  govuk_content_models (= 2.1.0)
   launchy
   less-rails-bootstrap
   lograge

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -20,9 +20,10 @@
   <%= semantic_form_for(@tag, :html => { :class => '', :id => 'tag'}) do |f| %>
     <%= f.inputs do %>
       <%= f.input :title, :input_html => { :class => "span6" } %>
+      <%= f.input :short_description, :as => :text, :input_html => { :class => "span6", :rows => 2} %>
       <%= f.input :description, :as => :text, :input_html => { :class => "span6", :rows => 6} %>
     <% end %>
-      <%= f.submit :value => "Save", :class => "btn btn-success" %>
+    <%= f.submit :value => "Save", :class => "btn btn-success" %>
   <% end %>
 </div>
 </div>

--- a/features/step_definitions/category_steps.rb
+++ b/features/step_definitions/category_steps.rb
@@ -32,6 +32,11 @@ When /^I change the category title to "(.*?)"$/ do |new_title|
   click_button "Save"
 end
 
+When /^I change the short description to "(.*?)"$/ do |short_description|
+  fill_in "Short description", with: short_description
+  click_button "Save"
+end
+
 Then /^I should be on the categories page$/ do
   assert_equal categories_path, page.current_url
 end

--- a/features/tag_management.feature
+++ b/features/tag_management.feature
@@ -13,3 +13,11 @@ Feature: Managing tags
 
     Then I should see "Successfully updated"
       And I should see "Crime, justice and superheroes"
+
+  Scenario: Updating a tag title
+    When I visit the categories page
+      And I follow the link to edit the category
+      And I change the short description to "A superhero is a fictional character who has powers which are unusual for normal people"
+
+    Then I should see "Successfully updated"
+      And I should see "A superhero is a fictional character who has powers which are unusual for normal people"

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -4,22 +4,21 @@ class TagsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
     TagRepository.put(tag_id: "crime", title: "Crime", tag_type: "section",
-                      short_description: "A crime (or misdemeanor or felony) is an act, that a person does, which is against the laws of a country or region")
-    TagRepository.put(tag_id: "crime/the-police", title: "The Police", tag_type: "section",
-                      short_description: "The police are a group of people whose job it is to enforce laws, help with emergencies, solve crimes and protect the public")
+                      short_description: "Legal processes, courts and the police")
+    TagRepository.put(tag_id: "crime/the-police", title: "The Police", tag_type: "section")
     @tag_count = 2
   end
 
   context "GET /tags/:id" do
     should "return tag" do
-      get :show, id: "crime/the-police", format: "json"
+      get :show, id: "crime", format: "json"
       parsed = JSON.parse(response.body)
       assert_response :success
       assert_equal parsed["status"], "ok"
       assert_equal parsed["tag"]["type"], "section"
-      assert_equal parsed["tag"]["id"], "crime/the-police"
-      assert_equal parsed["tag"]["title"], "The Police"
-      assert_match /people whose job it is to enforce laws/, parsed["tag"]["short_description"]
+      assert_equal parsed["tag"]["id"], "crime"
+      assert_equal parsed["tag"]["title"], "Crime"
+      assert_match /Legal processes, courts and the police/, parsed["tag"]["short_description"]
     end
 
     should "return 404" do

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -3,8 +3,10 @@ require 'test_helper'
 class TagsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
-    TagRepository.put(tag_id: "crime", title: "Crime", tag_type: "section")
-    TagRepository.put(tag_id: "crime/the-police", title: "The Police", tag_type: "section")
+    TagRepository.put(tag_id: "crime", title: "Crime", tag_type: "section",
+                      short_description: "A crime (or misdemeanor or felony) is an act, that a person does, which is against the laws of a country or region")
+    TagRepository.put(tag_id: "crime/the-police", title: "The Police", tag_type: "section",
+                      short_description: "The police are a group of people whose job it is to enforce laws, help with emergencies, solve crimes and protect the public")
     @tag_count = 2
   end
 
@@ -17,6 +19,7 @@ class TagsControllerTest < ActionController::TestCase
       assert_equal parsed["tag"]["type"], "section"
       assert_equal parsed["tag"]["id"], "crime/the-police"
       assert_equal parsed["tag"]["title"], "The Police"
+      assert_match /people whose job it is to enforce laws/, parsed["tag"]["short_description"]
     end
 
     should "return 404" do
@@ -33,7 +36,6 @@ class TagsControllerTest < ActionController::TestCase
       assert_equal parsed["status"], "ok"
       assert_equal parsed["total"], @tag_count
       assert_equal parsed["results"].count, @tag_count
-
     end
   end
 
@@ -46,6 +48,4 @@ class TagsControllerTest < ActionController::TestCase
       refute parsed["results"].any? { |result| result["id"] == "minister-of-silly" }
     end
   end
-
-
 end


### PR DESCRIPTION
As part of enabling root tags to be queried to build out the homepage,
provide them with a short description that can be set by content
editors.
