### PR TITLE
Make need_id editable even if it's not a new record

### DIFF
--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -23,7 +23,7 @@
         <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?}, :hint => name_hint_for(f.object) %>
         <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
-        <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
+        <%= f.input :need_id, :input_html => { :class => "span6" } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>
             <%= link_to "View in Need-O-Tron", need_url(f.object), :rel => 'external', :class => "btn btn-primary" %>
         <% end %>


### PR DESCRIPTION
It was made editable for new records by @daibach here: https://github.com/alphagov/panopticon/commit/739241f45290b777f0f5dd54674adf84f1ad5f1f
