### PR TITLE
Enable relating artefacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "10.4.1"
+  gem "govuk_content_models", "10.4.2"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (10.4.1)
+    govuk_content_models (10.4.2)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 10.4.1)
+  govuk_content_models (= 10.4.2)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/assets/stylesheets/artefacts/form.scss
+++ b/app/assets/stylesheets/artefacts/form.scss
@@ -181,3 +181,7 @@ label.section-label {
     margin: 0 0 0 25px;
   }
 }
+
+#artefact_related_artefact_slugs {
+  width: auto;
+}

--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -10,4 +10,13 @@ class Artefact
 
   STATES = [ "live", "draft", "archived" ]
 
+  def related_artefact_slugs=(slugs)
+    related_artefacts = Artefact.relatable_items.where(:slug.in => slugs).only(:_id)
+    self.related_artefact_ids = related_artefacts.map(&:_id).to_a
+  end
+
+  def related_artefact_slugs
+    self.related_artefacts.only(&:slug).map(&:slug)
+  end
+
 end

--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -1,25 +1,13 @@
 <div class="well">
   <%= f.inputs "Related content" do %>
     <div class="related-artefacts fieldset-section">
-      <label class="section-label">Related artefacts <span class="hint">(click and drag to reorder)</span></label>
-
       <div class="nested-item-group related-artefact-group">
-        <% if f.object.related_artefact_ids.length > 0 %>
-          <% f.object.related_artefact_ids.each do |related_artefact_id| %>
-            <%= render :partial => 'related_artefact', :locals => { related_artefact_id: related_artefact_id, is_template: false } %>
-          <% end %>
-        <% else %>
-          <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: false } %>
-        <% end %>
         <%= f.label :related_artefact_slugs, class: "section-label" %>
         <%= f.text_area :related_artefact_slugs, size: "75x3",
               placeholder: "Fill-in slugs of arefacts to relate, " +
                 "separated by a comma. for example: benefits-calculators, child-tax-credit",
               value: f.object.related_artefact_slugs.present? ? f.object.related_artefact_slugs.join(", ") : "" %>
       </div>
-
-      <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: true } %>
-      <button id="add-related" class="btn btn-success" type="button">Add another related item</button>
     </div>
 
     <div class="related-external-links fieldset-section">

--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -11,6 +11,11 @@
         <% else %>
           <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: false } %>
         <% end %>
+        <%= f.label :related_artefact_slugs, class: "section-label" %>
+        <%= f.text_area :related_artefact_slugs, size: "75x3",
+              placeholder: "Fill-in slugs of arefacts to relate, " +
+                "separated by a comma. for example: benefits-calculators, child-tax-credit",
+              value: f.object.related_artefact_slugs.present? ? f.object.related_artefact_slugs.join(", ") : "" %>
       </div>
 
       <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: true } %>

--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -3,11 +3,6 @@
     <div class="related-artefacts fieldset-section">
       <label class="section-label">Related artefacts <span class="hint">(click and drag to reorder)</span></label>
 
-      <p class="lead text-error"><strong>Editing of related artefacts is currently disabled.</strong></p>
-
-      <%# Disable the related artefact inputs because they're now too large to render %>
-      <% if false %>
-
       <div class="nested-item-group related-artefact-group">
         <% if f.object.related_artefact_ids.length > 0 %>
           <% f.object.related_artefact_ids.each do |related_artefact_id| %>
@@ -20,8 +15,6 @@
 
       <%= render :partial => 'related_artefact', :locals => { related_artefact_id: nil, is_template: true } %>
       <button id="add-related" class="btn btn-success" type="button">Add another related item</button>
-
-      <% end %><%# if false %>
     </div>
 
     <div class="related-external-links fieldset-section">

--- a/features/related_items.feature
+++ b/features/related_items.feature
@@ -1,3 +1,5 @@
+# while the javascript version of this feature is in development
+@wip
 Feature: Related items
   In order to help visitors find their way on GovUK
   I want to assign related items to artefacts

--- a/features/related_items.feature
+++ b/features/related_items.feature
@@ -1,5 +1,3 @@
-# Editing related artefacts is currently disabled
-@wip
 Feature: Related items
   In order to help visitors find their way on GovUK
   I want to assign related items to artefacts

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -177,12 +177,18 @@ class ArtefactsControllerTest < ActionController::TestCase
 
           assert_redirected_to "/artefacts/abc/edit"
         end
+      end
 
-        should "split need_ids if they come in as comma-separated values" do
-          post :create, artefact: valid_artefact_params.merge(need_ids: "331312,333123")
+      should "split need_ids if they come in as comma-separated values" do
+        post :create, artefact: valid_artefact_params.merge(need_ids: "331312,333123")
 
-          assert_equal ["331312", "333123"], @controller.params[:artefact][:need_ids]
-        end
+        assert_equal ["331312", "333123"], @controller.params[:artefact][:need_ids]
+      end
+
+      should "split related_artefact_slugs as they come in as comma-separated values" do
+        post :create, artefact: { related_artefact_slugs: "benefits-calculators, \nchild-tax-credit" }
+
+        assert_equal ["benefits-calculators", "child-tax-credit"], @controller.params[:artefact][:related_artefact_slugs]
       end
     end
 
@@ -490,6 +496,14 @@ class ArtefactsControllerTest < ActionController::TestCase
         put :update, id: artefact.id, artefact: { need_ids: "331312,333123" }
 
         assert_equal ["331312", "333123"], @controller.params[:artefact][:need_ids]
+      end
+
+      should "split related_artefact_slugs as they come in as comma-separated values" do
+        artefact = FactoryGirl.create(:artefact)
+
+        put :update, id: artefact.id, artefact: { related_artefact_slugs: "benefits-calculators, \nchild-tax-credit" }
+
+        assert_equal ["benefits-calculators", "child-tax-credit"], @controller.params[:artefact][:related_artefact_slugs]
       end
 
     end

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -289,16 +289,37 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     end
   end
 
-  should "not include completed transactions in related item lists" do
-    a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
-    b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')
-    c = FactoryGirl.create(:artefact, :name => "Done", :slug => 'done/completed-example', :kind => 'completed_transaction')
+  context "relating artefacts" do
+    context "using javascript" do
+      should "not include completed transactions in related item lists" do
 
-    visit "/artefacts"
-    click_on "Alpha"
+        a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
+        b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')
+        c = FactoryGirl.create(:artefact, :name => "Done", :slug => 'done/completed-example', :kind => 'completed_transaction')
 
-    assert page.has_selector?("#artefact_related_artefact_ids_ option[value='#{b.id}']")
-    assert ! page.has_selector?("#artefact_related_artefact_ids_ option[value='#{c.id}']")
+        visit "/artefacts"
+        click_on "Alpha"
+
+        assert page.has_selector?("#artefact_related_artefact_ids_ option[value='#{b.id}']")
+        assert ! page.has_selector?("#artefact_related_artefact_ids_ option[value='#{c.id}']")
+      end
+    end
+
+    context "without javascript" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact)
+        @artefacts_to_relate = *FactoryGirl.create_list(:artefact, 2)
+      end
+
+      should "be done by entering slugs of artefacts to relate" do
+        visit edit_artefact_path(@artefact)
+
+        fill_in "Related artefact slugs", with: @artefacts_to_relate.map(&:slug).join(", ")
+        click_on "Save and continue editing"
+
+        assert_equal @artefacts_to_relate.map(&:slug).join(", "), find_field("Related artefact slugs").value
+      end
+    end
   end
 
   context "related external links" do

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -292,6 +292,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   context "relating artefacts" do
     context "using javascript" do
       should "not include completed transactions in related item lists" do
+        pending "will re-use this test when implementing relating artefacts using javascript"
 
         a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
         b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -290,7 +290,6 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   end
 
   should "not include completed transactions in related item lists" do
-    skip "Editing related artefacts is currently disabled"
     a = FactoryGirl.create(:artefact, :name => "Alpha", :slug => 'alpha')
     b = FactoryGirl.create(:artefact, :name => "Beta", :slug => 'beta')
     c = FactoryGirl.create(:artefact, :name => "Done", :slug => 'done/completed-example', :kind => 'completed_transaction')

--- a/test/unit/enhancements/artefact_test.rb
+++ b/test/unit/enhancements/artefact_test.rb
@@ -1,0 +1,39 @@
+require_relative '../../test_helper'
+
+class ArtefactTest < ActiveSupport::TestCase
+
+  context "#related_artefact_slugs=" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact)
+      @artefacts_to_relate = *FactoryGirl.create_list(:artefact, 2)
+    end
+
+    should "assign related artefacts based on their slugs" do
+      @artefact.related_artefact_slugs = @artefacts_to_relate.map(&:slug)
+      @artefact.save!
+
+      assert_equal @artefacts_to_relate, @artefact.reload.related_artefacts
+    end
+
+    should "ignore slugs of artefacts that are not relatable" do
+      archived_artefact_not_relatable = FactoryGirl.create(:artefact)
+      archived_artefact_not_relatable.set(:state, "archived")
+      @artefact.related_artefact_slugs = @artefacts_to_relate.map(&:slug) + [archived_artefact_not_relatable.slug]
+      @artefact.save!
+
+      assert_equal @artefacts_to_relate, @artefact.reload.related_artefacts
+    end
+  end
+
+  context "#related_artefact_slugs" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact)
+      @artefact.related_artefacts = @related_artefacts = FactoryGirl.create_list(:artefact, 2)
+    end
+
+    should "should return slugs of related artefacts" do
+      assert_equal @related_artefacts.map(&:slug), @artefact.related_artefact_slugs
+    end
+  end
+
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/69920830
merge and bump this first: https://github.com/alphagov/govuk_content_models/pull/163

re-enabling the relating artefacts feature, implemented
in a way that it can handle copious amount of relatable
artefacts.

as a first step, progressively enhancing, we're allowing
users to enter a comma-separated list of slugs related
to an artefact. this will be a fall-back method when the
page doesn't run javascript.

by the end of the story, we'll have a [select2](http://ivaynberg.github.io/select2/) text field
that will allow users to search for artefacts they want
to relate, when javascript is working on the page.

some tests and view code has been marked pending,
removed temporarily only till we start working on the
javascript version of this feature - https://github.com/alphagov/panopticon/commit/1cb9b740d3f2a7df9bb2b434a937a7d0a0f1e0de
