### PR TITLE
Fix slug change migration to deal with rummager update

### DIFF
--- a/db/migrate/20130213162738_update_travel_advice_slugs.rb
+++ b/db/migrate/20130213162738_update_travel_advice_slugs.rb
@@ -1,15 +1,16 @@
 class UpdateTravelAdviceSlugs < Mongoid::Migration
   def self.up
     Artefact.where(:slug => %r{\Atravel-advice/}).each do |artefact|
-      artefact.slug = "foreign-#{artefact.slug}"
-      artefact.save :validate => false # validate => false necessary because these will be live artefacts
+      if ! Rails.env.development? or ENV['UPDATE_SEARCH'].present?
+        Rummageable.delete("/#{artefact.slug}")
+      end
+      artefact.set(:slug, "foreign-#{artefact.slug}")
     end
   end
 
   def self.down
     Artefact.where(:slug => %r{\Aforeign-travel-advice/(.*)\z}).each do |artefact|
-      artefact.slug = artefact.slug.sub(/\Aforeign-/, '')
-      artefact.save :validate => false # validate => false necessary because these will be live artefacts
+      artefact.set(:slug, artefact.slug.sub(/\Aforeign-/, ''))
     end
   end
 end


### PR DESCRIPTION
Switch to using set methos to avoid callbacks.  Will deal with re-adding
to search by re-registering everything from travel-advice-publisher
