### PR TITLE
Remove "relatedness done" flag

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -64,10 +64,6 @@ tr.top-level-section {
   margin-left: 0;
 }
 
-.relatedness-force-clear {
-  clear: both;
-}
-
 .language_icon  {
   display: inline-block;
   text-indent: -9999px;

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -71,8 +71,6 @@
 
         <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: true } %>
         <button id="add-related" class="btn btn-success" type="button">Add another related item</button>
-
-        <%= f.input :relatedness_done, :label => "Is relatedness done?", :as => :boolean %>
       <% end %>
 
       <hr>

--- a/app/views/artefacts/index.html.erb
+++ b/app/views/artefacts/index.html.erb
@@ -28,7 +28,6 @@
               <th scope="col">Primary section</th>
               <th scope="col">Other sections</th>
               <th scope="col">Related items</th>
-              <th scope="col">Relatedness done?</th>
               <th scope="col">App</th>
               <th scope="col">Slug</th>
             </tr>
@@ -45,7 +44,6 @@
               <td><%= artefact.primary_section %></td>
               <td><%= (artefact.sections - [artefact.primary_section]).join(", ") %></td>
               <td><%= artefact.related_artefact_ids.count %></td>
-              <td><%= artefact.relatedness_done %></td>
               <td><%= artefact.owning_app %></td>
               <td><%= link_to artefact.slug, published_url(artefact) %></td>
             </tr>

--- a/features/editing.feature
+++ b/features/editing.feature
@@ -16,7 +16,6 @@ Feature: Editing artefacts
   Scenario: Editing an artefact and returning to edit some more
     Given two artefacts exist
     When I change the title of the first artefact
-      And I mark relatedness as done
       And I save, indicating that I want to continue editing afterwards
     Then I should be redirected back to the edit page
       And I should see an indication that the save worked

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -18,10 +18,6 @@ Given /^two non-publisher artefacts exist$/ do
   @artefact, @related_artefact = create_two_artefacts("smart-answers")
 end
 
-When /^I mark relatedness as done$/ do
-  check :relatedness_done
-end
-
 When /^I change the title of the first artefact$/ do
   visit edit_artefact_path(@artefact)
   @new_name = "Some other new name"


### PR DESCRIPTION
This was used as a temporary mechanism for checking relatedness leading up to
the launch of GOV.UK, and is no longer used.

I will completely remove the field from `govuk_content_models`, and I have tested these changes with those. See: https://github.com/alphagov/govuk_content_models/pull/61
