### PR TITLE
Fixup Artefact paths and prefixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.12.0"
+  gem "govuk_content_models", "5.13.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.12.0)
+    govuk_content_models (5.13.0)
       bson_ext
       differ
       gds-api-adapters
@@ -340,7 +340,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.18.0)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 5.12.0)
+  govuk_content_models (= 5.13.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/db/migrate/20131108092159_cleanup_invalid_paths_prefixes.rb
+++ b/db/migrate/20131108092159_cleanup_invalid_paths_prefixes.rb
@@ -3,21 +3,13 @@ class CleanupInvalidPathsPrefixes < Mongoid::Migration
     Artefact.skip_callback(:update, :after, :update_editions)
     Artefact.all.each do |a|
       all_paths = (a.prefixes || []) + (a.paths || [])
-      if all_paths.any? {|p| ! valid_local_path?(p) }
+      if all_paths.any? {|p| ! a.send(:valid_url_path?, p) }
         puts "Invalid paths for #{a.slug} (#{a.state}, owning_app: #{a.owning_app})\n  prefixes: #{a.prefixes.inspect}\n  paths: #{a.paths.inspect}"
         a.paths = []
         a.prefixes = []
         a.save!
       end
     end
-  end
-
-  def self.valid_local_path?(path)
-    return false unless path.starts_with?("/")
-    uri = URI.parse(path)
-    uri.path == path && path !~ %r{//} && path !~ %r{./\z}
-  rescue URI::InvalidURIError
-    false
   end
 
   def self.down

--- a/db/migrate/20131108092159_cleanup_invalid_paths_prefixes.rb
+++ b/db/migrate/20131108092159_cleanup_invalid_paths_prefixes.rb
@@ -1,0 +1,25 @@
+class CleanupInvalidPathsPrefixes < Mongoid::Migration
+  def self.up
+    Artefact.skip_callback(:update, :after, :update_editions)
+    Artefact.all.each do |a|
+      all_paths = (a.prefixes || []) + (a.paths || [])
+      if all_paths.any? {|p| ! valid_local_path?(p) }
+        puts "Invalid paths for #{a.slug} (#{a.state}, owning_app: #{a.owning_app})\n  prefixes: #{a.prefixes.inspect}\n  paths: #{a.paths.inspect}"
+        a.paths = []
+        a.prefixes = []
+        a.save!
+      end
+    end
+  end
+
+  def self.valid_local_path?(path)
+    return false unless path.starts_with?("/")
+    uri = URI.parse(path)
+    uri.path == path && path !~ %r{//} && path !~ %r{./\z}
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def self.down
+  end
+end

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -1,0 +1,12 @@
+
+namespace :router do
+  desc "Reregister all live artefacts with the router"
+  task :reregister_live_artefacts => :environment do
+    puts "Re-registering all live artefacts with the router"
+    Artefact.where(:state => 'live').each do |artefact|
+      puts "  #{artefact.slug}..."
+      r = RoutableArtefact.new(artefact)
+      r.submit
+    end
+  end
+end


### PR DESCRIPTION
This adds the following:
- validation of artefact paths and prefixes (from alphagov/govuk_content_models#100)
- Migration to clean out invalid paths and prefixes
- Rake task to re-register all live artefacts with the router.
