### PR TITLE
Register specialist sectors with router

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "10.2.0"
+  gem "govuk_content_models", "10.3.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (10.2.0)
+    govuk_content_models (10.3.0)
       bson_ext
       differ
       gds-api-adapters
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.20.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 10.2.0)
+  govuk_content_models (= 10.3.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -139,6 +139,10 @@ class ArtefactsController < ApplicationController
         scope = scope.matching_query(filters[:search])
       end
 
+      # Exclude all panopticon-owned artefacts from the index
+      # because they have their own specialised interfaces.
+      scope = scope.where(:owning_app.ne => 'panopticon')
+
       scope
     end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -23,7 +23,7 @@ class TagsController < ApplicationController
   end
 
   def create
-    @tag = Tag.new(params[:tag])
+    @tag = form_object.new(params[:tag])
 
     if @tag.parent_id.present?
       @tag.tag_id = "#{@tag.parent_id}/#{@tag.tag_id}"
@@ -115,5 +115,18 @@ class TagsController < ApplicationController
 
   def tag_can_have_curated_list?(tag)
     tag.tag_type == 'section' && tag.has_parent?
+  end
+
+  def form_object
+    case tag_type
+    when 'specialist_sector'
+      SpecialistSectorTagForm
+    else
+      Tag
+    end
+  end
+
+  def tag_type
+    params[:tag] && params[:tag][:tag_type] || params[:type]
   end
 end

--- a/app/forms/specialist_sector_tag_form.rb
+++ b/app/forms/specialist_sector_tag_form.rb
@@ -7,6 +7,16 @@ class SpecialistSectorTagForm < BasicObject
     tag.valid? && artefact.valid?
   end
 
+  def errors
+    tag.errors.tap do |tag_errors|
+      if tag_errors[:tag_id].empty? && artefact.errors[:slug].any?
+        artefact.errors[:slug].each do |slug_error|
+          tag_errors.add(:tag_id, slug_error)
+        end
+      end
+    end
+  end
+
   def save
     valid? && tag.save && artefact.save
   end

--- a/app/forms/specialist_sector_tag_form.rb
+++ b/app/forms/specialist_sector_tag_form.rb
@@ -1,0 +1,40 @@
+class SpecialistSectorTagForm < BasicObject
+  def initialize(*args)
+    @tag = ::Tag.new(*args)
+  end
+
+  def valid?
+    tag.valid? && artefact.valid?
+  end
+
+  def save
+    valid? && tag.save && artefact.save
+  end
+
+private
+  attr_reader :tag
+
+  def method_missing(method, *args, &block)
+    tag.send(method, *args, &block)
+  end
+
+  def artefact
+    @artefact ||= ::Artefact.new(artefact_attributes)
+  end
+
+  def artefact_attributes
+    {
+      name: tag.title,
+      slug: slug,
+      paths: ["/#{slug}"],
+      kind: "specialist_sector",
+      owning_app: "panopticon",
+      rendering_app: "collections",
+      state: "live"
+    }
+  end
+
+  def slug
+    tag.tag_id
+  end
+end

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -15,11 +15,7 @@ module ArtefactsHelper
     "#{Plek.current.find(artefact.owning_app)}/admin/publications/#{artefact.id}"
   end
 
-  def non_whitehall_formats
-    Artefact::FORMATS_BY_DEFAULT_OWNING_APP.each_with_object([]) do |(owning_app, formats), result|
-      if owning_app != "whitehall"
-        result.concat(formats)
-      end
-    end
+  def manageable_formats
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP.except('whitehall', 'panopticon').values.flatten
   end
 end

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -9,7 +9,8 @@ module FilterHelper
   end
 
   def options_from_formats_for_select(selected_value=nil)
-    formats_with_labels = Artefact::FORMATS.sort.map {|format|
+    non_panopticon_formats = Artefact::FORMATS_BY_DEFAULT_OWNING_APP.except('panopticon').values.flatten
+    formats_with_labels = non_panopticon_formats.sort.map {|format|
       [ format.underscore.humanize, format ]
     }
     options = [["All", ""]] + formats_with_labels

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -3,7 +3,8 @@ class RummageableArtefact
   FORMATS_NOT_TO_INDEX = %W(business_support completed_transaction campaign) +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["whitehall"] +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["specialist-publisher"] +
-    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"]
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"] +
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["panopticon"]
 
   EXCEPTIONAL_SLUGS = %W(
     growthaccelerator

--- a/app/observers/update_specialist_sector_tag_artefact_observer.rb
+++ b/app/observers/update_specialist_sector_tag_artefact_observer.rb
@@ -1,0 +1,13 @@
+class UpdateSpecialistSectorTagArtefactObserver < Mongoid::Observer
+  observe :tag
+
+  def after_update(tag)
+    update_artefact(tag) if tag.tag_type == 'specialist_sector'
+  end
+
+private
+  def update_artefact(tag)
+    artefact = Artefact.where(kind: 'specialist_sector', slug: tag.tag_id).first
+    artefact.update_attributes(name: tag.title) if artefact
+  end
+end

--- a/app/views/artefacts/form/_core_attributes.html.erb
+++ b/app/views/artefacts/form/_core_attributes.html.erb
@@ -6,7 +6,7 @@
   <%= f.input :slug, :input_html => { :class => "span6" } %>
 
   <% if f.object.new_record? %>
-    <%= f.input :kind, :collection => non_whitehall_formats.map { |s| [s.humanize, s]}, :as => :select, :prompt => "Select a kind", :input_html => { :class => "span4" } %>
+    <%= f.input :kind, :collection => manageable_formats.map { |s| [s.humanize, s]}, :as => :select, :prompt => "Select a kind", :input_html => { :class => "span4" } %>
     <%= f.input :owning_app, :as => :hidden, :input_html => {:value => "publisher"} %>
   <% end %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,5 +59,9 @@ module Panopticon
     # Upon archiving an artefact we want this observer to run to remove
     # any related items that also point to that artefact.
     config.mongoid.observers << :remove_related_artefacts_observer
+
+    # When saving a specialist sector tag we want to update the title of the
+    # associated artefact
+    config.mongoid.observers << :update_specialist_sector_tag_artefact_observer
   end
 end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -29,7 +29,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           @controller.expects(:artefact_scope).returns(@scope)
 
           # stub out the extra calls which get made on the scope object
-          @scope.stubs(:order_by => @scope, :page => @scope, :per => @scope)
+          @scope.stubs(:order_by => @scope, :page => @scope, :per => @scope, :where => @scope)
 
           # we aren't testing the template behaviour here, so don't try and render the template
           @controller.stubs(:render)
@@ -94,6 +94,18 @@ class ArtefactsControllerTest < ActionController::TestCase
         assert_equal 10, assigns(:artefacts).size
         assigns(:artefacts).each do |artefact|
           assert artefact.is_a?(Artefact)
+        end
+      end
+
+      should "exclude artefacts owned by Panopticon" do
+        panopticon_artefact = FactoryGirl.create(:artefact, owning_app: 'panopticon')
+
+        get :index
+
+        assert_equal [panopticon_artefact], Artefact.all.to_a - assigns(:artefacts)
+
+        assigns(:artefacts).each do |artefact|
+          assert_not_equal 'panopticon', artefact.owning_app
         end
       end
 

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -1,0 +1,74 @@
+require_relative '../../test_helper'
+
+class SpecialistSectorTagFormTest < ActiveSupport::TestCase
+  context '#valid?' do
+    subject do
+      SpecialistSectorTagForm.new(
+        title: 'Oil and gas',
+        tag_type: 'specialist_sector',
+        tag_id: 'oil-and-gas',
+      )
+    end
+
+    context 'with an unused slug' do
+      should 'be true' do
+        assert subject.valid?
+      end
+    end
+
+    context 'with an already taken slug' do
+      setup do
+        FactoryGirl.create(:artefact, slug: 'oil-and-gas')
+      end
+
+      should 'be false' do
+        refute subject.valid?
+      end
+    end
+
+    context 'with a two-part slug' do
+      setup do
+        FactoryGirl.create(:artefact, slug: 'oil-and-gas')
+      end
+
+      subject do
+        SpecialistSectorTagForm.new(
+          title: 'Fields and wells',
+          tag_type: 'specialist_sector',
+          tag_id: 'oil-and-gas/fields-and-wells',
+        )
+      end
+    end
+  end
+
+  context '#save' do
+    setup do
+      stub_all_router_api_requests
+      stub_all_rummager_requests
+    end
+
+    subject do
+      SpecialistSectorTagForm.new(
+        title: 'Oil and gas',
+        tag_type: 'specialist_sector',
+        tag_id: 'oil-and-gas',
+      )
+    end
+
+    should 'create an artefact for the tag' do
+      assert_difference 'Artefact.count', 1 do
+        subject.save
+      end
+
+      artefact = Artefact.last
+
+      assert_equal 'specialist_sector', artefact.kind
+      assert_equal 'panopticon', artefact.owning_app
+      assert_equal 'collections', artefact.rendering_app
+      assert_equal 'Oil and gas', artefact.name
+      assert_equal 'oil-and-gas', artefact.slug
+      assert_equal ['/oil-and-gas'], artefact.paths
+      assert_equal 'live', artefact.state
+    end
+  end
+end

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -24,6 +24,11 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       should 'be false' do
         refute subject.valid?
       end
+
+      should 'include a validation error for tag_id' do
+        subject.valid?
+        assert subject.errors[:tag_id].include?('is already taken')
+      end
     end
 
     context 'with a two-part slug' do

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -1,0 +1,16 @@
+require_relative '../../test_helper'
+
+class ArtefactsHelperTest < ActiveSupport::TestCase
+  include ArtefactsHelper
+
+  context "#manageable_formats" do
+    should "exclude formats owned by Whitehall" do
+      assert manageable_formats.exclude?('publication')
+      assert manageable_formats.exclude?('speech')
+    end
+
+    should "exclude formats owned by Panopticon" do
+      assert manageable_formats.exclude?('specialist_sector')
+    end
+  end
+end

--- a/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
+++ b/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
@@ -1,0 +1,26 @@
+require_relative '../../test_helper'
+
+class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
+  setup do
+    @tag = FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
+  end
+
+  context 'when an artefact exists for the tag' do
+    setup do
+      @artefact = FactoryGirl.create(:artefact, kind: 'specialist_sector', slug: 'oil-and-gas')
+    end
+
+    should 'update the artefact name' do
+      @tag.update_attributes(title: 'A brand new title')
+      assert_equal 'A brand new title', @artefact.reload.name
+    end
+  end
+
+  context 'when an artefact does not exist for the tag' do
+    should 'do nothing' do
+      assert_difference 'Artefact.count', 0 do
+        @tag.update_attributes(title: 'A brand new title')
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/68791610

This:
- adds a new type of artefact called `specialist_sector` representing a specialist browse page (aka a tag)
- prevents this format being indexed in rummager
- prevents artefacts of this format being managed via the main `/artefacts` route, as it should only be managed via `/tags`

Here's the code to register the existing specialist sector tags with the router and search: https://gist.github.com/elliotcm/11285693
