### PR TITLE
Remove exception notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'ansi'
 gem 'gelf'
 gem 'null_logger'
 
-gem 'exception_notification'
 gem 'airbrake', '3.1.15'
 
 if ENV['API_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'http://rubygems.org'
-source 'https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/'
 
 gem 'plek', '1.5.0'
 gem 'formtastic', git: 'https://github.com/justinfrench/formtastic.git', branch: '2.1-stable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,8 +95,6 @@ GEM
       unf (~> 0.0.3)
     erubis (2.7.0)
     eventmachine (1.0.3)
-    exception_notification (2.6.1)
-      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     factory_girl (3.3.0)
@@ -342,7 +340,6 @@ DEPENDENCIES
   colorize (~> 0.5.8)
   cucumber-rails
   database_cleaner
-  exception_notification
   factory_girl (= 3.3.0)
   factory_girl_rails
   formtastic!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,6 @@ GIT
 
 GEM
   remote: http://rubygems.org/
-  remote: https://BnrJb6FZyzspBboNJzYZ@gem.fury.io/govuk/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.16)

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,0 @@
-unless Rails.env.development? or Rails.env.test?
-  Rails.application.config.middleware.use ExceptionNotifier,
-    :email_prefix => "[#{Rails.application.to_s.split('::').first}] ",
-    :sender_address => %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-    :exception_recipients => %w{govuk-exceptions@digital.cabinet-office.gov.uk}
-end


### PR DESCRIPTION
This is now using errbit for exception handling.

Note: this depends on https://github.gds/gds/alphagov-deployment/pull/440
