### PR TITLE
Surface business finance and support schemes in search

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -2,6 +2,20 @@ class RummageableArtefact
 
   FORMATS_NOT_TO_INDEX = %W(business_support completed_transaction) + Artefact::FORMATS_BY_DEFAULT_OWNING_APP["whitehall"]
 
+  EXCEPTIONAL_SLUGS = %W(
+    growthaccelerator
+    technology-strategy-board
+    enterprise-finance-guarantee
+    manufacturing-advisory-service-mas
+    research-development-tax-credit-smes
+    enterprise-investment-scheme
+    seed-enterprise-investment-scheme
+    designing-demand
+    business-mentoring-support
+    start-up-loans
+    new-enterprise-allowance
+  )
+
   def initialize(artefact)
     @artefact = artefact
   end
@@ -11,11 +25,19 @@ class RummageableArtefact
   end
 
   def should_be_indexed?
-    @artefact.live? && ! FORMATS_NOT_TO_INDEX.include?(@artefact.kind)
+    @artefact.live? && indexable_artefact?
+  end
+
+  def self.indexable_artefact?(kind, slug)
+    (FORMATS_NOT_TO_INDEX.exclude?(kind) || EXCEPTIONAL_SLUGS.include?(slug))
+  end
+
+  def indexable_artefact?
+    self.class.indexable_artefact?(@artefact.kind, @artefact.slug)
   end
 
   def submit
-    return if FORMATS_NOT_TO_INDEX.include?(@artefact.kind)
+    return unless indexable_artefact? 
 
     # API requests, if they know about the single registration API, will be
     # providing the indexable_content field to update Rummager. UI requests

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -14,6 +14,7 @@ class RummageableArtefact
     business-mentoring-support
     start-up-loans
     new-enterprise-allowance
+    helping-your-business-grow-internationally
   )
 
   def initialize(artefact)

--- a/app/observers/update_search_observer.rb
+++ b/app/observers/update_search_observer.rb
@@ -21,7 +21,7 @@ class UpdateSearchObserver < Mongoid::Observer
 
     not_a_new_record = ! old_kind.nil?
     not_a_new_record &&
-        (RummageableArtefact::FORMATS_NOT_TO_INDEX.exclude?(old_kind)) &&
-         RummageableArtefact::FORMATS_NOT_TO_INDEX.include?(new_kind)
+        (RummageableArtefact.indexable_artefact?(old_kind, artefact.slug)) &&
+         !RummageableArtefact.indexable_artefact?(new_kind, artefact.slug)
   end
 end

--- a/test/integration/artefact_search_indexing_test.rb
+++ b/test/integration/artefact_search_indexing_test.rb
@@ -38,4 +38,15 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
     @artefact.kind = "completed_transaction"
     @artefact.save!
   end
+
+  test "should not delete an artefact with an excluded kind where the slug is indexable" do
+    RummageableArtefact.any_instance.stubs(:submit)
+    @artefact = FactoryGirl.create(:artefact, kind: "answer", slug: "new-enterprise-allowance", state: "live")
+   
+    RummageableArtefact.any_instance.expects(:submit)
+    RummageableArtefact.any_instance.expects(:delete).never 
+    @artefact.kind = "business_support"
+    @artefact.save!
+  end
+
 end

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -133,6 +133,16 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     refute RummageableArtefact.new(artefact).should_be_indexed?
   end
 
+  test "should index business support content with an acceptable slug" do
+    artefact = Artefact.new do |artefact|
+      artefact.slug = "new-enterprise-allowance"
+      artefact.state = "live"
+      artefact.kind = "business_support"
+    end
+
+    assert RummageableArtefact.new(artefact).should_be_indexed?
+  end
+
   test "should not index content formats managed by Whitehall" do
     artefact = Artefact.new do |artefact|
       artefact.state = "live"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/50252885
Adds a list of slugs which can be submitted to the search index despite the format restrictions. Allows some BFSF schemes to surface in search.
