### PR TITLE
Allow artefacts to be tagged with organisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'plek', '1.5.0'
+gem 'plek', '1.7.0'
 
 gem 'nested_form', '0.3.2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'jquery-rails', '2.0.2'
 gem 'jquery-ui-rails', '3.0.1'
 gem 'chosen-rails', '1.0.2'
 
+gem 'whenever', '0.9.2', require: false
+
 group :assets do
   gem "therubyracer", "0.12.0"
   gem 'sass-rails', '3.2.6'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "7.2.1"
+  gem "govuk_content_models", "8.1.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       compass-rails (>= 1.1.2)
       railties (>= 3.0)
       sass-rails (>= 3.2)
+    chronic (0.10.2)
     chunky_png (1.2.9)
     ci_reporter (1.7.0)
       builder (>= 2.1.2)
@@ -325,6 +326,9 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
     webrobots (0.0.13)
+    whenever (0.9.2)
+      activesupport (>= 2.3.4)
+      chronic (>= 0.6.3)
     xml-simple (1.1.1)
     xpath (0.1.4)
       nokogiri (~> 1.3)
@@ -381,3 +385,4 @@ DEPENDENCIES
   uglifier
   unicorn (= 4.3.1)
   webmock
+  whenever (= 0.9.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (7.2.1)
+    govuk_content_models (8.1.0)
       bson_ext
       differ
       gds-api-adapters
@@ -353,7 +353,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 7.2.1)
+  govuk_content_models (= 8.1.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 0.9.3)
       omniauth (~> 1.2)
-    plek (1.5.0)
+    plek (1.7.0)
     poltergeist (0.7.0)
       capybara (~> 1.1)
       childprocess (~> 0.3)
@@ -367,7 +367,7 @@ DEPENDENCIES
   nested_form (= 0.3.2)
   nokogiri
   null_logger
-  plek (= 1.5.0)
+  plek (= 1.7.0)
   poltergeist (= 0.7.0)
   quiet_assets
   rails (= 3.2.17)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Welcome to Panopticon
-=====================
+# Panopticon
 
 The GOV.UK content platform has been built with a focus on tools over content.
 That is manifest in the existence of numerous small applications that provide
@@ -12,8 +11,7 @@ to attach consistent metadata to the pieces, connect them together as 'related
 items' and generally have a complete overview of all the solutions/artefacts in
 the system. That's this app: Panopticon.
 
-Interfaces
-----------
+# Interfaces
 
 Panopticon provides:
 
@@ -22,3 +20,12 @@ Panopticon provides:
 * a writeable API where applications can register the content
   they provide. This is authenticated using OAuth2.
 * a read API for retrieving metadata about a given item
+
+## Importing organisation tags
+
+Panopticon includes a Rake task to create tags for each organisation from the
+[Whitehall app](https://github.com/alphagov/whitehall). To run this in the
+development environment, the production data source can be used, so that there
+is no need to have an up-to-date Whitehall database.
+
+    PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk/ bundle exec rake organisations:import

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -201,7 +201,7 @@ class ArtefactsController < ApplicationController
       end
 
       # Strip out the empty submit option for sections
-      ['sections', 'legacy_source_ids', 'specialist_sector_ids'].each do |param|
+      ['sections', 'legacy_source_ids', 'specialist_sector_ids', 'organisation_ids'].each do |param|
         param_value = parameters_to_use[param]
         param_value.reject!(&:blank?) if param_value
       end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,6 +1,6 @@
 module TagsHelper
   def options_for_tags_of_type(tag_type)
-    Tag.where(:tag_type => tag_type).order(:title).map {|t| [t.title, t.tag_id]}
+    Tag.where(:tag_type => tag_type).order_by(:title, :asc).map {|t| [t.title, t.tag_id]}
   end
 
   def grouped_options_for_tags_of_type(tag_type)

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -34,5 +34,14 @@
                   :collection => grouped_options_for_tags_of_type('specialist_sector'),
                   :input_html => { :multiple => true, :class => "span12 chzn-select" } %>
     </div>
+
+    <div class="organisation-tags fieldset-section">
+      <label for="artefact_organisation_ids" class="section-label">Organisations</label>
+
+      <%= f.input :organisation_ids,
+                  :label => false,
+                  :collection => options_for_tags_of_type('organisation'),
+                  :input_html => { :multiple => true, :class => "span12 chzn-select" } %>
+    </div>
   <% end %>
 </div>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,2 @@
+# This file is here only for reference.
+# Tasks are configured from alphagov-deployment.

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -1,0 +1,76 @@
+require 'gds_api/organisations'
+
+class OrganisationImporter
+  TAG_TYPE = "organisation"
+
+  def run
+    logger.info "Fetching all organisations from the Organisation API"
+    organisations = organisations_api.organisations.with_subsequent_pages.to_a
+    logger.info "Loaded #{organisations.size} organisations"
+
+    organisations.each do |organisation|
+      create_or_update_organisation(organisation)
+    end
+
+    logger.info "Import complete"
+  end
+
+  private
+
+  def create_or_update_organisation(organisation)
+    tag_id = organisation.details.slug
+    existing_tag = Tag.where(tag_type: TAG_TYPE, tag_id: tag_id).first
+
+    if existing_tag.present?
+      if existing_tag.title != organisation.title
+        if existing_tag.update_attributes(title: organisation.title)
+          logger.info "Found existing tag: #{tag_id}; updated title to '#{existing_tag.title}'"
+        else
+          logger.info "Found existing tag: #{tag_id}; could not update title: #{existing_tag.errors.full_messages.join(', ')}"
+        end
+      else
+        logger.info "Found existing tag: #{tag_id}"
+      end
+    else
+      new_tag = Tag.new(tag_type: TAG_TYPE,
+                        tag_id: tag_id,
+                        title: organisation.title)
+
+      if new_tag.save
+        logger.info "Created organisation tag: #{tag_id}"
+      else
+        logger.info "Could not create organisation tag: #{tag_id} - #{new_tag.errors.full_messages.join(', ')}"
+      end
+    end
+  end
+
+  def logger
+    @logger ||= build_logger
+  end
+
+  def build_logger
+    output = case Rails.env
+             when "development" then STDOUT
+             when "test" then "/dev/null"
+             when "production" then Rails.root.join("log", "organisation_import.json.log")
+             end
+
+    Logger.new(output).tap {|logger|
+      logger.formatter = json_log_formatter if Rails.env.production?
+    }
+  end
+
+  def json_log_formatter
+    proc {|severity, datetime, progname, message|
+      {
+        "@message" => message,
+        "@tags" => ["cron", "rake"],
+        "@timestamp" => datetime.iso8601
+      }.to_json + "\n"
+    }
+  end
+
+  def organisations_api
+    @api_client ||= GdsApi::Organisations.new(Plek.current.find('whitehall-admin'))
+  end
+end

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -1,0 +1,8 @@
+require 'organisation_importer'
+
+namespace :organisations do
+  desc "Import organisations from the Organisations API"
+  task :import => :environment do
+    OrganisationImporter.new.run
+  end
+end

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -353,9 +353,10 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       click_on "VAT"
 
       within "select#artefact_organisation_ids" do
-        assert page.has_selector?("option", text: "HM Revenue and Customs")
-        assert page.has_selector?("option", text: "Driver and Vehicle Licensing Agency")
-        assert page.has_selector?("option", text: "Cabinet Office")
+        # Assert that organisations are returned in alphabetical order
+        assert page.has_selector?("option:nth-of-type(1)", text: "Cabinet Office")
+        assert page.has_selector?("option:nth-of-type(2)", text: "Driver and Vehicle Licensing Agency")
+        assert page.has_selector?("option:nth-of-type(3)", text: "HM Revenue and Customs")
       end
 
       select "HM Revenue and Customs", :from => "Organisations"

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -339,6 +339,49 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "editing organisations" do
+    setup do
+      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'hm-revenue-customs', title: 'HM Revenue and Customs')
+      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'driver-vehicle-licensing-agency', title: 'Driver and Vehicle Licensing Agency')
+      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'cabinet-office', title: 'Cabinet Office')
+
+      @artefact = FactoryGirl.create(:artefact, :name => "VAT")
+    end
+
+    should "allow adding organisation tags to artefacts" do
+      visit "/artefacts"
+      click_on "VAT"
+
+      within "select#artefact_organisation_ids" do
+        assert page.has_selector?("option", text: "HM Revenue and Customs")
+        assert page.has_selector?("option", text: "Driver and Vehicle Licensing Agency")
+        assert page.has_selector?("option", text: "Cabinet Office")
+      end
+
+      select "HM Revenue and Customs", :from => "Organisations"
+      select "Cabinet Office", :from => "Organisations"
+
+      click_on "Save and continue editing"
+
+      @artefact.reload
+      assert_equal ["cabinet-office", "hm-revenue-customs"], @artefact.organisation_ids.sort
+    end
+
+    should "allow removing organisation tags from artefacts" do
+      @artefact.organisation_ids = ["cabinet-office", "hm-revenue-customs"]
+      @artefact.save!
+
+      visit "/artefacts"
+      click_on "VAT"
+
+      unselect "Cabinet Office", :from => "Organisations"
+      click_on "Save and continue editing"
+
+      @artefact.reload
+      assert_equal ["hm-revenue-customs"], @artefact.organisation_ids
+    end
+  end
+
   context "editing language" do
     setup do
       @artefact = FactoryGirl.create(:artefact, :name => "Bank holidays", :language => nil)

--- a/test/unit/organisation_importer_test.rb
+++ b/test/unit/organisation_importer_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+require 'gds_api/test_helpers/organisations'
+
+require 'organisation_importer'
+
+class OrganisationImporterTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Organisations
+
+  should "create and update multiple organisations" do
+    organisations_api_has_organisations(["cabinet-office", "home-office", "ordnance-survey"])
+
+    importer = OrganisationImporter.new
+
+    importer.expects(:create_or_update_organisation).with(responds_with(:title, "Cabinet Office"))
+    importer.expects(:create_or_update_organisation).with(responds_with(:title, "Home Office"))
+    importer.expects(:create_or_update_organisation).with(responds_with(:title, "Ordnance Survey"))
+
+    importer.run
+  end
+
+  should "create a tag for a new organisation" do
+    organisations_api_has_organisations(["cabinet-office"])
+
+    assert_difference ->{ Tag.where(tag_type: "organisation").count } do
+      OrganisationImporter.new.run
+    end
+
+    created_tag = Tag.by_tag_id("cabinet-office", "organisation")
+    assert_equal "Cabinet Office", created_tag.title
+  end
+
+  should "not create a tag for an existing organisation" do
+    Tag.create!(tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
+
+    organisations_api_has_organisations(["cabinet-office"])
+    assert_difference ->{ Tag.where(tag_type: "organisation").count }, 0 do
+      OrganisationImporter.new.run
+    end
+  end
+
+  should "update the title of an existing organisation if it has changed" do
+    Tag.create!(tag_type: "organisation",
+                tag_id: "cabinet-office",
+                title: "An organisation by any other name")
+
+    organisations_api_has_organisations(["cabinet-office"])
+    OrganisationImporter.new.run
+
+    organisation_tag = Tag.by_tag_id("cabinet-office", "organisation")
+    assert_equal "Cabinet Office", organisation_tag.title
+  end
+
+  should "not update the title of an existing organisation if it hasn't changed" do
+    Tag.create!(tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
+
+    # assert that no tags are updated during the import run
+    Tag.any_instance.expects(:update_attributes).never
+
+    organisations_api_has_organisations(["cabinet-office"])
+    OrganisationImporter.new.run
+  end
+
+end


### PR DESCRIPTION
We'd like to be able to tag artefacts with organisations related to the content. Allowing content to be tagged with organisations makes it possible to introduce scoped search functionality in the future. 

This branch bumps govuk_content_models to introduce the new tag type `organisation`, and adds a corresponding field to the "Tags" section of the artefact form. 

This also adds a class to import organisations from the Whitehall API, which can be run from a Rake task. I've included the Whenever gem so that this task can be scheduled to run daily (pending a further change to alphagov-deployment).

It's important to note that the organisation tag type is not intended to denote ownership of the content by an organisation. However, as a further piece of work we do intend to tag publishing organisations for content in Whitehall as part of the Panopticon registration process.
