### PR TITLE
Fix incorrect artefact kinds

### DIFF
--- a/db/migrate/20130221152347_fix_incorrect_artefact_kinds.rb
+++ b/db/migrate/20130221152347_fix_incorrect_artefact_kinds.rb
@@ -1,0 +1,16 @@
+class FixIncorrectArtefactKinds < Mongoid::Migration
+  def self.up
+    Artefact.where(state: "live", owning_app: "publisher").each do |artefact|
+      edition = Edition.published.where(panopticon_id: artefact.id).first
+      if edition
+        if artefact.kind != edition.format.underscore
+          artefact.kind = edition.format.underscore
+          artefact.save
+        end
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Publisher hasn't been correctly updating the kind when a (new) edition is
published with a different kind (format).

This change fixes the existing data. The publisher bug will be fixed here: https://github.com/alphagov/publisher/pull/71
