### PR TITLE
Make need id editable when blank

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -4,4 +4,8 @@ class Artefact
   # Add a non-field attribute so we can pass indexable content over to Rummager
   # without persisting it
   attr_accessor :indexable_content
+
+  def need_id_editable?
+    self.new_record? || self.need_id.blank?
+  end
 end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -24,7 +24,7 @@
         <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_extended_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
-        <%= f.input :need_id, :input_html => { :class => "span6", :disabled => f.object.persisted? } %>
+        <%= f.input :need_id, :input_html => { :class => "span6", :disabled => !f.object.need_id_editable? } %>
         <% if ! artefact.new_record? && ! artefact.business_proposition %>
             <%= link_to "View in Need-O-Tron", need_url(f.object), :rel => 'external', :class => "btn btn-primary" %>
         <% end %>

--- a/db/migrate/20130422153224_normalise_need_i_ds.rb
+++ b/db/migrate/20130422153224_normalise_need_i_ds.rb
@@ -1,0 +1,8 @@
+class NormaliseNeedIDs < Mongoid::Migration
+  def self.up
+    Artefact.where(need_id: "1").update_all(need_id: nil)
+  end
+
+  def self.down
+  end
+end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -118,6 +118,19 @@ class ArtefactsControllerTest < ActionController::TestCase
     end
 
     context "GET edit" do
+      should "make need_id editable if it's blank" do
+        artefact = FactoryGirl.create(:artefact, need_id: "")
+        get :edit, id: artefact.id
+        assert_select "input#artefact_need_id[disabled]", count: 0
+        assert_select "input#artefact_need_id"
+      end
+
+      should "make need_id uneditable if set" do
+        artefact = FactoryGirl.create(:artefact, need_id: "B123")
+        get :edit, id: artefact.id
+        assert_select "input#artefact_need_id[disabled]", count: 1
+      end
+
       context "whitehall is the owning_app" do
         should "render the whitehall variant of the form" do
           artefact = FactoryGirl.create(:artefact, owning_app: "whitehall")


### PR DESCRIPTION
We should be very careful about allowing changes to need_ids, but blank ones
should be settable.

It would be good if someone could check my assertion that need_ids of "1" are essentially meaningless.
