### PR TITLE
Improve router re-registration task

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -22,7 +22,7 @@ class RoutableArtefact
     router_api.add_backend(rendering_app, backend_url)
   end
 
-  def submit
+  def submit(options = {})
     ensure_backend_exists
     prefixes.each do |path|
       logger.debug("Registering route #{path} (prefix) => #{rendering_app}")
@@ -32,10 +32,10 @@ class RoutableArtefact
       logger.debug("Registering route #{path} (exact) => #{rendering_app}")
       router_api.add_route(path, "exact", rendering_app, :skip_commit => true)
     end
-    router_api.commit_routes
+    commit unless options[:skip_commit]
   end
 
-  def delete
+  def delete(options = {})
     prefixes.each do |path|
       begin
         logger.debug "Removing route #{path} (prefix)"
@@ -50,6 +50,10 @@ class RoutableArtefact
       rescue GdsApi::HTTPNotFound
       end
     end
+    commit unless options[:skip_commit]
+  end
+
+  def commit
     router_api.commit_routes
   end
 

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -6,7 +6,9 @@ namespace :router do
     Artefact.where(:state => 'live').each do |artefact|
       puts "  #{artefact.slug}..."
       r = RoutableArtefact.new(artefact)
-      r.submit
+      r.submit(:skip_commit => true)
     end
+    puts "Committing routes"
+    RoutableArtefact.new(nil).commit
   end
 end

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -3,8 +3,9 @@ namespace :router do
   desc "Reregister all live artefacts with the router"
   task :reregister_live_artefacts => :environment do
     puts "Re-registering all live artefacts with the router"
-    Artefact.where(:state => 'live').each do |artefact|
-      puts "  #{artefact.slug}..."
+    artefact_count = Artefact.where(:state => 'live').count
+    Artefact.where(:state => 'live').each_with_index do |artefact, i|
+      puts "  #{artefact.slug} (#{i}/#{artefact_count})..."
       r = RoutableArtefact.new(artefact)
       r.submit(:skip_commit => true)
     end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -61,6 +61,14 @@ class RoutableArtefactTest < ActiveSupport::TestCase
       @routable.submit
     end
 
+    should "not commit when asked not to" do
+      @routable.router_api.expects(:commit_routes).never
+
+      @artefact.prefixes = ["/foo", "/bar", "/baz"]
+      @artefact.paths = ["/foo.json"]
+      @routable.submit(:skip_commit => true)
+    end
+
     should "not blow up if prefixes or paths is nil" do
       @artefact.prefixes = nil
       @artefact.paths = nil
@@ -100,6 +108,15 @@ class RoutableArtefactTest < ActiveSupport::TestCase
       @artefact.paths = ["/foo.json"]
       @routable.delete
     end
+
+    should "not commit when asked not to" do
+      @routable.router_api.expects(:commit_routes).never
+
+      @artefact.prefixes = ["/foo", "/bar", "/baz"]
+      @artefact.paths = ["/foo.json"]
+      @routable.delete(:skip_commit => true)
+    end
+
 
     should "not blow up if prefixes or paths is nil" do
       @artefact.prefixes = nil


### PR DESCRIPTION
Make it only commit the routes once.  This will save c. 3000 router reloads, and the corresponding logging mayhem.
