### PR TITLE
Add retry to router reregistration task

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -6,8 +6,19 @@ namespace :router do
     artefact_count = Artefact.where(:state => 'live').count
     Artefact.where(:state => 'live').each_with_index do |artefact, i|
       puts "  #{artefact.slug} (#{i}/#{artefact_count})..."
-      r = RoutableArtefact.new(artefact)
-      r.submit(:skip_commit => true)
+      retry_count = 0
+      begin
+        r = RoutableArtefact.new(artefact)
+        r.submit(:skip_commit => true)
+      rescue Timeout::Error, GdsApi::TimedOutException
+        if retry_count < 3
+          retry_count += 1
+          puts "    Encountered timeout, retrying (max 3 retries)"
+          retry
+        else
+          raise
+        end
+      end
     end
     puts "Committing routes"
     RoutableArtefact.new(nil).commit


### PR DESCRIPTION
We get occasional timeouts, and we don't want these to cause the whole job to abort.
