### PR TITLE
Delete artefacts from search index when changed to nonindexed kinds

### DIFF
--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -3,9 +3,25 @@ class UpdateSearchObserver < Mongoid::Observer
 
   def after_save(artefact)
     rummageable_artefact = RummageableArtefact.new(artefact)
+    
     rummageable_artefact.submit if rummageable_artefact.should_be_indexed?
+
+    if artefact.live? && becoming_nonindexed_kind?(artefact)
+      rummageable_artefact.delete
+    end
+
     # Relying on current behaviour where this does not raise errors
     # if done more than once, or done on artefacts never put live
     rummageable_artefact.delete if artefact.archived?
+  end
+
+  def becoming_nonindexed_kind?(artefact)
+    old_kind = artefact.kind_was
+    new_kind = artefact.kind
+
+    not_a_new_record = ! old_kind.nil?
+    not_a_new_record &&
+        (! RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(old_kind)) &&
+        RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(new_kind)
   end
 end

--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -21,7 +21,7 @@ class UpdateSearchObserver < Mongoid::Observer
 
     not_a_new_record = ! old_kind.nil?
     not_a_new_record &&
-        (! RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(old_kind)) &&
-        RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(new_kind)
+        (RummageableArtefact::FORMATS_NOT_TO_INDEX.exclude?(old_kind)) &&
+         RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(new_kind)
   end
 end

--- a/test/unit/artefact_test.rb
+++ b/test/unit/artefact_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class ArtefactTest < ActiveSupport::TestCase
+  def swallow_router_requests
+    stub_request(:any, %r{http://router.cluster:8080/router/.*}).to_return(:status => 200, :body => "{}")
+  end
+
   setup do
+    swallow_router_requests
     @artefact = FactoryGirl.create(:artefact)
   end
 
@@ -16,5 +21,26 @@ class ArtefactTest < ActiveSupport::TestCase
 
     reloaded_artefact = Artefact.find(@artefact.id)
     assert_nil reloaded_artefact.indexable_content
+  end
+
+  test "should submit live artefacts to the search index" do
+    RummageableArtefact.any_instance.expects(:submit)
+    @artefact.state = "live"
+    @artefact.save!
+  end
+
+  test "should delete archived artefacts from the search index" do
+    RummageableArtefact.any_instance.expects(:delete)
+    @artefact.state = "archived"
+    @artefact.save!
+  end
+
+  test "should delete live artefacts changing to an unindexed kind" do
+    RummageableArtefact.any_instance.stubs(:submit)
+    @artefact = FactoryGirl.create(:artefact, kind: "answer", state: "live")
+
+    RummageableArtefact.any_instance.expects(:delete)
+    @artefact.kind = "completed_transaction"
+    @artefact.save!
   end
 end

--- a/test/unit/update_search_observer_test.rb
+++ b/test/unit/update_search_observer_test.rb
@@ -1,0 +1,5 @@
+require_relative '../test_helper'
+
+class UpdateSearchObserverTest < ActiveSupport::TestCase
+  
+end

--- a/test/unit/update_search_observer_test.rb
+++ b/test/unit/update_search_observer_test.rb
@@ -1,5 +1,0 @@
-require_relative '../test_helper'
-
-class UpdateSearchObserverTest < ActiveSupport::TestCase
-  
-end


### PR DESCRIPTION
We have had some artefacts created (incorrectly) as Answers when they should
have been CompletedTransactions. These were not removed automatically. This
change would ensure that they are in future.

I haven't written any tests for which I feel bad, though I have tested by hand. I did try moving this logic into RummageableArtefact to make it more testable, but the use of ActiveModel's dirty tracking (`kind_was`) was a bit too hidden and distant, whereas in the context of an observer it feels sane.
