### PR TITLE
Bump govuk_content_models to 4.12.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.12.0"
+  gem "govuk_content_models", "4.12.1"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.12.0)
+    govuk_content_models (4.12.1)
       bson_ext
       differ
       gds-api-adapters
@@ -325,7 +325,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 4.12.0)
+  govuk_content_models (= 4.12.1)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -4,12 +4,4 @@ class Artefact
   # Add a non-field attribute so we can pass indexable content over to Rummager
   # without persisting it
   attr_accessor :indexable_content
-
-  def archived?
-    state == 'archived'
-  end
-
-  def self.relatable_items
-    self.in_alphabetical_order.where(:kind.nin => ["completed_transaction"], :state.nin => ["archived"])
-  end
 end


### PR DESCRIPTION
The methods that were originally added to the Artefact model with
meta-programming have since been moved into the model as part of
4.12.1 of govuk_content_models. For more context, see:
https://github.com/alphagov/govuk_content_models/pull/62

The attr_accessor has been left in place as it's a Rummageable method
added as part of the module and not something we want to expose on the
model for the time being.

The context of the attr_accessor can be found in
7734351324a80b89b46d00e8903fc6b194c8b858
