### PR TITLE
Correctly handle nil values for tag array fields

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -186,6 +186,13 @@ class ArtefactsController < ApplicationController
         end
       end
 
+      # Convert nil tag fields to empty arrays if they're present
+      Artefact.tag_types.each do |tag_type|
+        if parameters_to_use.has_key?(tag_type)
+          parameters_to_use[tag_type] ||= []
+        end
+      end
+
       # Strip out the empty submit option for sections
       ['sections', 'legacy_source_ids', 'industry_sector_ids'].each do |param|
         param_value = parameters_to_use[param]

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -452,6 +452,34 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal 409, response.status
         assert response.body.include? "publisher"
       end
+
+      should "convert nil values for tag attributes to an empty array" do
+        artefact = FactoryGirl.create(:artefact)
+
+        stub_action_user = stub("User")
+        @controller.expects(:action_user).returns(stub_action_user)
+
+        Artefact.any_instance.expects(:update_attributes_as)
+                              .with(stub_action_user, has_entry("industry_sectors", []))
+                              .returns(true)
+
+        put :update, id: artefact.id, format: :json, industry_sectors: nil
+        assert response.ok?
+      end
+
+      should "not populate empty arrays for tag types which haven't been provided" do
+        artefact = FactoryGirl.create(:artefact)
+
+        stub_action_user = stub("User")
+        @controller.expects(:action_user).returns(stub_action_user)
+
+        Artefact.any_instance.expects(:update_attributes_as)
+                              .with(stub_action_user, Not(has_key("industry_sectors")))
+                              .returns(true)
+
+        put :update, id: artefact.id, format: :json # not providing 'industry_sectors' here
+        assert response.ok?
+      end
     end
 
     context "DELETE /artefacts/:id" do


### PR DESCRIPTION
There's [a bug in Rails](https://github.com/rails/rails/issues/13420) where parameters that are an empty array get changed to be nil before being passed to the controller. This breaks requests passing in an empty array of tags as the nil gets passed down into the `set_tags_of_type` Taggable method, causing an exception in Mongo.

This fixes the behaviour so that a nil value for a field matching the tag types will get replaced with an empty array. This only applies to fields which have a key present in the params hash, to make sure we don't overwrite tags of every type.
