### PR TITLE
Fix nil need_ids on imported artefacts

### DIFF
--- a/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
+++ b/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
@@ -1,0 +1,8 @@
+class FixNilNeedIdsOnArtefacts < Mongoid::Migration
+  def self.up
+    Artefact.collection.find_and_modify(query: {need_ids: nil}, update: {need_ids: []})
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
some artefacts were imported before
we deployed the change to add need_ids
to Artefacts. hence the [earlier migration](https://github.com/alphagov/panopticon/blob/master/db/migrate/20140324144244_copy_artefact_need_id_to_array_field_need_ids.rb) didn't
account for those artefacts. this migration should
fix it and the related errors [in errbit](https://errbit.production.alphagov.co.uk/apps/52f0ceeb0da1152f0b000003/problems/535e833d0da1151271000d33).

[find_and_modify docs](http://docs.mongodb.org/v2.2/reference/method/db.collection.findAndModify/)
