### PR TITLE
Tag mainstream content with organisations based on needs

### DIFF
--- a/lib/importers/mainstream_organisation_tag_importer.rb
+++ b/lib/importers/mainstream_organisation_tag_importer.rb
@@ -1,0 +1,66 @@
+module Importers
+  class MainstreamOrganisationTagImporter
+
+    def initialize(need_api)
+      @need_api = need_api
+    end
+
+    def run
+      logger.info "Starting #{self.class.name}"
+
+      artefacts_with_needs.each do |artefact|
+        logger.info "  #{artefact.slug}:"
+        logger.info "    -> need IDs: #{artefact.need_ids.join(', ')}"
+
+        needs = maslow_need_ids(artefact).map {|need_id|
+          @need_api.need(need_id)
+        }.compact
+        logger.info "    -> Maslow needs found: #{needs.size}"
+
+        organisation_ids_to_add = needs.map {|need|
+          need['organisation_ids']
+        }.flatten
+
+        organisation_ids = (artefact.organisation_ids + organisation_ids_to_add).uniq
+
+        artefact.organisation_ids = organisation_ids
+        artefact.save
+
+        logger.info "    -> organisation_ids = #{organisation_ids}"
+      end
+
+      logger.info "Import completed"
+    end
+
+  private
+
+    def mainstream_owning_apps
+      [
+        'calculators',
+        'calendars',
+        'publisher',
+        'smartanswers',
+        'travel-advice-publisher',
+      ]
+    end
+
+    def artefacts_with_needs
+      Artefact.where("need_ids.0".to_sym.exists => true,
+                     :owning_app.in => mainstream_owning_apps,
+                     :state.ne => 'archived')
+    end
+
+    def maslow_need_ids(artefact)
+      artefact.need_ids.select {|need_id|
+        need_id =~ /\A\d{6}\Z/
+      }
+    end
+
+    def logger
+      # Don't output in the test environment, to avoid test output getting noisy
+      output = Rails.env.test? ? "/dev/null" : STDOUT
+      @logger ||= Logger.new(output)
+    end
+
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,12 @@
+require 'importers/mainstream_organisation_tag_importer'
+
+namespace :import do
+
+  desc "Import organisation tags for mainstream content from the Need API"
+  task :mainstream_organisation_tags => :environment do
+    Importers::MainstreamOrganisationTagImporter.new(
+      Panopticon.need_api
+    ).run
+  end
+
+end

--- a/test/unit/importers/mainstream_organisation_tag_importer_test.rb
+++ b/test/unit/importers/mainstream_organisation_tag_importer_test.rb
@@ -1,0 +1,145 @@
+require 'test_helper'
+require 'importers/mainstream_organisation_tag_importer'
+
+module Importers
+  class MainstreamOrganisationTagImporterTest < ActiveSupport::TestCase
+
+    setup do
+      @need_api = stub("GdsApi::NeedApi")
+      @importer = MainstreamOrganisationTagImporter.new(@need_api)
+    end
+
+    def stub_need_with_organisation_ids(need_id, *organisations)
+      organisations.each do |organisation|
+        next if Tag.by_tag_id(organisation, 'organisation')
+        create(:tag, tag_type: 'organisation', tag_id: organisation)
+      end
+
+      stub_need = {
+        'organisation_ids' => organisations
+      }
+      @need_api.expects(:need).with(need_id).returns(stub_need)
+    end
+
+    should 'not request a need for an artefact without a need ID' do
+      create(:draft_artefact, owning_app: 'publisher', need_ids: nil)
+
+      @need_api.expects(:need).never
+
+      @importer.run
+    end
+
+    should 'not request a need for a non-publisher artefact' do
+      create(:whitehall_draft_artefact, need_ids: ['100001'])
+
+      @need_api.expects(:need).never
+
+      @importer.run
+    end
+
+    should 'not request a need for an archived artefact' do
+      # disable observers whilst we create the artefact, so that we don't try to
+      # register with the router or index in search
+      Artefact.observers.disable :all do
+        create(:archived_artefact, owning_app: 'publisher', need_ids: ['100001'])
+      end
+
+      @need_api.expects(:need).never
+
+      @importer.run
+    end
+
+    should 'not request a need that is not a Maslow need ID' do
+      # as new need_ids are now validated to the Maslow format, we have to set the
+      # need_ids field manually so that we avoid validation.
+      artefact = create(:draft_artefact, owning_app: 'publisher')
+      artefact.update_attribute(:need_ids, ['123', 'B123'])
+
+      @need_api.expects(:need).never
+
+      @importer.run
+    end
+
+    should 'assign organisations for a need to a publisher artefact with a need ID' do
+      artefact = create(:draft_artefact, owning_app: 'publisher', need_ids: ['100001'])
+      stub_need_with_organisation_ids('100001', 'department-for-work-pensions',
+                                                'ministry-of-justice')
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['department-for-work-pensions', 'ministry-of-justice'],
+                   artefact.organisation_ids
+    end
+
+    should 'assign organisations for all needs to a publisher artefact with multiple need IDs' do
+      artefact = create(:draft_artefact, owning_app: 'publisher', need_ids: ['100001', '100002'])
+      stub_need_with_organisation_ids('100001', 'home-office',
+                                                'uk-visas-and-immigration')
+      stub_need_with_organisation_ids('100002', 'environment-agency')
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['home-office', 'uk-visas-and-immigration', 'environment-agency'],
+                   artefact.organisation_ids
+    end
+
+    should 'not remove existing organisation tags from the artefact' do
+      create(:tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
+      artefact = create(:draft_artefact, owning_app: 'publisher',
+                                         need_ids: ['100001'],
+                                         organisation_ids: ['ministry-of-defence'])
+
+      stub_need_with_organisation_ids('100001', 'home-office')
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['ministry-of-defence', 'home-office'], artefact.organisation_ids
+    end
+
+    should 'not tag the same new organisation multiple times to an artefact' do
+      artefact = create(:draft_artefact, owning_app: 'publisher', need_ids: ['100001', '100002'])
+      stub_need_with_organisation_ids('100001', 'home-office',
+                                                'uk-visas-and-immigration')
+      stub_need_with_organisation_ids('100002', 'home-office')
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['home-office', 'uk-visas-and-immigration'],
+                   artefact.organisation_ids
+    end
+
+    should 'not tag an organisation to an artefact to which it is already tagged' do
+      create(:tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
+      artefact = create(:draft_artefact, owning_app: 'publisher',
+                                         need_ids: ['100001'],
+                                         organisation_ids: ['ministry-of-defence'])
+
+      stub_need_with_organisation_ids('100001', 'ministry-of-defence')
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['ministry-of-defence'], artefact.organisation_ids
+    end
+
+    should 'assign organisations for any present needs to an artefact with incorrect need IDs' do
+      artefact = create(:draft_artefact, owning_app: 'publisher',
+                                         need_ids: ['100001', '100002', '100003'])
+
+      stub_need_with_organisation_ids('100001', 'home-office')
+      stub_need_with_organisation_ids('100002', 'environment-agency')
+
+      # stub a nil response from the api adapter as if this need does not exist
+      @need_api.expects(:need).with('100003').returns(nil)
+
+      @importer.run
+      artefact.reload
+
+      assert_equal ['home-office', 'environment-agency'], artefact.organisation_ids
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70747368

This adds an importer to tag mainstream content with organisations, based on their associated Maslow needs.

The importer supports artefacts with multiple needs, and needs which have multiple organisations. It will append any new organisations to the list, rather than replacing any existing organisation tags which may have been added.

The importer can be ran with `rake import:mainstream_organisation_tags`. The existing Need API client in Panopticon will be used to make requests.
