### PR TITLE
Allow the artefact's need_id to be changed when < 100000

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -6,7 +6,7 @@ class Artefact
   attr_accessor :indexable_content
 
   def need_id_editable?
-    self.new_record? || self.need_id.blank? || self.need_id.strip !~ /\A\d+\z/
+    self.new_record? || self.need_id.blank? || self.need_id.strip !~ /\A\d+\z/ || self.need_id.to_i < 100000
   end
 
   def need_owning_service

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -5,12 +5,27 @@ class Artefact
   # without persisting it
   attr_accessor :indexable_content
 
+  MASLOW_NEED_ID_LOWER_BOUND = 100000
+
   def need_id_editable?
-    self.new_record? || self.need_id.blank? || self.need_id.strip !~ /\A\d+\z/ || self.need_id.to_i < 100000
+    # allow the Need ID to be edited if:
+    # - it's a new record
+    # - the need ID is blank
+    # - the need ID is not a number
+    # - the need is a Need-o-tron need
+    #
+    self.new_record? ||
+      self.need_id.blank? ||
+      ! self.need_id_numeric? ||
+      self.need_owning_service == "needotron"
+  end
+
+  def need_id_numeric?
+    self.need_id.strip =~ /\A\d+\z/
   end
 
   def need_owning_service
     return nil unless self.need_id.present? and self.need_id.match(/\A[0-9]+\Z/)
-    self.need_id.to_i < 100000 ? "needotron" : "maslow"
+    self.need_id.to_i < MASLOW_NEED_ID_LOWER_BOUND ? "needotron" : "maslow"
   end
 end

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -46,8 +46,8 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   end
 
   context "restricting editing of need_id" do
-    should "not allow editing with existing numeric value" do
-      artefact = FactoryGirl.create(:artefact, :need_id => "1234")
+    should "not allow editing if it looks like a Maslow need >= 100000" do
+      artefact = FactoryGirl.create(:artefact, :need_id => "100123")
       visit "/artefacts/#{artefact.id}/edit"
       field = page.find_field("Need")
       assert field[:disabled]
@@ -68,6 +68,19 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
     should "allow editing if non-numeric" do
       artefact = FactoryGirl.create(:artefact, :need_id => "B241")
+      visit "/artefacts/#{artefact.id}/edit"
+      field = page.find_field("Need")
+      assert field[:disabled].nil?
+
+      fill_in "Need", :with => "2345"
+      click_on "Save and continue editing"
+
+      artefact.reload
+      assert_equal "2345", artefact.need_id
+    end
+
+    should "allow editing if it looks like a Need-o-tron need < 100000" do
+      artefact = FactoryGirl.create(:artefact, :need_id => "99999")
       visit "/artefacts/#{artefact.id}/edit"
       field = page.find_field("Need")
       assert field[:disabled].nil?

--- a/test/unit/artefact_test.rb
+++ b/test/unit/artefact_test.rb
@@ -72,4 +72,18 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
+  context "need_id_numeric?" do
+    should "be true for a number" do
+      artefact = FactoryGirl.build(:artefact, need_id: "12345")
+
+      assert artefact.need_id_numeric?
+    end
+
+    should "not be true when not a number" do
+      artefact = FactoryGirl.build(:artefact, need_id: "NOT A NUMBER, HONEST")
+
+      refute artefact.need_id_numeric?
+    end
+  end
+
 end

--- a/test/unit/artefact_test.rb
+++ b/test/unit/artefact_test.rb
@@ -34,4 +34,42 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
+  context "need_id_editable?" do
+    should "return true for a new record" do
+      artefact = Artefact.new
+
+      assert artefact.need_id_editable?
+    end
+
+    should "return true when need_id is nil" do
+      artefact = FactoryGirl.create(:artefact, need_id: nil)
+
+      assert artefact.need_id_editable?
+    end
+
+    should "return true when need_id is blank" do
+      artefact = FactoryGirl.create(:artefact, need_id: "")
+
+      assert artefact.need_id_editable?
+    end
+
+    should "return true when need_id is not a number" do
+      artefact = FactoryGirl.create(:artefact, need_id: "B5253")
+
+      assert artefact.need_id_editable?
+    end
+
+    should "return false when need_id >= 100000" do
+      artefact = FactoryGirl.create(:artefact, need_id: "100000")
+
+      refute artefact.need_id_editable?
+    end
+
+    should "return true when need_id < 100000" do
+      artefact = FactoryGirl.create(:artefact, need_id: "99999")
+
+      assert artefact.need_id_editable?
+    end
+  end
+
 end


### PR DESCRIPTION
Need IDs below 100,000 are Needotron need IDs. We'd like to be able to change these to use Maslow need IDs. 

This changes the Artefact's need_id_editable? criteria to allow the need_id to be changed when it is less than 100,000.
