### PR TITLE
Display Maslow need information in the artefact form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'exception_notification'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', "7.18.0"
+  gem 'gds-api-adapters', "7.20.0"
 end
 
 gem 'aws-ses', require: 'aws/ses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     ffi (1.1.4)
-    gds-api-adapters (7.18.0)
+    gds-api-adapters (7.20.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -186,7 +186,7 @@ GEM
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (~> 0.0, >= 0.0.9)
     metaclass (0.0.1)
-    mime-types (1.22)
+    mime-types (1.25)
     minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -337,7 +337,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters (= 7.18.0)
+  gds-api-adapters (= 7.20.0)
   gds-sso (= 3.0.0)
   gelf
   govuk_content_models (= 5.14.1)

--- a/app/assets/stylesheets/artefact.css
+++ b/app/assets/stylesheets/artefact.css
@@ -1,0 +1,14 @@
+#user-need h3 {
+  margin-bottom: 10px;
+}
+
+.need-id {
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 20px;
+}
+
+.need-body {
+  font-size: 16px;
+  line-height: 1.31579;
+}

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -28,4 +28,11 @@ class Artefact
     return nil unless self.need_id.present? and self.need_id.match(/\A[0-9]+\Z/)
     self.need_id.to_i < MASLOW_NEED_ID_LOWER_BOUND ? "needotron" : "maslow"
   end
+
+  def need
+    return unless need_owning_service == "maslow"
+
+    @need ||= Panopticon.need_api.need(need_id)
+  rescue GdsApi::BaseError
+  end
 end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -24,11 +24,11 @@
         <%= f.input :description, :input_html => { :class => "span6", :disabled => true, :rows => 6 }, :hint => 'Managed through API and/or owning app', :as => :text %>
         <%= f.input :slug, :input_html => { :class => "span6", :disabled => f.object.live? }, :hint => "A valid slug might look like this: i-am-a-good-slug-with-no-spaces" %>
         <%= f.input :need_extended_font, :label => "Does this artefact need the extra font files?", :as => :boolean %>
-        <%= f.input :need_id, :input_html => { :class => "span6", :disabled => !f.object.need_id_editable? } %>
 
-        <%= link_to_view_need(f.object) if ! artefact.new_record? && ! artefact.business_proposition %>
         <%= link_to "View on site", published_url(f.object), :rel => 'external', :class => "btn btn-primary" unless f.object.new_record? %>
 
+        <hr>
+        <%= render :partial => "need", :locals => { :f => f } %>
         <hr>
 
         <%= f.input :language, :collection => {"English" => "en", "Welsh" => "cy"}, :as => :select, :input_html => { :class => "span2" }, :include_blank => false %>

--- a/app/views/artefacts/_need.html.erb
+++ b/app/views/artefacts/_need.html.erb
@@ -1,0 +1,16 @@
+<section id="user-need">
+  <h3>User need</h3>
+
+  <% if f.object.need %>
+    <p class="need-body">
+      As a <%= f.object.need.role %><br>
+      I need to <%= f.object.need.goal %><br>
+      So that <%= f.object.need.benefit %>
+    </p>
+    <p class="need-id">Maslow #<%= f.object.need.id %></p>
+  <% else %>
+    <%= f.input :need_id, :label => "Need ID", :input_html => { :class => "span3", :disabled => !f.object.need_id_editable? } %>
+  <% end %>
+
+  <p><%= link_to_view_need(f.object) if ! f.object.new_record? && ! f.object.business_proposition %></p>
+</section>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ if defined?(Bundler)
 end
 
 module Panopticon
+  mattr_accessor :need_api
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/need_api.rb
+++ b/config/initializers/need_api.rb
@@ -1,0 +1,7 @@
+require 'gds_api/base'
+require 'gds_api/need_api'
+
+Panopticon.need_api = GdsApi::NeedApi.new(Plek.current.find("need-api"),
+  timeout: 1,
+  bearer_token: ENV["panopticon_need_api_bearer_token"] || "change me when you deploy"
+)

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -1,9 +1,20 @@
 require_relative '../integration_test_helper'
+require 'gds_api/test_helpers/need_api'
 
 class ArtefactsEditTest < ActionDispatch::IntegrationTest
+  include GdsApi::TestHelpers::NeedApi
 
   setup do
     create_test_user
+  end
+
+  def stub_basic_need_api_response(need_id = "100123")
+    need_api_has_need(
+      "id" => need_id,
+      "role" => "user",
+      "goal" => "do something",
+      "benefit" => "reason"
+    )
   end
 
   should "link to the live site from the edit form" do
@@ -15,81 +26,164 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     assert page.has_link?("View on site", :href => "http://www.dev.gov.uk/alpha")
   end
 
-  context "linking to needs" do
-    should "link to the Needotron given a need ID < 100000" do
-      artefact = FactoryGirl.create(:artefact, :name => "Need from Needotron", :slug => 'needotron', :need_id => "99999")
+  context "displaying need information" do
+    context "when a Maslow need ID present" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact, :need_id => "100123")
+      end
 
-      visit "/artefacts"
-      click_on "Need from Needotron"
+      should "show basic information about a need from the API" do
+        need_api_has_need(
+          "id" => "100123",
+          "role" => "user",
+          "goal" => "buy bunting",
+          "benefit" => "bunting"
+        )
 
-      assert page.has_link?("View in Needotron", :href => "http://needotron.dev.gov.uk/needs/99999")
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        within "#user-need" do
+          within ".need-body" do
+            assert page.has_content?("As a user")
+            assert page.has_content?("I need to buy bunting")
+            assert page.has_content?("So that bunting")
+          end
+
+          assert page.has_link?("View in Maslow", href: "http://maslow.dev.gov.uk/needs/100123")
+        end
+      end
+
+      should "not display the need id field" do
+        stub_basic_need_api_response
+
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        within "#user-need" do
+          assert page.has_no_field?("Need ID")
+        end
+      end
+
+      should "show a disabled need_id field and a link to Maslow when the Need API request is unsuccessful" do
+        need_api_has_no_need("100123")
+
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        within "#user-need" do
+          assert page.has_no_selector?(".need-body")
+
+          field = page.find_field("Need ID")
+          assert field[:disabled]
+
+          assert page.has_link?("View in Maslow", href: "http://maslow.dev.gov.uk/needs/100123")
+        end
+      end
     end
 
-    should "link to Maslow given a need ID >= 100000" do
-      artefact = FactoryGirl.create(:artefact, :name => "Need from Maslow", :slug => 'maslow', :need_id => "100000")
+    context "when a Need-o-tron ID present" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact, :need_id => "99999")
+      end
 
-      visit "/artefacts"
-      click_on "Need from Maslow"
+      should "not show additional need information" do
+        visit "/artefacts/#{@artefact.id}/edit"
 
-      assert page.has_link?("View in Maslow", :href => "http://maslow.dev.gov.uk/needs/100000")
+        within "#user-need" do
+          assert page.has_no_selector?(".need-body")
+        end
+      end
+
+      should "allow editing of the need ID" do
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        field = page.find_field("Need ID")
+        assert field[:disabled].nil?
+
+        fill_in "Need", :with => "2345"
+        click_on "Save and continue editing"
+
+        @artefact.reload
+        assert_equal "2345", @artefact.need_id
+      end
+
+      should "link to the Need-o-tron" do
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        within "#user-need" do
+          assert page.has_link?("View in Needotron", :href => "http://needotron.dev.gov.uk/needs/99999")
+        end
+      end
     end
 
-    should "not link to any need if the need ID is non-numeric" do
-      artefact = FactoryGirl.create(:artefact, :name => "Need from a spreadsheet", :slug => 'spreadsheet', :need_id => "B12345")
+    context "when a non-numeric need ID present" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact, :need_id => "B241")
+      end
 
-      visit "/artefacts"
-      click_on "Need from a spreadsheet"
+      should "not show additional need information" do
+        visit "/artefacts/#{@artefact.id}/edit"
 
-      assert page.has_no_link?("View in Needotron")
-      assert page.has_no_link?("View in Maslow")
-    end
-  end
+        within "#user-need" do
+          assert page.has_no_selector?(".need-body")
+        end
+      end
 
-  context "restricting editing of need_id" do
-    should "not allow editing if it looks like a Maslow need >= 100000" do
-      artefact = FactoryGirl.create(:artefact, :need_id => "100123")
-      visit "/artefacts/#{artefact.id}/edit"
-      field = page.find_field("Need")
-      assert field[:disabled]
-    end
+      should "allow editing of the Need ID" do
+        visit "/artefacts/#{@artefact.id}/edit"
 
-    should "allow editing if blank" do
-      artefact = FactoryGirl.create(:artefact, :need_id => " ")
-      visit "/artefacts/#{artefact.id}/edit"
-      field = page.find_field("Need")
-      assert field[:disabled].nil?
+        field = page.find_field("Need ID")
+        assert field[:disabled].nil?
 
-      fill_in "Need", :with => "2345"
-      click_on "Save and continue editing"
+        fill_in "Need", :with => "2345"
+        click_on "Save and continue editing"
 
-      artefact.reload
-      assert_equal "2345", artefact.need_id
-    end
+        @artefact.reload
+        assert_equal "2345", @artefact.need_id
+      end
 
-    should "allow editing if non-numeric" do
-      artefact = FactoryGirl.create(:artefact, :need_id => "B241")
-      visit "/artefacts/#{artefact.id}/edit"
-      field = page.find_field("Need")
-      assert field[:disabled].nil?
+      should "not link to Maslow or the Need-o-tron" do
+        visit "/artefacts/#{@artefact.id}/edit"
 
-      fill_in "Need", :with => "2345"
-      click_on "Save and continue editing"
-
-      artefact.reload
-      assert_equal "2345", artefact.need_id
+        within "#user-need" do
+          assert page.has_no_link?("View in Needotron")
+          assert page.has_no_link?("View in Maslow")
+        end
+      end
     end
 
-    should "allow editing if it looks like a Need-o-tron need < 100000" do
-      artefact = FactoryGirl.create(:artefact, :need_id => "99999")
-      visit "/artefacts/#{artefact.id}/edit"
-      field = page.find_field("Need")
-      assert field[:disabled].nil?
+    context "when the need ID is blank" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact, :need_id => "")
+      end
 
-      fill_in "Need", :with => "2345"
-      click_on "Save and continue editing"
+      should "not show additional need information" do
+        visit "/artefacts/#{@artefact.id}/edit"
 
-      artefact.reload
-      assert_equal "2345", artefact.need_id
+        within "#user-need" do
+          assert page.has_no_selector?(".need-body")
+        end
+      end
+
+      should "allow editing of the Need ID" do
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        field = page.find_field("Need ID")
+        assert field[:disabled].nil?
+
+        fill_in "Need", :with => "2345"
+        click_on "Save and continue editing"
+
+        @artefact.reload
+        assert_equal "2345", @artefact.need_id
+      end
+
+      should "not link to Maslow or the Need-o-tron" do
+        visit "/artefacts/#{@artefact.id}/edit"
+
+        within "#user-need" do
+          assert page.has_no_link?("View in Needotron")
+          assert page.has_no_link?("View in Maslow")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When an artefact has a Maslow need ID, show some basic information about the need in the form. This looks like:

```
As a <role>
I need to <goal>
So that <benefit>
```

To do this, I've added a new method to the Artefact class called `need`, which will make a request to the Need API with the value of the `need_id` field. If `need_id` is blank, if it doesn't look like a Maslow id, or if the request to the API fails, we show a text field instead, just like the current behaviour.

This branch also includes some tidying up of the `artefact_edit_test.rb` integration test so that all the tests based on the `need_id` are together and share similar test data.

---

This should be merged around the same time as **alphagov-deployment#364**
