### PR TITLE
Cleanup jenkins sh

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -e
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop db:create db:schema:load
 bundle exec rake

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,13 +1,5 @@
 #!/bin/bash -x
 
-# This removes rbenv shims from the PATH where there is no
-# .ruby-version file. This is because certain gems call their
-# respective tasks with ruby -S which causes the following error to
-# appear: ruby: no Ruby script found in input (LoadError).
-if [ ! -f .ruby-version ]; then
-  export PATH=$(printf $PATH | awk 'BEGIN { RS=":"; ORS=":" } !/rbenv/' | sed 's/:$//')
-fi
-
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake db:drop db:create db:schema:load
 bundle exec rake


### PR DESCRIPTION
This fixes a couple of things in the jenkins.sh
- It should have been `set -e` so that it aborts on any error.
- It didn't need the rbenv workaround any more.
