### PR TITLE
Allow editing non-numeric need_ids

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -6,6 +6,6 @@ class Artefact
   attr_accessor :indexable_content
 
   def need_id_editable?
-    self.new_record? || self.need_id.blank?
+    self.new_record? || self.need_id.blank? || self.need_id.strip !~ /\A\d+\z/
   end
 end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -118,19 +118,6 @@ class ArtefactsControllerTest < ActionController::TestCase
     end
 
     context "GET edit" do
-      should "make need_id editable if it's blank" do
-        artefact = FactoryGirl.create(:artefact, need_id: "")
-        get :edit, id: artefact.id
-        assert_select "input#artefact_need_id[disabled]", count: 0
-        assert_select "input#artefact_need_id"
-      end
-
-      should "make need_id uneditable if set" do
-        artefact = FactoryGirl.create(:artefact, need_id: "B123")
-        get :edit, id: artefact.id
-        assert_select "input#artefact_need_id[disabled]", count: 1
-      end
-
       context "whitehall is the owning_app" do
         should "render the whitehall variant of the form" do
           artefact = FactoryGirl.create(:artefact, owning_app: "whitehall")

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -15,6 +15,41 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     assert page.has_link?("View on site", :href => "http://www.dev.gov.uk/alpha")
   end
 
+  context "restricting editing of need_id" do
+    should "not allow editing with existing numeric value" do
+      artefact = FactoryGirl.create(:artefact, :need_id => "1234")
+      visit "/artefacts/#{artefact.id}/edit"
+      field = page.find_field("Need")
+      assert field[:disabled]
+    end
+
+    should "allow editing if blank" do
+      artefact = FactoryGirl.create(:artefact, :need_id => " ")
+      visit "/artefacts/#{artefact.id}/edit"
+      field = page.find_field("Need")
+      assert field[:disabled].nil?
+
+      fill_in "Need", :with => "2345"
+      click_on "Save and continue editing"
+
+      artefact.reload
+      assert_equal "2345", artefact.need_id
+    end
+
+    should "allow editing if non-numeric" do
+      artefact = FactoryGirl.create(:artefact, :need_id => "B241")
+      visit "/artefacts/#{artefact.id}/edit"
+      field = page.find_field("Need")
+      assert field[:disabled].nil?
+
+      fill_in "Need", :with => "2345"
+      click_on "Save and continue editing"
+
+      artefact.reload
+      assert_equal "2345", artefact.need_id
+    end
+  end
+
   context "editing legacy_sources" do
     setup do
       @bl   = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')


### PR DESCRIPTION
This is to allow us to gradually transition the business need_ids (B324 etc.) to proper need-o-tron need_ids.
