### PR TITLE
Allow artefact registration to support whitehall slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'plek', '1.7.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "8.1.0"
+  gem "govuk_content_models", "8.7.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     PriorityQueue (0.1.2)
     actionmailer (3.2.17)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,11 +130,11 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.3.0)
+    govspeak (1.5.1)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (8.1.0)
+    govuk_content_models (8.7.0)
       bson_ext
       differ
       gds-api-adapters
@@ -357,7 +357,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 8.1.0)
+  govuk_content_models (= 8.7.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,17 @@
 Panopticon::Application.routes.draw do
-  resources :artefacts, :constraints => { :id => /[^\.]+/ } do
+  # This is necessary to support some whitehall artefacts with a locale extension on the end
+  # of the slug.  If we just blanket allow . in the slug, this interferes with the formatted
+  # routes, so this instead special cases the 3 variants of locale extensions (.fr, .zh-hk, .es-419)
+  artefact_id_regex = %r{
+    [^\.]+                # 1 or more non-dot characters
+    (\.[a-z]{2}           # optionally dot followed by a basic locale (eg 'fr')
+      (                     # optionally followed by a locale extension
+        -[a-z]{2} |           # eg zh-hk
+        -\d{3}                # eg es-419
+      )?
+    )?
+  }x
+  resources :artefacts, :constraints => { :id => artefact_id_regex } do
     member do
       get :history
       get :archive

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -73,6 +73,30 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         artefact = Artefact.find_by_slug('foreign-travel-advice/aruba')
         assert artefact
       end
+
+      [
+        'fr',
+        'zh-hk',
+        'es-419',
+      ].each do |locale|
+        should "support whitehall artefact slugs ending with a locale '.#{locale}'" do
+          slug = "government/world-location-news/221033.#{locale}"
+          artefact_data = {
+            'slug' => slug,
+            'name' => "News article in locale #{locale}",
+            'kind' => 'world_location_news_article',
+            'description' => "Interesting news article",
+            'owning_app' => 'whitehall',
+            'rendering_app' => 'whitehall-frontend',
+          }
+
+          put "/artefacts/#{slug}.json", artefact_data
+          assert_equal 201, last_response.status
+
+          artefact = Artefact.find_by_slug(slug)
+          assert artefact
+        end
+      end
     end # for a new artefact
 
     context "for an existing artefact" do


### PR DESCRIPTION
This needs to support slugs with consecutive '-'s in them, and
aditionally some with a .locale suffix.

The former is addressed by the content_models bump, whereas the latter
additionally needed support in the routes.

Fixes [[#67540714](https://www.pivotaltracker.com/story/show/67540714), [#67541692](https://www.pivotaltracker.com/story/show/67541692)]
