### PR TITLE
Update govuk_content_models version to 5.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.5.0"
+  gem "govuk_content_models", "5.7.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.5.0)
+    govuk_content_models (5.7.0)
       bson_ext
       differ
       gds-api-adapters
@@ -337,7 +337,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 5.5.0)
+  govuk_content_models (= 5.7.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/test/integration/artefact_create_test.rb
+++ b/test/integration/artefact_create_test.rb
@@ -1,0 +1,52 @@
+require_relative '../integration_test_helper'
+
+class ArtefactCreateTest < ActionDispatch::IntegrationTest
+
+  setup do
+    create_test_user
+  end
+
+  should "allow the use of deep slugs when creating a whitehall artefact" do
+    visit "/artefacts"
+    click_on "Add Whitehall artefact"
+
+    within("form#edit_artefact") do
+      fill_in "Name", :with => "British Embassy Legoland"
+      fill_in "Description", :with => "Some information on the British Embassy in Legoland"
+      fill_in "Slug", :with => "government/world/organisations/british-embassy-legoland"
+      select "Worldwide priority", :from => "Kind"
+      click_on "Save and continue editing"
+
+      artefact = Artefact.where(:slug => 'government/world/organisations/british-embassy-legoland').last
+
+      assert_equal "/artefacts/#{artefact.to_param}/edit", current_path 
+    end
+
+    assert page.has_link?("View on site")
+    within(".alert.alert-error") do 
+      assert page.has_no_css?("li"), "No form errors were expected"
+    end
+
+  end
+
+  should "not allow the use of invalid slugs when creating a whitehall artefact" do
+    visit "/artefacts"
+    click_on "Add Whitehall artefact"
+
+    within("form#edit_artefact") do
+      fill_in "Name", :with => "British Embassy Legoland"
+      fill_in "Description", :with => "Some information on the British Embassy in Legoland"
+      fill_in "Slug", :with => "government/world/.organi$ation$/briti$h~embassy~legoland"
+      select "Worldwide priority", :from => "Kind"
+      click_on "Save and continue editing"
+    end
+
+    assert_equal "/artefacts", current_path
+    
+    within(".alert.alert-error") do
+      assert page.has_content?("Slug must be usable in a URL") 
+    end
+
+  end
+
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/50728561
Latest version of govuk_content_models allows deep slugs to be saved in panopticon e.g. 'government/world/organisations/british-embassy-moscow'
