### PR TITLE
Fix specialist tag validation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', "7.20.0"
+  gem 'gds-api-adapters', "10.10.0"
 end
 
 gem 'rails', '3.2.17'
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "10.3.0"
+  gem "govuk_content_models", "10.4.1"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     formtastic-bootstrap (2.1.3)
       formtastic (~> 2.2)
     fssm (0.2.10)
-    gds-api-adapters (7.20.0)
+    gds-api-adapters (10.10.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -123,10 +123,10 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (10.3.0)
+    govuk_content_models (10.4.1)
       bson_ext
       differ
-      gds-api-adapters
+      gds-api-adapters (>= 10.9.0)
       gds-sso (>= 7.0.0, < 10.0.0)
       govspeak (>= 1.0.1, < 2.0.0)
       mongoid (~> 2.5)
@@ -335,10 +335,10 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.2.1)
   formtastic-bootstrap (= 2.1.3)
-  gds-api-adapters (= 7.20.0)
+  gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 10.3.0)
+  govuk_content_models (= 10.4.1)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/features/support/sections.rb
+++ b/features/support/sections.rb
@@ -1,8 +1,7 @@
 require 'govuk_content_models/test_helpers/factories'
 
 def create_section
-  FactoryGirl.create(
-    :tag,
+  FactoryGirl.create(:tag,
     tag_id: "crime",
     tag_type: "section",
     title: "Crime"
@@ -10,14 +9,14 @@ def create_section
 end
 
 def create_sections
-  create_section
-  FactoryGirl.create(
-    :tag,
+  section = create_section
+  subsection = FactoryGirl.create(:tag,
     tag_id: "crime/batman",
     tag_type: "section",
-    title: "Batman"
+    title: "Batman",
+    parent_id: section.id
   )
-  return ["crime", "crime/batman"].map { |tag_id| Tag.where(tag_id: tag_id, tag_type: 'section').first }
+  return [section, subsection]
 end
 
 def select_section(section)


### PR DESCRIPTION
Tags are only allowed to contain `/` if they are a child tag.

This `govuk_content_models` version depends on a bump to `gds-api-adapters` which includes 3 major version increases and thus three potentially breaking changes.
1. Changes to the Content API adapter to decouple tag methods from the `section` tag type.
2. Remove obsolete `curated_lists` method from Panopticon API. [unlikely to break anything]
3. Remove the ability to retrieve [business support schemes] by identifiers.

This warrants careful testing before deploy.
