### PR TITLE
Link to the correct place for a need based on the artefact's Need ID

### DIFF
--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -1,8 +1,4 @@
 module ArtefactsHelper
-  def need_url(artefact)
-    Plek.current.find('needotron') + "/needs/#{artefact.need_id}"
-  end
-
   def published_url(artefact)
     Plek.current.website_root + "/#{artefact.slug}"
   end
@@ -21,5 +17,11 @@ module ArtefactsHelper
         result.concat(formats)
       end
     end
+  end
+
+  def need_url(artefact)
+    return unless artefact.need_owning_service
+
+    Plek.current.find(artefact.need_owning_service) + "/needs/#{artefact.need_id}"
   end
 end

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -24,4 +24,10 @@ module ArtefactsHelper
 
     Plek.current.find(artefact.need_owning_service) + "/needs/#{artefact.need_id}"
   end
+
+  def link_to_view_need(artefact)
+    return unless artefact.need_owning_service
+
+    link_to("View in #{artefact.need_owning_service.titleize}", need_url(artefact), :rel => 'external', :class => "btn btn-primary")
+  end
 end

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -8,4 +8,9 @@ class Artefact
   def need_id_editable?
     self.new_record? || self.need_id.blank? || self.need_id.strip !~ /\A\d+\z/
   end
+
+  def need_owning_service
+    return nil unless self.need_id.present? and self.need_id.match(/\A[0-9]+\Z/)
+    self.need_id.to_i < 100000 ? "needotron" : "maslow"
+  end
 end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -25,9 +25,8 @@
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_extended_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
         <%= f.input :need_id, :input_html => { :class => "span6", :disabled => !f.object.need_id_editable? } %>
-        <% if ! artefact.new_record? && ! artefact.business_proposition %>
-            <%= link_to "View in Need-O-Tron", need_url(f.object), :rel => 'external', :class => "btn btn-primary" %>
-        <% end %>
+
+        <%= link_to_view_need(f.object) if ! artefact.new_record? && ! artefact.business_proposition %>
         <%= link_to "View on site", published_url(f.object), :rel => 'external', :class => "btn btn-primary" unless f.object.new_record? %>
 
         <hr>

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -15,6 +15,36 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     assert page.has_link?("View on site", :href => "http://www.dev.gov.uk/alpha")
   end
 
+  context "linking to needs" do
+    should "link to the Needotron given a need ID < 100000" do
+      artefact = FactoryGirl.create(:artefact, :name => "Need from Needotron", :slug => 'needotron', :need_id => "99999")
+
+      visit "/artefacts"
+      click_on "Need from Needotron"
+
+      assert page.has_link?("View in Needotron", :href => "http://needotron.dev.gov.uk/needs/99999")
+    end
+
+    should "link to Maslow given a need ID >= 100000" do
+      artefact = FactoryGirl.create(:artefact, :name => "Need from Maslow", :slug => 'maslow', :need_id => "100000")
+
+      visit "/artefacts"
+      click_on "Need from Maslow"
+
+      assert page.has_link?("View in Maslow", :href => "http://maslow.dev.gov.uk/needs/100000")
+    end
+
+    should "not link to any need if the need ID is non-numeric" do
+      artefact = FactoryGirl.create(:artefact, :name => "Need from a spreadsheet", :slug => 'spreadsheet', :need_id => "B12345")
+
+      visit "/artefacts"
+      click_on "Need from a spreadsheet"
+
+      assert page.has_no_link?("View in Needotron")
+      assert page.has_no_link?("View in Maslow")
+    end
+  end
+
   context "restricting editing of need_id" do
     should "not allow editing with existing numeric value" do
       artefact = FactoryGirl.create(:artefact, :need_id => "1234")

--- a/test/unit/artefact_test.rb
+++ b/test/unit/artefact_test.rb
@@ -1,0 +1,37 @@
+require_relative '../test_helper'
+
+class ArtefactTest < ActiveSupport::TestCase
+
+  context "need_owning_service" do
+    should "return needotron when need_id =< 5000" do
+      artefact = FactoryGirl.create(:artefact, need_id: "99999")
+
+      assert_equal "needotron", artefact.need_owning_service
+    end
+
+    should "return maslow when need_id >= 100000" do
+      artefact = FactoryGirl.create(:artefact, need_id: "100000")
+
+      assert_equal "maslow", artefact.need_owning_service
+    end
+
+    should "return nil if need_id is nil" do
+      artefact = FactoryGirl.create(:artefact, need_id: nil)
+
+      assert_nil artefact.need_owning_service
+    end
+
+    should "return nil if need_id is empty" do
+      artefact = FactoryGirl.create(:artefact, need_id: "")
+
+      assert_nil artefact.need_owning_service
+    end
+
+    should "return nil if need_id is non-numeric" do
+      artefact = FactoryGirl.create(:artefact, need_id: "B5678")
+
+      assert_nil artefact.need_owning_service
+    end
+  end
+
+end

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -16,4 +16,20 @@ class ArtefactsHelperTest < ActionView::TestCase
       assert_nil need_url(artefact)
     end
   end
+
+  context "link_to_view_need" do
+    should "render a link to the need" do
+      artefact = OpenStruct.new(need_owning_service: "needorama")
+      expects(:need_url).with(artefact).returns("http://needorama.dev.gov.uk/a-need")
+
+      expected = "<a href=\"http://needorama.dev.gov.uk/a-need\" class=\"btn btn-primary\" rel=\"external\">View in Needorama</a>"
+      assert_equal expected, link_to_view_need(artefact)
+    end
+
+    should "not render a link if need_owning_service is nil" do
+      artefact = OpenStruct.new(need_owning_service: nil)
+
+      assert_nil link_to_view_need(artefact)
+    end
+  end
 end

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../test_helper'
+
+class ArtefactsHelperTest < ActionView::TestCase
+  include ArtefactsHelper
+
+  context "need_url" do
+    should "build a url from the need_owning_service" do
+      artefact = OpenStruct.new(need_owning_service: "needorama", need_id: "123456")
+
+      assert_equal "http://needorama.dev.gov.uk/needs/123456", need_url(artefact)
+    end
+
+    should "return nil if need_owning_service is nil" do
+      artefact = OpenStruct.new(need_owning_service: nil, need_id: "malformed need ID")
+
+      assert_nil need_url(artefact)
+    end
+  end
+end


### PR DESCRIPTION
This changes the button in the artefact edit form to view the need to link to the correct service - either Need-o-tron or Maslow - based on the Need ID.

A Need ID for Maslow will always be above or equal to 100000. Anything less than that is assumed to be a Need-o-tron need.

This also removes the button in the case where the value of the Need ID field in the artefact is non-numeric, as this will be a reference to a need from a spreadsheet and so it won't exist in any of the two services.
