### PR TITLE
Drop the legacy tags field from artefacts

### DIFF
--- a/db/migrate/20140205155241_drop_tags_field_from_artefacts.rb
+++ b/db/migrate/20140205155241_drop_tags_field_from_artefacts.rb
@@ -1,0 +1,8 @@
+class DropTagsFieldFromArtefacts < Mongoid::Migration
+  def self.up
+    Artefact.collection.update({}, {'$unset' => {tags: 1}}, multi: true)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Some artefacts contain a field called `tags`, containing a string of comma-separated keywords. This field has been long deprecated, and it should be dropped.

This does not affect how tags are stored for artefacts, as the `tag_ids` array is in use for this.
