### PR TITLE
Bump content models to 5.10.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'lograge', '~> 0.1.0'
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.7.0"
+  gem "govuk_content_models", "5.10.1"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.7.0)
+    govuk_content_models (5.10.1)
       bson_ext
       differ
       gds-api-adapters
@@ -337,7 +337,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 5.7.0)
+  govuk_content_models (= 5.10.1)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
This is to pull in the current method of modeling simple smart answers.
Without this, updates to artefacts for simple smart answers would
sometimes fail with a suprious validation error.
