### PR TITLE
Fix nil error in RouteableArtefact#delete

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -39,7 +39,7 @@ class RoutableArtefact
   end
 
   def delete
-    ([@artefact.slug] + @artefact.paths + @artefact.prefixes).each do |path|
+    ([@artefact.slug] + (@artefact.paths || []) + (@artefact.prefixes || [])).each do |path|
       router.delete_route(path)
     end
   end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -80,4 +80,31 @@ class RoutableArtefactTest < ActiveSupport::TestCase
     Router.any_instance.stubs(:create_route)
     @routable.submit
   end
+
+  context "deleting routes for an artefact" do
+
+    should "delete the artefact slug from the router" do
+      Router.any_instance.expects(:delete_route).with(@artefact.slug)
+      @routable.delete
+    end
+
+    should "delete all paths and prefixes as well as the slug" do
+      @artefact.paths = ["foo", "bar"]
+      @artefact.prefixes = ["baz"]
+      Router.any_instance.expects(:delete_route).with(@artefact.slug)
+      Router.any_instance.expects(:delete_route).with("foo")
+      Router.any_instance.expects(:delete_route).with("bar")
+      Router.any_instance.expects(:delete_route).with("baz")
+      @routable.delete
+    end
+
+    should "cope with paths or prefixes being set to nil" do
+      @artefact.paths = nil
+      @artefact.prefixes = nil
+      Router.any_instance.expects(:delete_route).with(@artefact.slug)
+      assert_nothing_raised do
+        @routable.delete
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some artefacts have paths or prefixes set to nil, not []. This was
causing 500 errors when archiving these.  It also prevented them
from being removed from search because this observer fires first.
