### PR TITLE
Upgrade gds-api-adapters and govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'null_logger'
 
 gem 'exception_notification'
 
-gem 'gds-api-adapters', '~> 4.0.0'
+gem 'gds-api-adapters', "4.0.0"
 gem 'router-client', "3.1.0"
 
 gem 'aws-ses', require: 'aws/ses'
@@ -35,7 +35,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 2.4.0'
+  gem "govuk_content_models", "2.4.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'null_logger'
 
 gem 'exception_notification'
 
-gem 'gds-api-adapters'
+gem 'gds-api-adapters', '~> 4.0.0'
 gem 'router-client', "3.1.0"
 
 gem 'aws-ses', require: 'aws/ses'
@@ -35,7 +35,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "2.1.0"
+  gem "govuk_content_models", '~> 2.4.0'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     bson (1.6.2)
     bson_ext (1.6.2)
       bson (~> 1.6.2)
-    builder (3.0.0)
+    builder (3.0.4)
     capybara (1.1.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -104,7 +104,7 @@ GEM
     faraday (0.8.4)
       multipart-post (~> 1.1)
     ffi (1.1.4)
-    gds-api-adapters (0.2.2)
+    gds-api-adapters (4.0.0)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -119,11 +119,11 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.2.2)
+    govspeak (1.2.3)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.1.0)
+    govuk_content_models (2.4.0)
       bson_ext
       differ
       gds-api-adapters
@@ -136,10 +136,10 @@ GEM
     hashie (1.2.0)
     hike (1.2.1)
     htmlentities (4.3.1)
-    httpauth (0.1)
-    i18n (0.6.0)
+    httpauth (0.2.0)
+    i18n (0.6.1)
     journey (1.0.4)
-    json (1.7.4)
+    json (1.7.5)
     jwt (0.1.5)
       multi_json (>= 1.0)
     kgio (2.7.4)
@@ -184,7 +184,7 @@ GEM
       activemodel (~> 3.1)
       mongo (<= 1.6.2)
       tzinfo (~> 0.3.22)
-    multi_json (1.3.6)
+    multi_json (1.3.7)
     multipart-post (1.1.5)
     net-http-digest_auth (1.2.1)
     net-http-persistent (2.7)
@@ -202,7 +202,7 @@ GEM
       rack
     omniauth-gds (0.0.3)
       omniauth-oauth2 (~> 1.0)
-    omniauth-oauth2 (1.1.0)
+    omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
     plek (0.3.0)
@@ -215,7 +215,7 @@ GEM
       rack (>= 0.4)
     rack-ssl (1.3.2)
       rack
-    rack-test (0.6.1)
+    rack-test (0.6.2)
       rack (>= 1.0)
     rails (3.2.7)
       actionmailer (= 3.2.7)
@@ -233,7 +233,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.10.0)
-    rake (0.9.2.2)
+    rake (10.0.2)
     rdoc (3.12)
       json (~> 1.4)
     rest-client (1.6.7)
@@ -271,12 +271,12 @@ GEM
       libv8 (~> 3.3.10)
     thor (0.16.0)
     tilt (1.3.3)
-    treetop (1.4.10)
+    treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    tzinfo (0.3.33)
+    tzinfo (0.3.35)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
@@ -318,11 +318,11 @@ DEPENDENCIES
   factory_girl_rails
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters
+  gds-api-adapters (~> 4.0.0)
   gds-sso (= 2.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 2.1.0)
+  govuk_content_models (~> 2.4.0)
   launchy
   less-rails-bootstrap
   lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,11 +318,11 @@ DEPENDENCIES
   factory_girl_rails
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters (~> 4.0.0)
+  gds-api-adapters (= 4.0.0)
   gds-sso (= 2.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (~> 2.4.0)
+  govuk_content_models (= 2.4.0)
   launchy
   less-rails-bootstrap
   lograge

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -70,7 +70,6 @@
 
         <%= f.input :department, :label => "Writing team", :input_html => { :disabled => f.object.persisted?, :class => "span6"} %>
         <%= f.input :fact_checkers, :input_html => { :disabled => f.object.persisted?, :class => "span6"} %>
-        <%= f.input :contact, :as => :hidden, :collection => Contact.in_alphabetical_order %>
 
       <% end %>
 

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -9,10 +9,6 @@ end
 When /^I put a new smart answer's details into panopticon$/ do
   prepare_registration_environment
 
-  # TODO: Make this work via API Adapters
-  # interface = GdsApi::CoreApi.new('test', "http://example.com")
-  # interface.register(resource_details)
-
   put "/artefacts/#{example_smart_answer['slug']}.json", artefact: example_smart_answer
 end
 

--- a/lib/tasks/relatedness.rake
+++ b/lib/tasks/relatedness.rake
@@ -70,7 +70,7 @@ namespace :relatedness do
       # being drafted, reviewed, etc.
       def cluster
         require 'gds_api/publisher'
-        api = GdsApi::Publisher.new(Plek.current.environment, 'http://localhost:3000')
+        api = GdsApi::Publisher.new(Plek.current.find('publisher'), 'http://localhost:3000')
         if artefact.valid? and api.publication_for_slug(artefact.slug)
           "published"
         else


### PR DESCRIPTION
As part of the drive to remove Plek.current.environment we have required newer versions of
these 2 gems. References to Contact have been removed to ensure tests continue to pass.
