### PR TITLE
Bump therubyracer to 0.12.0 to match static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'jquery-rails', '2.0.2'
 gem 'jquery-ui-rails', '3.0.1'
 
 group :assets do
-  gem "therubyracer", "~> 0.9.4"
+  gem "therubyracer", "0.12.0"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       less (~> 2.2.0)
     less-rails-bootstrap (2.0.13)
       less-rails (~> 2.2.0)
-    libv8 (3.3.10.4)
+    libv8 (3.16.14.3)
     libwebsocket (0.1.5)
       addressable
     link_header (0.0.8)
@@ -260,6 +260,7 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rubyzip (0.9.9)
@@ -287,8 +288,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     treetop (1.4.15)
@@ -362,7 +364,7 @@ DEPENDENCIES
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)
   simplecov-rcov
-  therubyracer (~> 0.9.4)
+  therubyracer (= 0.12.0)
   turn
   uglifier
   unicorn (= 4.3.1)


### PR DESCRIPTION
Bump to 0.12.0 which is compilable with Mavericks and matches the version used in `static`.
