### PR TITLE
Remove gds-warmup-controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'http://rubygems.org'
 source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
-gem 'gds-warmup-controller', '0.1.0'
-
 gem 'plek', '1.3.1'
 gem 'formtastic', git: 'https://github.com/justinfrench/formtastic.git', branch: '2.1-stable'
 gem 'formtastic-bootstrap', git: 'https://github.com/cgunther/formtastic-bootstrap.git', branch: 'bootstrap-2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,6 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    gds-warmup-controller (0.1.0)
-      rails (>= 3.0.0)
     gelf (1.3.2)
       json
     gherkin (2.11.1)
@@ -325,7 +323,6 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
-  gds-warmup-controller (= 0.1.0)
   gelf
   govuk_content_models (= 4.7.0)
   jquery-rails (= 2.0.2)


### PR DESCRIPTION
This is no longer used since we switched to unicorn
