### PR TITLE
Correcting the artefact need_ids update migration

### DIFF
--- a/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
+++ b/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
@@ -1,6 +1,7 @@
 class FixNilNeedIdsOnArtefacts < Mongoid::Migration
   def self.up
-    Artefact.collection.find_and_modify(query: {need_ids: nil}, update: {need_ids: []})
+    result = Artefact.where(need_ids: nil).update_all(need_ids: [])
+    puts "Updated need_ids to `[]` for #{result["n"]} artefacts where need_ids was nil"
   end
 
   def self.down


### PR DESCRIPTION
.find_and_modify updates the entire document and
not just attributes mentioned in the update value.
