### PR TITLE
Use London timezone, not UTC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.10.2"
+  gem "govuk_content_models", "4.11.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.10.2)
+    govuk_content_models (4.11.0)
       bson_ext
       differ
       gds-api-adapters
@@ -142,7 +142,7 @@ GEM
       jquery-rails
       railties (>= 3.1.0)
     json (1.7.7)
-    jwt (0.1.7)
+    jwt (0.1.8)
       multi_json (>= 1.5)
     kgio (2.7.4)
     kramdown (0.13.8)
@@ -326,7 +326,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 4.10.2)
+  govuk_content_models (= 4.11.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   launchy

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,5 @@ ENV["GOVUK_WEBSITE_ROOT"] = ENV.fetch("GOVUK_WEBSITE_ROOT", "http://www.dev.gov.
 require File.expand_path('../config/application', __FILE__)
 
 Panopticon::Application.load_tasks
+
+task :default => [:test, :check_for_bad_time_handling]

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module Panopticon
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,12 +1,15 @@
+# This file is overwritten by one in alphagov-deployment at deploy time
 development:
   host: localhost
   database: govuk_content_development
   persist_in_safe_mode: true
+  use_activesupport_time_zone: true
 
 test:
   host: localhost
   # Don't want this interfering with a concurrent Publisher test run
   database: govuk_content_panopticon_test
+  use_activesupport_time_zone: true
 
 # set these environment variables on your prod server
 production:
@@ -15,6 +18,7 @@ production:
   username: <%= ENV['MONGOID_USERNAME'] %>
   password: <%= ENV['MONGOID_PASSWORD'] %>
   database: <%= ENV['MONGOID_DATABASE'] %>
+  use_activesupport_time_zone: true
   # slaves:
   #   - host: slave1.local
   #     port: 27018

--- a/lib/tasks/check_for_bad_time_handling.rake
+++ b/lib/tasks/check_for_bad_time_handling.rake
@@ -1,0 +1,25 @@
+task :check_for_bad_time_handling do
+  directories = Dir.glob(File.join(Rails.root, '**', '*.rb'))
+  matching_files = directories.select do |filename|
+    match = false
+    File.open(filename) do |file|
+      match = file.grep(%r{Time\.(now|utc|parse)}).any?
+    end
+    match
+  end
+  if matching_files.any?
+    raise <<-MSG
+
+Avoid issues with daylight-savings time by always building instances of
+TimeWithZone and not Time. Use methods like:
+    Time.zone.now, Time.zone.parse, n.days.ago, m.hours.from_now, etc
+
+in preference to methods like:
+    Time.now, Time.utc, Time.parse, etc
+
+Files that contain bad Time handling:
+  #{matching_files.join("\n  ")}
+
+MSG
+  end
+end


### PR DESCRIPTION
Also, test for inappropriate uses of time without zone.

The changes to mongoid.yml need to be reflected in alphagov-deployment: https://github.com/alphagov/alphagov-deployment/pull/116
