### PR TITLE
Fixing artefacts controller tests

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -228,7 +228,6 @@ class ArtefactsController < ApplicationController
       %w[asc desc].include?(params[:direction]) ? params[:direction] : :asc
     end
 
-    # users will enter need_ids as comma-separated list in a text field
     def prepare_need_ids
       return if params[:artefact].blank? || params[:artefact][:need_ids].blank?
       params[:artefact][:need_ids] = params[:artefact][:need_ids].split(",").map(&:strip).reject(&:blank?)

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -130,13 +130,13 @@ class ArtefactsControllerTest < ActionController::TestCase
       context "invalid artefact" do
         should "rerender the form" do
           Artefact.any_instance.stubs(:need)
-          post :create, :slug => 'not/valid', :owning_app => 'smart-answers', :kind => 'smart-answer', :name => 'Whatever', :need_ids => ['100001']
+          post :create, :artefact => { :slug => 'not/valid', :owning_app => 'smart-answers', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
         end
       end
 
       should "redirect to GET edit" do
         Artefact.any_instance.stubs(:id).returns("abc")
-        post :create, :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => ['100001']
+        post :create, :artefact => { :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
 
         assert_redirected_to "/artefacts/abc/edit"
       end
@@ -151,23 +151,23 @@ class ArtefactsControllerTest < ActionController::TestCase
             :slug => 'whatever',
             :kind => 'guide',
             :name => 'Whatever',
-            :need_ids => ['100001'] }
+            :need_ids => "100001" }
         end
 
         should "redirect to publisher" do
-          post :create, valid_artefact_params
+          post :create, artefact: valid_artefact_params
 
           assert_redirected_to Plek.current.find('publisher') + "/admin/publications/abc"
         end
 
         should "redirect to edit page when requested" do
-          post :create, valid_artefact_params.merge(:commit => "Save and continue editing")
+          post :create, artefact: valid_artefact_params, commit: "Save and continue editing"
 
           assert_redirected_to "/artefacts/abc/edit"
         end
 
         should "split need_ids if they come in as comma-separated values" do
-          post :create, valid_artefact_params.merge(artefact: { need_ids: "331312,333123" })
+          post :create, artefact: valid_artefact_params.merge(need_ids: "331312,333123")
 
           assert_equal ["331312", "333123"], @controller.params[:artefact][:need_ids]
         end
@@ -230,7 +230,7 @@ class ArtefactsControllerTest < ActionController::TestCase
 
       should "redirect to GET edit" do
         artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", kind: "smart-answer")
-        put :update, :id => artefact.id, :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => ['100001']
+        put :update, :id => artefact.id, :artefact => { :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
 
         assert_redirected_to "/artefacts/#{artefact.id}/edit"
       end
@@ -238,7 +238,7 @@ class ArtefactsControllerTest < ActionController::TestCase
       context "publisher is owning_app" do
         should "redirect to GET show (which then redirects to publisher)" do
           artefact = FactoryGirl.create(:artefact)
-          put :update, :id => artefact.id, :owning_app => 'publisher', :slug => 'whatever', :kind => 'guide', :name => 'Whatever', :need_ids => ['100001']
+          put :update, :id => artefact.id, :artefact => { :owning_app => 'publisher', :slug => 'whatever', :kind => 'guide', :name => 'Whatever', :need_ids => '100001' }
 
           assert_redirected_to "/artefacts/#{artefact.id}"
         end


### PR DESCRIPTION
POST and PUT actions get params from html form
submissions. so their `params` hash should contain
artefact attributes within the `:artefact` key.

/cc @tekin
