### PR TITLE
Always allow the need_id for an Artefact to be edited

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -7,19 +7,6 @@ class Artefact
 
   MASLOW_NEED_ID_LOWER_BOUND = 100000
 
-  def need_id_editable?
-    # allow the Need ID to be edited if:
-    # - it's a new record
-    # - the need ID is blank
-    # - the need ID is not a number
-    # - the need is a Need-o-tron need
-    #
-    self.new_record? ||
-      self.need_id.blank? ||
-      ! self.need_id_numeric? ||
-      self.need_owning_service == "needotron"
-  end
-
   def need_id_numeric?
     self.need_id.strip =~ /\A\d+\z/
   end

--- a/app/views/artefacts/_need.html.erb
+++ b/app/views/artefacts/_need.html.erb
@@ -8,9 +8,9 @@
       So that <%= f.object.need.benefit %>
     </p>
     <p class="need-id">Maslow #<%= f.object.need.id %></p>
-  <% else %>
-    <%= f.input :need_id, :label => "Need ID", :input_html => { :class => "span3", :disabled => !f.object.need_id_editable? } %>
   <% end %>
+
+  <%= f.input :need_id, :label => "Need ID", :input_html => { :class => "span3" } %>
 
   <p><%= link_to_view_need(f.object) if ! f.object.new_record? && ! f.object.business_proposition %></p>
 </section>

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -53,27 +53,30 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "not display the need id field" do
+      should "allow editing of the need ID" do
         stub_basic_need_api_response
 
         visit "/artefacts/#{@artefact.id}/edit"
 
-        within "#user-need" do
-          assert page.has_no_field?("Need ID")
-        end
+        field = page.find_field("Need ID")
+        assert field[:disabled].nil?
+
+        fill_in "Need", :with => "100123"
+        click_on "Save and continue editing"
+
+        @artefact.reload
+        assert_equal "100123", @artefact.need_id
       end
 
-      should "show a disabled need_id field and a link to Maslow when the Need API request is unsuccessful" do
+      should "show a need edit field and link to Maslow when the Need API request is unsuccessful" do
         need_api_has_no_need("100123")
 
         visit "/artefacts/#{@artefact.id}/edit"
 
+        field = page.find_field("Need ID")
+        assert field[:disabled].nil?
+
         within "#user-need" do
-          assert page.has_no_selector?(".need-body")
-
-          field = page.find_field("Need ID")
-          assert field[:disabled]
-
           assert page.has_link?("View in Maslow", href: "http://maslow.dev.gov.uk/needs/100123")
         end
       end

--- a/test/unit/artefact_test.rb
+++ b/test/unit/artefact_test.rb
@@ -35,44 +35,6 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
-  context "need_id_editable?" do
-    should "return true for a new record" do
-      artefact = Artefact.new
-
-      assert artefact.need_id_editable?
-    end
-
-    should "return true when need_id is nil" do
-      artefact = FactoryGirl.create(:artefact, need_id: nil)
-
-      assert artefact.need_id_editable?
-    end
-
-    should "return true when need_id is blank" do
-      artefact = FactoryGirl.create(:artefact, need_id: "")
-
-      assert artefact.need_id_editable?
-    end
-
-    should "return true when need_id is not a number" do
-      artefact = FactoryGirl.create(:artefact, need_id: "B5253")
-
-      assert artefact.need_id_editable?
-    end
-
-    should "return false when need_id >= 100000" do
-      artefact = FactoryGirl.create(:artefact, need_id: "100000")
-
-      refute artefact.need_id_editable?
-    end
-
-    should "return true when need_id < 100000" do
-      artefact = FactoryGirl.create(:artefact, need_id: "99999")
-
-      assert artefact.need_id_editable?
-    end
-  end
-
   context "need_id_numeric?" do
     should "be true for a number" do
       artefact = FactoryGirl.build(:artefact, need_id: "12345")


### PR DESCRIPTION
Once over, Need IDs that looked like Need-o-tron needs could not be changed in Panopticon, for reasons unknown. When I added integration with Maslow needs, I kept the same behaviour for Maslow needs.

We'd now like to change this so that any Need ID can be changed for an artefact. This will make it easier for content designers to keep the artefact up to date with the most appropriate need (and to more easily correct any mistakes).

I've removed the `need_id_editable?` method from the Artefact model extension class. I've also changed the form so that the Need ID field is always shown (and editable) regardless of whether the Need API returns information or not.
