### PR TITLE
Include organisations in the search index (and upgrade Rummageable) 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rails', '3.2.17'
 gem 'unicorn', '4.3.1'
 
 gem 'colorize', '~> 0.5.8'
-gem 'rummageable', "~> 0.3.0"
+gem 'rummageable', "1.0.1"
 
 gem "mongoid_rails_migrations", "1.0.0"
 gem "kaminari", "0.14.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.2.0)
       railties (>= 3.2.0)
-    multi_json (1.8.4)
+    multi_json (1.9.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nested_form (0.3.2)
@@ -270,9 +270,9 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rubyzip (0.9.9)
-    rummageable (0.3.0)
-      json
-      plek
+    rummageable (1.0.1)
+      multi_json
+      null_logger
       rest-client
     sanitize (2.0.6)
       nokogiri (>= 1.4.4)
@@ -375,7 +375,7 @@ DEPENDENCIES
   poltergeist (= 0.7.0)
   quiet_assets
   rails (= 3.2.17)
-  rummageable (~> 0.3.0)
+  rummageable (= 1.0.1)
   sass-rails (= 3.2.6)
   shoulda (~> 2.11.3)
   simplecov (~> 0.6.4)

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ development environment, the production data source can be used, so that there
 is no need to have an up-to-date Whitehall database.
 
     PLEK_SERVICE_WHITEHALL_ADMIN_URI=https://www.gov.uk/ bundle exec rake organisations:import
+
+## Indexing artefacts in search
+
+Panopticon includes observers which will index, update or delete records in the
+search index when an artefact is updated. It expects an instance of
+[Rummager](https://github.com/alphagov/rummager) to be present.
+
+Indexing is disabled by default in the development environment. To turn indexing
+on, set the `UPDATE_SEARCH` environment variable when starting Panopticon.

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -43,23 +43,27 @@ class RummageableArtefact
   def submit
     return unless indexable_artefact?
 
+    search_index = SearchIndex.instance
+
     # API requests, if they know about the single registration API, will be
     # providing the indexable_content field to update Rummager. UI requests
     # and requests from apps that don't know about single registration, will
     # not include this field
     if should_amend
       logger.info "Posting amendments to Rummager: #{artefact_link}"
-      Rummageable.amend artefact_link, artefact_hash
+      search_index.amend artefact_link, artefact_hash
     else
       logger.info "Posting document to Rummager: #{artefact_link}"
-      Rummageable.index [artefact_hash]
+      search_index.add artefact_hash
     end
   end
 
   def delete
     logger.info "Deleting item from Rummager: #{artefact_link}"
-    Rummageable.delete(artefact_link)
-    Rummageable.commit
+
+    search_index = SearchIndex.instance
+    search_index.delete(artefact_link)
+    search_index.commit
   end
 
   def should_amend

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -70,6 +70,9 @@ class RummageableArtefact
     # This won't cope with nested values, but we don't have any of those yet
     # When we want to include additional links, this will become an issue
     rummageable_keys = Rummageable::VALID_KEYS.map {|full_key| full_key[0]}.uniq
+    rummageable_keys += [
+      "organisations"
+    ]
 
     # When amending an artefact, requests with the "link" parameter will be
     # refused, because we can't amend the link within Rummager
@@ -120,6 +123,10 @@ class RummageableArtefact
 
   def artefact_link
     "/#{@artefact.slug}"
+  end
+
+  def artefact_organisations
+    @artefact.organisation_ids
   end
 
 private

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -69,14 +69,12 @@ class RummageableArtefact
   def artefact_hash
     # This won't cope with nested values, but we don't have any of those yet
     # When we want to include additional links, this will become an issue
-    rummageable_keys = Rummageable::VALID_KEYS.map {|full_key| full_key[0]}.uniq
-    rummageable_keys += [
-      "organisations"
-    ]
+    rummageable_keys = %w{title description format section subsection
+      indexable_content boost_phrases organisations additional_links}
 
     # When amending an artefact, requests with the "link" parameter will be
     # refused, because we can't amend the link within Rummager
-    rummageable_keys.delete "link" if should_amend
+    rummageable_keys << "link" unless should_amend
 
     result = {}
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module Panopticon
     config.assets.precompile += %W(html5.js)
 
     # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/app/repositories)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -1,6 +1,6 @@
 module RegistrationInfo
 
-  SEARCH_ROOT = "http://search.dev.gov.uk"
+  SEARCH_ROOT = "http://search.dev.gov.uk/mainstream"
 
   def example_smart_answer
     {

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -58,7 +58,7 @@ module RegistrationInfo
 
   def stub_search_delete
     @fake_search_delete = WebMock.stub_request(:delete, artefact_search_url(@artefact)).to_return(status: 200)
-    WebMock.stub_request(:post, "http://search.dev.gov.uk/commit")
+    WebMock.stub_request(:post, "#{SEARCH_ROOT}/commit")
            .to_return(:status => 200)
   end
 

--- a/lib/search_index.rb
+++ b/lib/search_index.rb
@@ -1,0 +1,9 @@
+class SearchIndex
+  def self.instance
+    @@instance ||= Rummageable::Index.new(rummager_host, '/mainstream', logger: Rails.logger)
+  end
+
+  def self.rummager_host
+    Plek.current.find('search')
+  end
+end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -459,9 +459,9 @@ class ArtefactsControllerTest < ActionController::TestCase
     context "DELETE /artefacts/:id" do
       setup do
         stub_all_router_api_requests
-        WebMock.stub_request(:delete, "http://search.dev.gov.uk/documents/%2Fwhatever").
+        WebMock.stub_request(:delete, "http://search.dev.gov.uk/mainstream/documents/%2Fwhatever").
             to_return(:status => 200)
-        WebMock.stub_request(:post, "http://search.dev.gov.uk/commit").
+        WebMock.stub_request(:post, "http://search.dev.gov.uk/mainstream/commit").
             to_return(:status => 200)
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,7 @@ DatabaseCleaner.clean
 
 class ActiveSupport::TestCase
   include Rack::Test::Methods
+  include FactoryGirl::Syntax::Methods
 
   def clean_db
     DatabaseCleaner.clean

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,6 +60,6 @@ class ActiveSupport::TestCase
   end
 
   def stub_all_rummager_requests
-    WebMock.stub_request(:any, %r{\A#{Rummageable.rummager_host}})
+    WebMock.stub_request(:any, %r{\A#{SearchIndex.rummager_host}})
   end
 end

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -224,4 +224,40 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       refute RummageableArtefact.new(artefact).should_be_indexed?
     end
   end
+
+  test "adds a rummageable artefact with indexable content to the search index" do
+    artefact = build(:artefact, indexable_content: "blah")
+    rummageable_artefact = RummageableArtefact.new(artefact)
+
+    stub_search_index = stub("Rummageable::Index")
+    SearchIndex.expects(:instance).returns(stub_search_index)
+
+    stub_search_index.expects(:add).with(rummageable_artefact.artefact_hash)
+    rummageable_artefact.submit
+  end
+
+  test "amends a rummageable artefact without indexable content" do
+    artefact = build(:artefact, indexable_content: nil)
+    rummageable_artefact = RummageableArtefact.new(artefact)
+
+    stub_search_index = stub("Rummageable::Index")
+    SearchIndex.expects(:instance).returns(stub_search_index)
+
+    stub_search_index.expects(:amend).with(rummageable_artefact.artefact_link,
+                                           rummageable_artefact.artefact_hash)
+    rummageable_artefact.submit
+  end
+
+  test "deletes a rummageable artefact" do
+    artefact = build(:artefact)
+    rummageable_artefact = RummageableArtefact.new(artefact)
+
+    stub_search_index = stub("Rummageable::Index")
+    SearchIndex.expects(:instance).returns(stub_search_index)
+
+    stub_search_index.expects(:delete).with(rummageable_artefact.artefact_link)
+    stub_search_index.expects(:commit)
+
+    rummageable_artefact.delete
+  end
 end

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -5,6 +5,9 @@ class RummageableArtefactTest < ActiveSupport::TestCase
   setup do
     FactoryGirl.create(:tag, tag_type: "section", tag_id: "crime", title: "Crime")
     FactoryGirl.create(:tag, tag_type: "section", tag_id: "crime/batman", title: "Batman", parent_id: "crime")
+
+    FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
+    FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "department-for-transport", title: "Department for Transport")
   end
 
   test "should extract artefact attributes" do
@@ -18,7 +21,8 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "title" => "My artefact",
       "format" => "guide",
       "section" => nil,
-      "subsection" => nil
+      "subsection" => nil,
+      "organisations" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -37,6 +41,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "description" => "Describe describey McDescribe",
       "section" => nil,
       "subsection" => nil,
+      "organisations" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -55,7 +60,8 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "format" => "guide",
       "section" => nil,
       "subsection" => nil,
-      "indexable_content" => "Blah blah blah index this"
+      "indexable_content" => "Blah blah blah index this",
+      "organisations" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -74,7 +80,8 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "format" => "guide",
       "section" => nil,
       "subsection" => nil,
-      "indexable_content" => "Blah blah blah index this"
+      "indexable_content" => "Blah blah blah index this",
+      "organisations" => [],
     }
   end
 
@@ -92,7 +99,8 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "format" => "guide",
       "section" => "crime",
       "subsection" => nil,
-      "indexable_content" => "Blah blah blah index this"
+      "indexable_content" => "Blah blah blah index this",
+      "organisations" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -111,7 +119,8 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "format" => "guide",
       "section" => "crime",
       "subsection" => "batman",
-      "indexable_content" => "Blah blah blah index this"
+      "indexable_content" => "Blah blah blah index this",
+      "organisations" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -129,6 +138,30 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "format" => "travel-advice",
       "section" => "foreign-travel-advice",
       "subsection" => nil,
+      "indexable_content" => "Blah blah blah index this",
+      "organisations" => [],
+    }
+    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+  end
+
+  test "should include organisations" do
+    artefact = Artefact.new do |artefact|
+      artefact.name = "My artefact"
+      artefact.slug = "my-artefact"
+      artefact.kind = "guide"
+      artefact.indexable_content = "Blah blah blah index this"
+      artefact.organisation_ids = ["cabinet-office", "department-for-transport"]
+    end
+    expected = {
+      "link" => "/my-artefact",
+      "title" => "My artefact",
+      "format" => "guide",
+      "subsection" => nil,
+      "section" => nil,
+      "organisations" => [
+        "cabinet-office",
+        "department-for-transport"
+      ],
       "indexable_content" => "Blah blah blah index this"
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash

--- a/test/unit/search_index_test.rb
+++ b/test/unit/search_index_test.rb
@@ -1,0 +1,14 @@
+require_relative '../test_helper'
+
+class SearchIndexTest < ActiveSupport::TestCase
+
+  test "builds a Rummageable::Index instance" do
+    Rummageable::Index.expects(:new)
+                        .with('http://search.dev.gov.uk', '/mainstream', has_key(:logger))
+                        .returns('search client')
+
+    client = SearchIndex.instance
+    assert_equal 'search client', client
+  end
+
+end


### PR DESCRIPTION
In order to supports future scoped search work, we're allowing mainstream content to be tagged with organisations in Panopticon.

This pull request includes a new field in `RegisterableArtefact` that is an array of organisation slugs, based on the tags associated with the artefact. 

To make this happen, Rummageable had to be updated from 0.3.0 to 1.0.0, which includes major changes to its public API. I've updated the RummageableArtefact class so that it continues to work, whilst abstracting some of the index configuration into a new class `SearchIndex`. I've also improved some of the unit test coverage for registering artefacts with Rummager.

This is dependent on the schema change made in alphagov/rummager#201.
