### PR TITLE
Bump govuk_content_models to 4.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.12.0"
+  gem "govuk_content_models", "4.13.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.12.0)
+    govuk_content_models (4.13.0)
       bson_ext
       differ
       gds-api-adapters
@@ -325,7 +325,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 4.12.0)
+  govuk_content_models (= 4.13.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -4,12 +4,4 @@ class Artefact
   # Add a non-field attribute so we can pass indexable content over to Rummager
   # without persisting it
   attr_accessor :indexable_content
-
-  def archived?
-    state == 'archived'
-  end
-
-  def self.relatable_items
-    self.in_alphabetical_order.where(:kind.nin => ["completed_transaction"], :state.nin => ["archived"])
-  end
 end

--- a/app/observers/remove_related_artefacts_observer.rb
+++ b/app/observers/remove_related_artefacts_observer.rb
@@ -2,7 +2,7 @@ class RemoveRelatedArtefactsObserver < Mongoid::Observer
   observe :artefact
 
   def after_save(artefact)
-    if artefact.state == 'archived'
+    if artefact.archived?
       Artefact.where(:related_artefact_ids.in => [artefact.id]).each do | a |
         a.related_artefact_ids.delete(artefact.id)
         a.save

--- a/app/views/artefacts/edit.html.erb
+++ b/app/views/artefacts/edit.html.erb
@@ -6,7 +6,7 @@
   <ul class="nav nav-tabs">
     <li class="active"><a href="#edit" data-toggle="tab">Edit</a></li>
     <li><a href="#history" data-toggle="tab">History</a></li>
-    <% if @artefact.state != "archived" %>
+    <% unless @artefact.archived? %>
       <li><a href="#archive" data-toggle="tab">Archive</a></li>
     <% end %>
   </ul>
@@ -21,7 +21,7 @@
     <div class="tab-pane" id="history">
       <%= render 'history', actions: @actions %>
     </div>
-    <% if @artefact.state != "archived" %>
+    <% unless @artefact.archived? %>
       <div class="tab-pane" id="archive">
         <%= render 'archive', artefact: @artefact %>
       </div>


### PR DESCRIPTION
The methods that were originally added to the Artefact model with
meta-programming have since been moved into the model as part of
4.13.0 of govuk_content_models. For more context, see:
https://github.com/alphagov/govuk_content_models/pull/62

The attr_accessor has been left in place as it's a Rummageable method
added as part of the module and not something we want to expose on the
model for the time being.

The context of the attr_accessor can be found in
7734351324a80b89b46d00e8903fc6b194c8b858
