### PR TITLE
Change industry sector to specialist sector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.1.0"
+  gem "govuk_content_models", "7.0.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (6.1.0)
+    govuk_content_models (7.0.0)
       bson_ext
       differ
       gds-api-adapters
@@ -351,7 +351,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 6.1.0)
+  govuk_content_models (= 7.0.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -10,7 +10,7 @@ class ArtefactsController < ApplicationController
   ITEMS_PER_PAGE = 100
 
   def index
-    @filters = params.slice(:section, :industry_sector, :kind, :state, :search)
+    @filters = params.slice(:section, :specialist_sector, :kind, :state, :search)
     @scope = apply_filters(artefact_scope, @filters)
 
     @scope = @scope.order_by([[sort_column, sort_direction]])
@@ -120,7 +120,7 @@ class ArtefactsController < ApplicationController
     end
 
     def apply_filters(scope, filters)
-      [:section, :industry_sector].each do |tag_type|
+      [:section, :specialist_sector].each do |tag_type|
         if filters[tag_type].present?
           scope = scope.with_parent_tag(tag_type, filters[tag_type])
         end
@@ -181,7 +181,7 @@ class ArtefactsController < ApplicationController
     end
 
     def extract_parameters(params)
-      fields_to_update = Artefact.fields.keys + ['sections', 'primary_section', 'industry_sectors']
+      fields_to_update = Artefact.fields.keys + ['sections', 'primary_section', 'specialist_sectors']
 
       # TODO: Remove this variance
       parameters_to_use = params[:artefact] || params.slice(*fields_to_update)
@@ -201,7 +201,7 @@ class ArtefactsController < ApplicationController
       end
 
       # Strip out the empty submit option for sections
-      ['sections', 'legacy_source_ids', 'industry_sector_ids'].each do |param|
+      ['sections', 'legacy_source_ids', 'specialist_sector_ids'].each do |param|
         param_value = parameters_to_use[param]
         param_value.reject!(&:blank?) if param_value
       end

--- a/app/views/artefacts/_filters.html.erb
+++ b/app/views/artefacts/_filters.html.erb
@@ -8,8 +8,8 @@
     </div>
 
     <div>
-      <label for="industry_sector">Industry sector</label>
-      <%= select_tag :industry_sector, options_from_tags_for_select("industry_sector", @filters[:industry_sector]), class: "span12" %>
+      <label for="specialist_sector">Specialist sector</label>
+      <%= select_tag :specialist_sector, options_from_tags_for_select("specialist_sector", @filters[:specialist_sector]), class: "span12" %>
     </div>
 
     <div>

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -26,12 +26,12 @@
                   :input_html => { :multiple => true, :class => "span12 chzn-select" } %>
     </div>
 
-    <div class="industry-sector-tags fieldset-section">
-      <label for="artefact_industry_sector_ids" class="section-label">Industry sectors</label>
+    <div class="specialist-sector-tags fieldset-section">
+      <label for="artefact_specialist_sector_ids" class="section-label">Specialist sectors</label>
 
-      <%= f.input :industry_sector_ids,
+      <%= f.input :specialist_sector_ids,
                   :label => false,
-                  :collection => grouped_options_for_tags_of_type('industry_sector'),
+                  :collection => grouped_options_for_tags_of_type('specialist_sector'),
                   :input_html => { :multiple => true, :class => "span12 chzn-select" } %>
     </div>
   <% end %>

--- a/db/migrate/20140212153406_rename_industry_sector_tag_type_to_specialist_sector.rb
+++ b/db/migrate/20140212153406_rename_industry_sector_tag_type_to_specialist_sector.rb
@@ -1,0 +1,9 @@
+class RenameIndustrySectorTagTypeToSpecialistSector < Mongoid::Migration
+  def self.up
+    Tag.where(tag_type: "industry_sector").update_all(tag_type: "specialist_sector")
+  end
+
+  def self.down
+    Tag.where(tag_type: "specialist_sector").update_all(tag_type: "industry_sector")
+  end
+end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -41,10 +41,10 @@ class ArtefactsControllerTest < ActionController::TestCase
           get :index, section: "driving"
         end
 
-        should "apply the tag scope for industry sector filters" do
-          @scope.expects(:with_parent_tag).with(:industry_sector, "oil-and-gas").returns(@scope)
+        should "apply the tag scope for specialist sector filters" do
+          @scope.expects(:with_parent_tag).with(:specialist_sector, "oil-and-gas").returns(@scope)
 
-          get :index, industry_sector: "oil-and-gas"
+          get :index, specialist_sector: "oil-and-gas"
         end
 
         should "apply the kind scope" do
@@ -79,12 +79,12 @@ class ArtefactsControllerTest < ActionController::TestCase
 
         should "combine multiple scopes together" do
           @scope.expects(:with_parent_tag).with(:section, "driving").returns(@scope)
-          @scope.expects(:with_parent_tag).with(:industry_sector, "oil-and-gas").returns(@scope)
+          @scope.expects(:with_parent_tag).with(:specialist_sector, "oil-and-gas").returns(@scope)
           @scope.expects(:of_kind).with("answer").returns(@scope)
           @scope.expects(:in_state).with("live").returns(@scope)
           @scope.expects(:matching_query).with("foo").returns(@scope)
 
-          get :index, section: "driving", industry_sector: "oil-and-gas", kind: "answer", state: "live", search: "foo"
+          get :index, section: "driving", specialist_sector: "oil-and-gas", kind: "answer", state: "live", search: "foo"
         end
       end
 
@@ -391,26 +391,26 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal [tag2.tag_id, tag1.tag_id], artefact.sections.map(&:tag_id)
       end
 
-      should "Update the industry sectors and ensure it persists into tags" do
-        tag1 = FactoryGirl.create(:tag, tag_id: "fizzy-drinks", title: "Fizzy drinks", tag_type: "industry_sector")
-        tag2 = FactoryGirl.create(:tag, tag_id: "confectionery", title: "Confectionery", tag_type: "industry_sector")
+      should "Update the specialist sectors and ensure it persists into tags" do
+        tag1 = FactoryGirl.create(:tag, tag_id: "fizzy-drinks", title: "Fizzy drinks", tag_type: "specialist_sector")
+        tag2 = FactoryGirl.create(:tag, tag_id: "confectionery", title: "Confectionery", tag_type: "specialist_sector")
 
         artefact = Artefact.new(:slug => 'a-history-of-chocolate', :kind => 'guide',
                                     :owning_app => 'publisher', :name => 'A history of chocolate', :need_id => 1)
-        artefact.industry_sectors = [tag1.tag_id]
+        artefact.specialist_sectors = [tag1.tag_id]
         artefact.save!
 
-        put :update, :id => artefact.id, :artefact => {:industry_sectors => [tag1.tag_id, tag2.tag_id]}
+        put :update, :id => artefact.id, :artefact => {:specialist_sectors => [tag1.tag_id, tag2.tag_id]}
 
         artefact.reload
-        assert_equal [tag1.tag_id, tag2.tag_id], artefact.industry_sectors.map(&:tag_id)
+        assert_equal [tag1.tag_id, tag2.tag_id], artefact.specialist_sectors.map(&:tag_id)
         assert_equal [tag1.tag_id, tag2.tag_id], artefact.tags.map(&:tag_id)
 
         # try the case when a request is made without the 'artefact' param
-        put :update, :id => artefact.id, :industry_sectors => [tag1.tag_id]
+        put :update, :id => artefact.id, :specialist_sectors => [tag1.tag_id]
 
         artefact.reload
-        assert_equal [tag1.tag_id], artefact.industry_sectors.map(&:tag_id)
+        assert_equal [tag1.tag_id], artefact.specialist_sectors.map(&:tag_id)
         assert_equal [tag1.tag_id], artefact.tags.map(&:tag_id)
       end
 
@@ -434,10 +434,10 @@ class ArtefactsControllerTest < ActionController::TestCase
         @controller.stubs(:current_user).returns(stub_current_user)
 
         Artefact.any_instance.expects(:update_attributes_as)
-                              .with(stub_current_user, has_entry("industry_sectors", []))
+                              .with(stub_current_user, has_entry("specialist_sectors", []))
                               .returns(true)
 
-        put :update, id: artefact.id, format: :json, industry_sectors: nil
+        put :update, id: artefact.id, format: :json, specialist_sectors: nil
         assert response.ok?
       end
 
@@ -448,10 +448,10 @@ class ArtefactsControllerTest < ActionController::TestCase
         @controller.stubs(:current_user).returns(stub_current_user)
 
         Artefact.any_instance.expects(:update_attributes_as)
-                              .with(stub_current_user, Not(has_key("industry_sectors")))
+                              .with(stub_current_user, Not(has_key("specialist_sectors")))
                               .returns(true)
 
-        put :update, id: artefact.id, format: :json # not providing 'industry_sectors' here
+        put :update, id: artefact.id, format: :json # not providing 'specialist_sectors' here
         assert response.ok?
       end
     end

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -291,21 +291,21 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   end
 
 
-  context "editing industry_sectors" do
+  context "editing specialist_sectors" do
     setup do
-      FactoryGirl.create(:tag, tag_type: 'industry_sector', tag_id: 'oil-and-gas', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_type: 'industry_sector', tag_id: 'oil-and-gas/fields-and-wells', title: 'Fields and wells', parent_id: 'oil-and-gas')
-      FactoryGirl.create(:tag, tag_type: 'industry_sector', tag_id: 'charities', title: 'Charities')
-      FactoryGirl.create(:tag, tag_type: 'industry_sector', tag_id: 'charities/starting-a-charity', title: 'Starting a charity', parent_id: 'charities')
+      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas', title: 'Oil and gas')
+      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas/fields-and-wells', title: 'Fields and wells', parent_id: 'oil-and-gas')
+      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'charities', title: 'Charities')
+      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'charities/starting-a-charity', title: 'Starting a charity', parent_id: 'charities')
 
       @artefact = FactoryGirl.create(:artefact, :name => "VAT")
     end
 
-    should "allow adding industry sectors to artefacts" do
+    should "allow adding specialist sectors to artefacts" do
       visit "/artefacts"
       click_on "VAT"
 
-      within "select#artefact_industry_sector_ids" do
+      within "select#artefact_specialist_sector_ids" do
         assert page.has_selector?("optgroup[label='Oil and gas']")
         assert page.has_selector?("optgroup[label='Charities']")
 
@@ -315,27 +315,27 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
         end
       end
 
-      select "Oil and gas: Fields and wells", :from => "Industry sectors"
-      select "Charities: Starting a charity", :from => "Industry sectors"
+      select "Oil and gas: Fields and wells", :from => "Specialist sectors"
+      select "Charities: Starting a charity", :from => "Specialist sectors"
 
       click_on "Save and continue editing"
 
       @artefact.reload
-      assert_equal ["charities/starting-a-charity", "oil-and-gas/fields-and-wells"], @artefact.industry_sector_ids.sort
+      assert_equal ["charities/starting-a-charity", "oil-and-gas/fields-and-wells"], @artefact.specialist_sector_ids.sort
     end
 
-    should "allow removing industry sectors from artefacts" do
-      @artefact.industry_sector_ids = ["oil-and-gas/fields-and-wells", "charities/starting-a-charity"]
+    should "allow removing specialist sectors from artefacts" do
+      @artefact.specialist_sector_ids = ["oil-and-gas/fields-and-wells", "charities/starting-a-charity"]
       @artefact.save!
 
       visit "/artefacts"
       click_on "VAT"
 
-      unselect "Oil and gas: Fields and wells", :from => "Industry sectors"
+      unselect "Oil and gas: Fields and wells", :from => "Specialist sectors"
       click_on "Save and continue editing"
 
       @artefact.reload
-      assert_equal ["charities/starting-a-charity"], @artefact.industry_sector_ids
+      assert_equal ["charities/starting-a-charity"], @artefact.specialist_sector_ids
     end
   end
 

--- a/test/integration/artefacts_index_test.rb
+++ b/test/integration/artefacts_index_test.rb
@@ -77,7 +77,7 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
 
           within "form" do
             assert page.has_select?("Section", selected: "All")
-            assert page.has_select?("Industry sector", selected: "All")
+            assert page.has_select?("Specialist sector", selected: "All")
             assert page.has_select?("Format", selected: "All")
             assert page.has_select?("State", selected: "All")
             assert page.has_field?("Contains", with: nil)
@@ -132,13 +132,13 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "filter by industry_sector tag" do
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'industry_sector', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'industry_sector', title: 'Wells', parent_id: 'oil-and-gas')
+    should "filter by specialist_sector tag" do
+      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
+      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
 
-      FactoryGirl.create(:artefact, name: 'Something else', slug: 'something-else', industry_sector_ids: [])
-      FactoryGirl.create(:artefact, name: 'Oil and gas licensing', slug: 'oil-and-gas-licensing', industry_sector_ids: ['oil-and-gas'])
-      FactoryGirl.create(:artefact, name: 'Digging a well', slug: 'digging-wells', industry_sector_ids: ['oil-and-gas/wells'])
+      FactoryGirl.create(:artefact, name: 'Something else', slug: 'something-else', specialist_sector_ids: [])
+      FactoryGirl.create(:artefact, name: 'Oil and gas licensing', slug: 'oil-and-gas-licensing', specialist_sector_ids: ['oil-and-gas'])
+      FactoryGirl.create(:artefact, name: 'Digging a well', slug: 'digging-wells', specialist_sector_ids: ['oil-and-gas/wells'])
 
       visit '/artefacts'
 
@@ -149,7 +149,7 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
       end
 
       within "#filters" do
-        select "Oil and gas", from: "Industry sector"
+        select "Oil and gas", from: "Specialist sector"
         click_on "Update results"
       end
 
@@ -161,7 +161,7 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
       end
 
       within "#filters" do
-        assert page.has_select?("Industry sector", selected: "Oil and gas")
+        assert page.has_select?("Specialist sector", selected: "Oil and gas")
       end
     end
 
@@ -295,13 +295,13 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
       FactoryGirl.create(:tag, tag_id: 'driving', tag_type: 'section', title: 'Driving')
       FactoryGirl.create(:tag, tag_id: 'driving/learning-to-drive', tag_type: 'section', title: 'Learning to drive', parent_id: 'driving')
 
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'industry_sector', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'industry_sector', title: 'Wells', parent_id: 'oil-and-gas')
+      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
+      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
 
-      FactoryGirl.create(:artefact, name: 'Motor incidents involving wells', industry_sector_ids: ["oil-and-gas/wells"], section_ids: ["driving/learning-to-drive"])
-      FactoryGirl.create(:artefact, name: 'Driving forward the oil and gas industry', industry_sector_ids: ["oil-and-gas"], section_ids: ["driving"])
-      FactoryGirl.create(:artefact, name: 'An illustrated history of wells', industry_sector_ids: ["oil-and-gas/wells"], section_ids: [])
-      FactoryGirl.create(:artefact, name: 'Getting your provisional licence', industry_sector_ids: [], section_ids: ["driving/learning-to-drive"])
+      FactoryGirl.create(:artefact, name: 'Motor incidents involving wells', specialist_sector_ids: ["oil-and-gas/wells"], section_ids: ["driving/learning-to-drive"])
+      FactoryGirl.create(:artefact, name: 'Driving forward the oil and gas industry', specialist_sector_ids: ["oil-and-gas"], section_ids: ["driving"])
+      FactoryGirl.create(:artefact, name: 'An illustrated history of wells', specialist_sector_ids: ["oil-and-gas/wells"], section_ids: [])
+      FactoryGirl.create(:artefact, name: 'Getting your provisional licence', specialist_sector_ids: [], section_ids: ["driving/learning-to-drive"])
 
       visit '/artefacts'
 
@@ -314,7 +314,7 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
 
       within "#filters" do
         select "Driving", from: "Section"
-        select "Oil and gas", from: "Industry sector"
+        select "Oil and gas", from: "Specialist sector"
 
         click_on "Update results"
       end
@@ -329,7 +329,7 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
 
       within "#filters" do
         assert page.has_select?("Section", selected: "Driving")
-        assert page.has_select?("Industry sector", selected: "Oil and gas")
+        assert page.has_select?("Specialist sector", selected: "Oil and gas")
       end
     end
   end


### PR DESCRIPTION
We're renaming the tag type "industry_sector" to be "specialist_sector". This pull request makes changes to support this.

The accepted fields for an artefact have been updated, along with the form field for selecting tags. This also includes a migration to set the new tag type for any existing tags of type `industry_sector` (these will just be the Oil and Gas tags).
