### PR TITLE
aligning gds-api-adapters version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'lograge'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "2.4.0"
+  gem "govuk_content_models", "2.5.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'null_logger'
 
 gem 'exception_notification'
 
-gem 'gds-api-adapters', "4.0.0"
+gem 'gds-api-adapters', "4.1.3"
 gem 'router-client', "3.1.0"
 
 gem 'aws-ses', require: 'aws/ses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.4.0)
+    govuk_content_models (2.5.0)
       bson_ext
       differ
       gds-api-adapters
@@ -322,7 +322,7 @@ DEPENDENCIES
   gds-sso (= 2.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 2.4.0)
+  govuk_content_models (= 2.5.0)
   launchy
   less-rails-bootstrap
   lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     faraday (0.8.4)
       multipart-post (~> 1.1)
     ffi (1.1.4)
-    gds-api-adapters (4.0.0)
+    gds-api-adapters (4.1.3)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -159,7 +159,7 @@ GEM
     lograge (0.0.6)
       actionpack
       activesupport
-    lrucache (0.1.3)
+    lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     mail (2.4.4)
       i18n (>= 0.4.0)
@@ -318,7 +318,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters (= 4.0.0)
+  gds-api-adapters (= 4.1.3)
   gds-sso (= 2.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf


### PR DESCRIPTION
in preparation for new Plek rollout. (previously did 4.0.0 but has since been upgraded by Jamie C to 4.1.3)
