### PR TITLE
Prepare for and create Oil & Gas industry sector tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.0.3"
+  gem "govuk_content_models", "6.0.5"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.0.1"
+  gem "govuk_content_models", "6.0.3"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (6.0.3)
+    govuk_content_models (6.0.5)
       bson_ext
       differ
       gds-api-adapters
@@ -339,7 +339,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 6.0.3)
+  govuk_content_models (= 6.0.5)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,11 +121,11 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.2.3)
+    govspeak (1.2.5)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-      sanitize (= 2.0.3)
-    govuk_content_models (6.0.1)
+      sanitize (~> 2.0.3)
+    govuk_content_models (6.0.3)
       bson_ext
       differ
       gds-api-adapters
@@ -167,7 +167,7 @@ GEM
     libv8 (3.3.10.4)
     libwebsocket (0.1.5)
       addressable
-    link_header (0.0.7)
+    link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.1)
       logstash-event (~> 1.1.0)
@@ -267,8 +267,8 @@ GEM
       json
       plek
       rest-client
-    sanitize (2.0.3)
-      nokogiri (>= 1.4.4, < 1.6)
+    sanitize (2.0.6)
+      nokogiri (>= 1.4.4)
     selenium-webdriver (2.25.0)
       childprocess (>= 0.2.5)
       libwebsocket (~> 0.1.3)
@@ -339,7 +339,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 3.0.0)
   gelf
-  govuk_content_models (= 6.0.1)
+  govuk_content_models (= 6.0.3)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -156,7 +156,7 @@ class ArtefactsController < ApplicationController
     end
 
     def extract_parameters(params)
-      fields_to_update = Artefact.fields.keys + ['sections', 'primary_section']
+      fields_to_update = Artefact.fields.keys + ['sections', 'primary_section', 'industry_sectors']
 
       # TODO: Remove this variance
       parameters_to_use = params[:artefact] || params.slice(*fields_to_update)

--- a/db/migrate/20140113135231_create_oil_and_gas_sector_tags.rb
+++ b/db/migrate/20140113135231_create_oil_and_gas_sector_tags.rb
@@ -1,0 +1,30 @@
+class CreateOilAndGasSectorTags < Mongoid::Migration
+  def self.oil_and_gas_topics
+    [
+      { slug: "carbon-capture-and-storage", title: "Carbon capture and storage" },
+      { slug: "environment-reporting-and-regulation", title: "Environment reporting and regulation" },
+      { slug: "exploration-and-development", title: "Exploration and development" },
+      { slug: "fields-and-wells", title: "Fields and wells" },
+      { slug: "finance-and-taxation", title: "Finance and taxation" },
+      { slug: "infrastructure-and-decommissioning", title: "Infrastructure and decommissioning" },
+      { slug: "licensing", title: "Licensing" },
+      { slug: "onshore-oil-and-gas", title: "Onshore oil and gas" }
+    ]
+  end
+
+  def self.up
+    Tag.create!(tag_type: "industry_sector", tag_id: "oil-and-gas", title: "Oil and gas")
+
+    oil_and_gas_topics.each do |topic|
+      Tag.create!(tag_type: "industry_sector", parent_id: "oil-and-gas", tag_id: "oil-and-gas/#{topic[:slug]}", title: topic[:title])
+    end
+  end
+
+  def self.down
+    Tag.by_tag_id("oil-and-gas", "industry_sector").destroy
+
+    oil_and_gas_topics.each do |topic|
+      Tag.by_tag_id("oil-and-gas/#{topic[:slug]}", "industry_sector").destroy
+    end
+  end
+end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -384,6 +384,29 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal [tag2.tag_id, tag1.tag_id], artefact.sections.map(&:tag_id)
       end
 
+      should "Update the industry sectors and ensure it persists into tags" do
+        tag1 = FactoryGirl.create(:tag, tag_id: "fizzy-drinks", title: "Fizzy drinks", tag_type: "industry_sector")
+        tag2 = FactoryGirl.create(:tag, tag_id: "confectionery", title: "Confectionery", tag_type: "industry_sector")
+
+        artefact = Artefact.new(:slug => 'a-history-of-chocolate', :kind => 'guide',
+                                    :owning_app => 'publisher', :name => 'A history of chocolate', :need_id => 1)
+        artefact.industry_sectors = [tag1.tag_id]
+        artefact.save!
+
+        put :update, :id => artefact.id, :artefact => {:industry_sectors => [tag1.tag_id, tag2.tag_id]}
+
+        artefact.reload
+        assert_equal [tag1.tag_id, tag2.tag_id], artefact.industry_sectors.map(&:tag_id)
+        assert_equal [tag1.tag_id, tag2.tag_id], artefact.tags.map(&:tag_id)
+
+        # try the case when a request is made without the 'artefact' param
+        put :update, :id => artefact.id, :industry_sectors => [tag1.tag_id]
+
+        artefact.reload
+        assert_equal [tag1.tag_id], artefact.industry_sectors.map(&:tag_id)
+        assert_equal [tag1.tag_id], artefact.tags.map(&:tag_id)
+      end
+
       should "Reject JSON requests to update an artefact's owning app" do
         artefact = Artefact.create!(
           slug: "whatever",


### PR DESCRIPTION
This pull request adds support for industry sector tags and creates the first set of tags aimed at users in the Oil & Gas industry.

Right now, there's no user interface for these tags to be assigned, as they will be set automatically when artefacts are pushed from Whitehall, based on the detailed guide categories (created in alphagov/whitehall#1213).
