### PR TITLE
Bump govuk_content_models to 6.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.14.1"
+  gem "govuk_content_models", "6.0.1"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,10 +121,10 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.2.3)
+    govspeak (1.2.5)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-      sanitize (= 2.0.3)
+      sanitize (~> 2.0.3)
     govuk_content_models (5.14.1)
       bson_ext
       differ
@@ -267,8 +267,8 @@ GEM
       json
       plek
       rest-client
-    sanitize (2.0.3)
-      nokogiri (>= 1.4.4, < 1.6)
+    sanitize (2.0.6)
+      nokogiri (>= 1.4.4)
     selenium-webdriver (2.25.0)
       childprocess (>= 0.2.5)
       libwebsocket (~> 0.1.3)


### PR DESCRIPTION
This allows us to add content from Departments and Policy without causing erroneous validation errors due to the way suffixes are used to differentiate clashing URLs.
