### PR TITLE
Add extended font flag checkbox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.10.2"
+  gem "govuk_content_models", "4.11.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.10.2)
+    govuk_content_models (4.11.0)
       bson_ext
       differ
       gds-api-adapters
@@ -326,7 +326,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 4.10.2)
+  govuk_content_models (= 4.11.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   launchy

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -23,6 +23,7 @@
         <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?}, :hint => name_hint_for(f.object) %>
         <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
+        <%= f.input :need_international_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>
             <%= link_to "View in Need-O-Tron", need_url(f.object), :rel => 'external', :class => "btn btn-primary" %>

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -23,7 +23,7 @@
         <%= f.input :name, :input_html => { :class => "span6", :disabled => f.object.persisted?}, :hint => name_hint_for(f.object) %>
         <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
-        <%= f.input :need_international_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
+        <%= f.input :need_extended_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>
             <%= link_to "View in Need-O-Tron", need_url(f.object), :rel => 'external', :class => "btn btn-primary" %>

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -17,7 +17,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
           'owning_app' => 'publisher',
           'rendering_app' => 'frontend',
           'state' => 'draft',
-          'need_international_font' => false
+          'need_extended_font' => false
         }
 
         # Rack::Test put method calls to_json on whatever body you pass.
@@ -35,7 +35,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         assert_equal 'publisher', artefact.owning_app
         assert_equal 'frontend', artefact.rendering_app
         assert_equal 'draft', artefact.state
-        assert_equal false, artefact.need_international_font
+        assert_equal false, artefact.need_extended_font
       end
 
       should "return an error if creating an artefact fails" do

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -17,6 +17,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
           'owning_app' => 'publisher',
           'rendering_app' => 'frontend',
           'state' => 'draft',
+          'need_international_font' => false
         }
 
         # Rack::Test put method calls to_json on whatever body you pass.
@@ -34,6 +35,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         assert_equal 'publisher', artefact.owning_app
         assert_equal 'frontend', artefact.rendering_app
         assert_equal 'draft', artefact.state
+        assert_equal false, artefact.need_international_font
       end
 
       should "return an error if creating an artefact fails" do


### PR DESCRIPTION
This is the second part of the task that started with this pull request: https://github.com/alphagov/govuk_content_models/pull/60

Adds a checkbox to the artefact to allow the `need_extended_font` flag to be set / unset.
