### PR TITLE
Add admin_url_for_edition method for redirecting

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -20,7 +20,7 @@ class ArtefactsController < ApplicationController
 
   def show
     respond_with @artefact do |format|
-      format.html { redirect_to @artefact.admin_url }
+      format.html { redirect_to admin_url_for_edition(@artefact) }
     end
   end
 
@@ -34,7 +34,7 @@ class ArtefactsController < ApplicationController
 
   def create
     @artefact.save_as action_user
-    location = @artefact.admin_url(params.slice(:return_to))
+    location = admin_url_for_edition(@artefact, params.slice(:return_to))
     respond_with @artefact, location: location
   end
 
@@ -83,6 +83,13 @@ class ArtefactsController < ApplicationController
   end
 
   private
+
+    def admin_url_for_edition(artefact, options = {})
+      [
+        "#{Plek.current.find(artefact.owning_app)}/admin/publications/#{artefact.id}",
+        options.to_query
+      ].reject(&:blank?).join("?")
+    end
 
     def tag_collection
       @tag_collection = TagRepository.load_all(:tag_type => 'section')


### PR DESCRIPTION
We had a method on the model to get an artefact's admin URL. That didn't really feel like a model concern and is only used in one controller so I've brought it in line here and will remove it from the model.

I considered using a decorator to wrap the artefact and provide the method but that seemed like a lot of overhead for a single method. We should consider something like that if attempting a broader refactor.

(this also helps reduce govuk_content_models' reliance on Plek)
