### PR TITLE
[#51001091] Remove rbenv shims when a .ruby-version file isn't present

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,13 @@
 #!/bin/bash -x
+
+# This removes rbenv shims from the PATH where there is no
+# .ruby-version file. This is because certain gems call their
+# respective tasks with ruby -S which causes the following error to
+# appear: ruby: no Ruby script found in input (LoadError).
+if [ ! -f .ruby-version ]; then
+  export PATH=`echo $PATH | awk 'BEGIN { RS=":"; ORS=":" } !/rbenv/' | sed 's/:$//'`
+fi
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop db:create db:schema:load
 bundle exec rake


### PR DESCRIPTION
Due to the way that cucumber works[1], having rbenv's shims on the
PATH causes a `ruby: no Ruby script found in input (LoadError)` error
to occur.

This fix removes rbenv's shims from the PATH so that the provided (our
packaged) version of Ruby (1.9.2) gets used.

[1] https://github.com/cucumber/cucumber/blob/281b271f8e1957b36eee357a4c90727b91ced65e/lib/cucumber/rake/task.rb#L89
