### PR TITLE
Disable (limited) exception/debug pages in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,6 +7,14 @@ Panopticon::Application.configure do
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
+  # Disable even limited exception/debug pages in production for two reasons:
+  #  1) our backend rails apps get X-Forwarded-For & Client-IP for all requests 
+  #     as 10.x.x.x, which is a trusted proxy. This means they render the 
+  #     limited exception/debug pages.
+  #  2) our backend rails apps receive requests from other apps that might 
+  #     appear to be on trusted proxy IPs, so we might render exception/debug
+  #     page, which could then be exposed in a frontend app to the world.
+  config.action_dispatch.show_exceptions = false
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
   config.serve_static_assets = false


### PR DESCRIPTION
Rails has a default of showing limited exceptions to the user in production, IF it thinks
the request is local/from a trusted proxy (and not being proxied from the
internet). Our infrastructure is telling apps that all requests actually come
from trusted proxies, even though they don't, hence our problem.

A wrinkle is that we have apps that are talking to each other, so it's
conceivable that information could get from an inter-app request that errored
and then be displayed to the outside world.

The problem would be limited if the proxies set the headers correctly, but
eliminated if we set config.action_dispatch.show_exceptions to false.

[Nick has dealt with the problem](https://github.com/alphagov/puppet/pull/227) in such a way that prevents exception
information being shown, but which also hides helpful 4xx and 5xx messages
(eg if you don't have "signin" permission for an app, you get a 403 and
explanatory HTML, but now it gets clobbered). I'm sure there are other cases.

I intend to make this same change in each backend Rails app if this gets merged. Once each app is deployed, we can change the configuration that Nick added.
