### PR TITLE
Fix artefact registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.0.0"
+  gem "govuk_content_models", "4.3.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.0.0)
+    govuk_content_models (4.3.0)
       bson_ext
       differ
       gds-api-adapters
@@ -324,7 +324,7 @@ DEPENDENCIES
   gds-sso (= 3.0.0)
   gds-warmup-controller (= 0.1.0)
   gelf
-  govuk_content_models (= 4.0.0)
+  govuk_content_models (= 4.3.0)
   launchy
   less-rails-bootstrap
   lograge (~> 0.1.0)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -72,7 +72,7 @@ class ArtefactsController < ApplicationController
           if saved
             render json: @artefact.to_json, status: status_to_use
           else
-            render json: {"errors" => @artefact.errors.full_messages}, status: 400
+            render json: {"errors" => @artefact.errors.full_messages}, status: 422
           end
         end
       end

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -68,7 +68,13 @@ class ArtefactsController < ApplicationController
     else
       @actions = build_actions
       respond_with @artefact, status: status_to_use do |format|
-        format.json { render json: @artefact.to_json, status: status_to_use }
+        format.json do
+          if saved
+            render json: @artefact.to_json, status: status_to_use
+          else
+            render json: {"errors" => @artefact.errors.full_messages}, status: 400
+          end
+        end
       end
     end
   end

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -52,6 +52,25 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         error_details = JSON.parse(last_response.body)
         assert_equal({"errors" => ["Kind is not included in the list"]}, error_details)
       end
+
+      should "support travel-advice artefacts with a travel-advice/foo style slug" do
+        artefact_data = {
+          'slug' => 'travel-advice/aruba',
+          'name' => 'Aruba travel advice',
+          'kind' => 'travel-advice',
+          'description' => 'Travel advice for people travelling to Aruba',
+          'owning_app' => 'travel-advice-publisher',
+          'rendering_app' => 'frontend',
+          'state' => 'draft',
+        }
+
+        put "/artefacts/travel-advice/aruba.json", artefact_data
+
+        assert_equal 201, last_response.status
+
+        artefact = Artefact.find_by_slug('travel-advice/aruba')
+        assert artefact
+      end
     end # for a new artefact
 
     context "for an existing artefact" do

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -1,0 +1,109 @@
+require_relative '../test_helper'
+
+class ArtefactsAPITest < ActiveSupport::TestCase
+
+  setup do
+    create_test_user
+  end
+
+  context "registering an artefact in panopticon" do
+    context "for a new artefact" do
+      should "create a new artefact, and return its details" do
+        artefact_data = {
+          'slug' => 'wibble',
+          'name' => 'Wibble',
+          'kind' => 'answer',
+          'description' => 'Wibble description',
+          'owning_app' => 'publisher',
+          'rendering_app' => 'frontend',
+          'state' => 'draft',
+        }
+
+        # Rack::Test put method calls to_json on whatever body you pass.
+        # This is different to the post method.  Go figure.
+        put "/artefacts/wibble.json", artefact_data
+
+        assert_equal 201, last_response.status
+
+        artefact = Artefact.find_by_slug('wibble')
+        assert artefact
+        assert_equal 'wibble', artefact.slug
+        assert_equal 'Wibble', artefact.name
+        assert_equal 'answer', artefact.kind
+        assert_equal 'Wibble description', artefact.description
+        assert_equal 'publisher', artefact.owning_app
+        assert_equal 'frontend', artefact.rendering_app
+        assert_equal 'draft', artefact.state
+      end
+
+      should "return an error if creating an artefact fails" do
+        artefact_data = {
+          'slug' => 'wibble',
+          'name' => 'Wibble',
+          'kind' => 'wibble', # invalid kind
+          'description' => 'Wibble description',
+          'owning_app' => 'publisher',
+          'state' => 'draft',
+        }
+
+        put "/artefacts/wibble.json", artefact_data
+
+        assert_equal 400, last_response.status
+        error_details = JSON.parse(last_response.body)
+        assert_equal({"errors" => ["Kind is not included in the list"]}, error_details)
+      end
+    end # for a new artefact
+
+    context "for an existing artefact" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact, :slug => 'wibble', :name => "Wibble")
+      end
+
+      should "update the artefact" do
+        artefact_data = {
+          'slug' => 'wibble',
+          'name' => 'Wibble 2 - the return',
+          'kind' => 'answer',
+          'description' => 'Wibble description',
+          'owning_app' => 'publisher',
+          'rendering_app' => 'frontend',
+          'state' => 'draft',
+        }
+
+        put "/artefacts/wibble.json", artefact_data
+
+        assert_equal 200, last_response.status
+
+        @artefact.reload
+        assert_equal 'wibble', @artefact.slug
+        assert_equal 'Wibble 2 - the return', @artefact.name
+        assert_equal 'answer', @artefact.kind
+        assert_equal 'Wibble description', @artefact.description
+        assert_equal 'publisher', @artefact.owning_app
+        assert_equal 'frontend', @artefact.rendering_app
+        assert_equal 'draft', @artefact.state
+      end
+
+      should "return an error if updating the artefact fails" do
+        artefact_data = {
+          'slug' => 'wibble',
+          'name' => 'Wibble 2 - the return',
+          'kind' => 'wibble', # invalid kind
+          'description' => 'Wibble description',
+          'owning_app' => 'publisher',
+          'state' => 'draft',
+        }
+
+        put "/artefacts/wibble.json", artefact_data
+
+        assert_equal 400, last_response.status
+        error_details = JSON.parse(last_response.body)
+        assert_equal({"errors" => ["Kind is not included in the list"]}, error_details)
+
+        @artefact.reload
+        assert_equal "Wibble", @artefact.name
+      end
+
+    end
+  end
+end

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -48,7 +48,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
 
         put "/artefacts/wibble.json", artefact_data
 
-        assert_equal 400, last_response.status
+        assert_equal 422, last_response.status
         error_details = JSON.parse(last_response.body)
         assert_equal({"errors" => ["Kind is not included in the list"]}, error_details)
       end
@@ -115,7 +115,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
 
         put "/artefacts/wibble.json", artefact_data
 
-        assert_equal 400, last_response.status
+        assert_equal 422, last_response.status
         error_details = JSON.parse(last_response.body)
         assert_equal({"errors" => ["Kind is not included in the list"]}, error_details)
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,12 +1,10 @@
 require_relative 'test_helper'
 require 'capybara/rails'
-require 'webmock'
 
 DatabaseCleaner.strategy = :truncation
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-  include WebMock::API
 
   setup do
     DatabaseCleaner.clean
@@ -14,7 +12,6 @@ class ActionDispatch::IntegrationTest
 
   teardown do
     DatabaseCleaner.clean
-    WebMock.reset!  # Not entirely sure whether this happens anyway
     Capybara.use_default_driver
   end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -7,9 +7,5 @@ class ActionDispatch::IntegrationTest
   teardown do
     Capybara.use_default_driver
   end
-
-  def create_test_user
-    FactoryGirl.create(:user)
-  end
 end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,17 +1,10 @@
 require_relative 'test_helper'
 require 'capybara/rails'
 
-DatabaseCleaner.strategy = :truncation
-
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 
-  setup do
-    DatabaseCleaner.clean
-  end
-
   teardown do
-    DatabaseCleaner.clean
     Capybara.use_default_driver
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'mocha'
-require 'webmock'
+require 'webmock/minitest'
 require 'govuk_content_models/test_helpers/factories'
 
 DatabaseCleaner.strategy = :truncation
@@ -27,10 +27,6 @@ class ActiveSupport::TestCase
     DatabaseCleaner.clean
   end
   set_callback :teardown, :before, :clean_db
-
-  def setup
-    WebMock.disable_net_connect!
-  end
 
   def app
     Panopticon::Application
@@ -50,9 +46,5 @@ class ActiveSupport::TestCase
       :authenticated? => true,
       :user => user
     )
-  end
-
-  def teardown
-    WebMock.reset!
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,4 +47,8 @@ class ActiveSupport::TestCase
       :user => user
     )
   end
+
+  def create_test_user
+    FactoryGirl.create(:user)
+  end
 end


### PR DESCRIPTION
This fixes a couple of things with panopticon artefact registration:
- If creating/updating an artefact fails, we now return a 400 status with error messages (previously we were still returning 200/201 with no indication that anything had failed.)
- Registration didn't support travel-advice slugs (of the form `travel-advice/<country_slug>`).  This required an update to govuk_content_models.

I've also tidied up the setup of webmock and database_cleaner.
