### PR TITLE
Allow industry sector tags to be assigned to artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -187,7 +187,7 @@ class ArtefactsController < ApplicationController
       end
 
       # Strip out the empty submit option for sections
-      ['sections', 'legacy_source_ids'].each do |param|
+      ['sections', 'legacy_source_ids', 'industry_sector_ids'].each do |param|
         param_value = parameters_to_use[param]
         param_value.reject!(&:blank?) if param_value
       end

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -18,6 +18,18 @@ module SectionsHelper
     Tag.where(:tag_type => tag_type).order(:title).map {|t| [t.title, t.tag_id]}
   end
 
+  def grouped_options_for_tags_of_type(tag_type)
+    parents = Tag.where(:tag_type => tag_type, :parent_id => nil).order(:title).all
+    tags = Tag.where(:tag_type => tag_type, :parent_id.ne => nil).order(:title)
+
+    tags.group_by {|tag|
+      parent = parents.select {|p| tag.parent_id == p.tag_id }.first
+      parent.title if parent
+    }.map {|parent, tags|
+      [parent, tags.map {|t| ["#{parent}: #{t.title}", t.tag_id] }]
+    }
+  end
+
   # Convert an array of sections into a nested array suitable for
   # using with the rails form helpers' select box tools.
   #

--- a/app/helpers/sections_helper.rb
+++ b/app/helpers/sections_helper.rb
@@ -14,22 +14,6 @@ module SectionsHelper
     sections.reject { |s| s[1] == options[:except] }
   end
 
-  def options_for_tags_of_type(tag_type)
-    Tag.where(:tag_type => tag_type).order(:title).map {|t| [t.title, t.tag_id]}
-  end
-
-  def grouped_options_for_tags_of_type(tag_type)
-    parents = Tag.where(:tag_type => tag_type, :parent_id => nil).order(:title).all
-    tags = Tag.where(:tag_type => tag_type, :parent_id.ne => nil).order(:title)
-
-    tags.group_by {|tag|
-      parent = parents.select {|p| tag.parent_id == p.tag_id }.first
-      parent.title if parent
-    }.map {|parent, tags|
-      [parent, tags.map {|t| ["#{parent}: #{t.title}", t.tag_id] }]
-    }
-  end
-
   # Convert an array of sections into a nested array suitable for
   # using with the rails form helpers' select box tools.
   #

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -5,13 +5,23 @@ module TagsHelper
 
   def grouped_options_for_tags_of_type(tag_type)
     parents = Tag.where(:tag_type => tag_type, :parent_id => nil).order(:title).all
-    tags = Tag.where(:tag_type => tag_type, :parent_id.ne => nil).order(:title)
+    tags = Tag.where(:tag_type => tag_type).order([:parent_id, :asc], [:title, :asc])
 
     tags.group_by {|tag|
-      parent = parents.select {|p| tag.parent_id == p.tag_id }.first
-      parent.title if parent
+      if tag.has_parent?
+        parent = parents.select {|p| tag.parent_id == p.tag_id }.first
+        parent.title if parent
+      else
+        tag.title
+      end
     }.map {|parent, tags|
-      [parent, tags.map {|t| ["#{parent}: #{t.title}", t.tag_id] }]
+      [parent, tags.map {|t|
+        # don't repeat the parent title if it's the same
+        # (eg. the parent category entry)
+        formatted_tag_title = (t.title == parent) ? t.title : "#{parent}: #{t.title}"
+
+        [formatted_tag_title, t.tag_id]
+      }]
     }
   end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,17 @@
+module TagsHelper
+  def options_for_tags_of_type(tag_type)
+    Tag.where(:tag_type => tag_type).order(:title).map {|t| [t.title, t.tag_id]}
+  end
+
+  def grouped_options_for_tags_of_type(tag_type)
+    parents = Tag.where(:tag_type => tag_type, :parent_id => nil).order(:title).all
+    tags = Tag.where(:tag_type => tag_type, :parent_id.ne => nil).order(:title)
+
+    tags.group_by {|tag|
+      parent = parents.select {|p| tag.parent_id == p.tag_id }.first
+      parent.title if parent
+    }.map {|parent, tags|
+      [parent, tags.map {|t| ["#{parent}: #{t.title}", t.tag_id] }]
+    }
+  end
+end

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -100,7 +100,7 @@
       <hr>
 
       <%= f.input :legacy_source_ids, :label => "Legacy sources", :collection => options_for_tags_of_type('legacy_source'), :input_html => { :multiple => true, :class => "span6 chzn-select" } %>
-
+      <%= f.input :industry_sector_ids, :label => "Industry sectors", :collection => grouped_options_for_tags_of_type('industry_sector'), :input_html => { :multiple => true, :class => "span6 chzn-select" } %>
 
       <%= f.inputs do %>
 

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -245,7 +245,8 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
         assert page.has_selector?("optgroup[label='Charities']")
 
         within "optgroup[label='Oil and gas']" do
-          assert page.has_selector?("option", text: "Fields and wells")
+          assert page.has_selector?("option", text: "Oil and gas")
+          assert page.has_selector?("option", text: "Oil and gas: Fields and wells")
         end
       end
 
@@ -255,7 +256,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       click_on "Save and continue editing"
 
       @artefact.reload
-      assert_equal ["oil-and-gas/fields-and-wells", "charities/starting-a-charity"], @artefact.industry_sector_ids
+      assert_equal ["charities/starting-a-charity", "oil-and-gas/fields-and-wells"], @artefact.industry_sector_ids.sort
     end
 
     should "allow removing industry sectors from artefacts" do

--- a/test/unit/helpers/tags_helper_test.rb
+++ b/test/unit/helpers/tags_helper_test.rb
@@ -9,11 +9,14 @@ class TagsHelperTest < ActiveSupport::TestCase
       Tag.create!(tag_type: "section", tag_id: "driving", title: "Driving")
       Tag.create!(tag_type: "section", tag_id: "driving/car-tax", title: "Car tax", parent_id: "driving")
       Tag.create!(tag_type: "section", tag_id: "driving/mot", title: "MOT", parent_id: "driving")
+
+      Tag.create!(tag_type: "legacy_source", tag_id: "directgov", title: "Directgov")
     end
 
     should "return a hierarchy of parent tags and their children" do
       expected = [
-        [ "Driving", [ ["Driving: Car tax", "driving/car-tax"], ["Driving: MOT", "driving/mot"] ]]
+        [ "Driving", [ ["Driving", "driving"], ["Driving: Car tax", "driving/car-tax"], ["Driving: MOT", "driving/mot"] ]],
+        [ "Tax", [["Tax", "tax"]] ]
       ]
 
       assert_equal expected, grouped_options_for_tags_of_type("section")

--- a/test/unit/helpers/tags_helper_test.rb
+++ b/test/unit/helpers/tags_helper_test.rb
@@ -1,0 +1,23 @@
+require_relative '../../test_helper'
+
+class TagsHelperTest < ActiveSupport::TestCase
+  include TagsHelper
+
+  context "grouped_options_for_tags_of_type" do
+    setup do
+      Tag.create!(tag_type: "section", tag_id: "tax", title: "Tax")
+      Tag.create!(tag_type: "section", tag_id: "driving", title: "Driving")
+      Tag.create!(tag_type: "section", tag_id: "driving/car-tax", title: "Car tax", parent_id: "driving")
+      Tag.create!(tag_type: "section", tag_id: "driving/mot", title: "MOT", parent_id: "driving")
+    end
+
+    should "return a hierarchy of parent tags and their children" do
+      expected = [
+        [ "Driving", [ ["Driving: Car tax", "driving/car-tax"], ["Driving: MOT", "driving/mot"] ]]
+      ]
+
+      assert_equal expected, grouped_options_for_tags_of_type("section")
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a new select element to the artefact form, so that industry sector tags can be assigned to artefacts. 

I've also added a new helper method which returns options for a select box grouped by parent tags, in a structure that Rails' option tag helpers can turn into `<optgroup>` tags.

The new field looks like this:
![screen shot 2014-01-23 at 14 04 54](https://f.cloud.github.com/assets/71922/1985015/676e3ea0-8437-11e3-8e62-e9dcfef289fa.png)
