### PR TITLE
Rename an oil and gas industry sector tag

### DIFF
--- a/db/migrate/20140120162640_rename_oil_and_gas_sector_tag.rb
+++ b/db/migrate/20140120162640_rename_oil_and_gas_sector_tag.rb
@@ -1,0 +1,19 @@
+class RenameOilAndGasSectorTag < Mongoid::Migration
+  def self.up
+    tag = Tag.where(tag_id: "oil-and-gas/exploration-and-development", tag_type: "industry_sector").first
+
+    tag.tag_id = "oil-and-gas/exploration-and-production"
+    tag.title = "Exploration and production"
+
+    tag.save!
+  end
+
+  def self.down
+    tag = Tag.where(tag_id: "oil-and-gas/exploration-and-production", tag_type: "industry_sector").first
+
+    tag.tag_id = "oil-and-gas/exploration-and-development"
+    tag.title = "Exploration and development"
+
+    tag.save!
+  end
+end


### PR DESCRIPTION
Rename the tag "oil-and-gas/exploration-and-development" to "oil-and-gas/exploration-and-production".

Nothing is currently tagged with this ID in any environment, so we don't need to migrate any artefacts over.
