### PR TITLE
Fix rendering of relatable artefact list.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.13.0"
+  gem "govuk_content_models", "5.14.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.13.0)
+    govuk_content_models (5.14.0)
       bson_ext
       differ
       gds-api-adapters
@@ -340,7 +340,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.18.0)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 5.13.0)
+  govuk_content_models (= 5.14.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
This was failing due to an inefficient query against Mongo, which is slow most of the time and breaks completely if there are enough artefacts.

See alphagov/govuk_content_models#101 for more details.
