### PR TITLE
Remove puts from migration

### DIFF
--- a/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
+++ b/db/migrate/20140429085510_fix_nil_need_ids_on_artefacts.rb
@@ -1,7 +1,6 @@
 class FixNilNeedIdsOnArtefacts < Mongoid::Migration
   def self.up
-    result = Artefact.where(need_ids: nil).update_all(need_ids: [])
-    puts "Updated need_ids to `[]` for #{result["n"]} artefacts where need_ids was nil"
+    Artefact.where(need_ids: nil).update_all(need_ids: [])
   end
 
   def self.down


### PR DESCRIPTION
the `puts` relies on a result returned from
update_all which was returning different results
on development and staging boxes, which was
blocking deployments.

/cc @fatbusinessman 
