### PR TITLE
Disable editing of related artefacts.

### DIFF
--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -3,6 +3,11 @@
     <div class="related-artefacts fieldset-section">
       <label class="section-label">Related artefacts <span class="hint">(click and drag to reorder)</span></label>
 
+      <p class="lead text-error"><strong>Editing of related artefacts is currently disabled.</strong></p>
+
+      <%# Disable the related artefact inputs because they're now too large to render %>
+      <% if false %>
+
       <div class="nested-item-group related-artefact-group">
         <% if f.object.related_artefact_ids.length > 0 %>
           <% f.object.related_artefact_ids.each do |related_artefact_id| %>
@@ -15,6 +20,8 @@
 
       <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: true } %>
       <button id="add-related" class="btn btn-success" type="button">Add another related item</button>
+
+      <% end %><%# if false %>
     </div>
 
     <div class="related-external-links fieldset-section">

--- a/features/related_items.feature
+++ b/features/related_items.feature
@@ -1,3 +1,5 @@
+# Editing related artefacts is currently disabled
+@wip
 Feature: Related items
   In order to help visitors find their way on GovUK
   I want to assign related items to artefacts

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -411,6 +411,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   end
 
   should "not include completed transactions in related item lists" do
+    skip "Editing related artefacts is currently disabled"
     a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
     b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')
     c = FactoryGirl.create(:artefact, :name => "Done", :slug => 'done/completed-example', :kind => 'completed_transaction')


### PR DESCRIPTION
There are now c. 90k erteable tefacts.  This means that it's not
feasable to render these select inputs in their current form, and the
edit pages are currently timing out.

As a short-term measure, this disables these inputs so that the edit
form will work again.  A proper fix will follow as a separate piece of
work.

See https://www.pivotaltracker.com/story/show/69912646 for more details.
