### PR TITLE
Bump content_models to support specialist documents.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.1.0"
+  gem "govuk_content_models", "6.4.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (6.1.0)
+    govuk_content_models (6.4.0)
       bson_ext
       differ
       gds-api-adapters
@@ -348,7 +348,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 6.1.0)
+  govuk_content_models (= 6.4.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
Provides `SpecialistDocumentEdition` and permits forward-slash in `Artefact` of `kind` `specialist-document`.
