### PR TITLE
Fix artefacts index view when need_ids is nil

### DIFF
--- a/app/views/artefacts/index.html.erb
+++ b/app/views/artefacts/index.html.erb
@@ -29,8 +29,10 @@
           <% @artefacts.each do |artefact| %>
             <tr class="<%= artefact.state %>">
               <td>
-                <% artefact.need_ids.each do |need_id| %>
-                  <%= content_tag "span", need_id, :class => "label need-id" %>
+                <% if artefact.need_ids %>
+                  <% artefact.need_ids.each do |need_id| %>
+                    <%= content_tag "span", need_id, :class => "label need-id" %>
+                  <% end %>
                 <% end %>
               </td>
               <td><%= link_to artefact.name, edit_artefact_path(artefact.id) %></td>


### PR DESCRIPTION
This was causing 500 errors in prod.

need_ids should always be an array, but in some cases it can be nil
(often caused by Rails params_wrapper 'helpfully' converting empty array
in JSON requests to nil).
