### PR TITLE
Disable active_resource

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "active_resource/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 require "govuk_content_models"


### PR DESCRIPTION
We don't use active_resource in panopticon but we were explicitly requiring it anyway.
