### PR TITLE
Add migration to delete three RPA specialist sectors

### DIFF
--- a/db/migrate/20140602152302_remove_rpa_specialist_sectors.rb
+++ b/db/migrate/20140602152302_remove_rpa_specialist_sectors.rb
@@ -1,0 +1,41 @@
+class RemoveRpaSpecialistSectors < Mongoid::Migration
+  TAG_TYPE = "specialist-sector"
+
+  def self.up
+    tags_to_remove.each do |tag_id, _, _|
+      tag = Tag.by_tag_id(tag_id, TAG_TYPE)
+
+      if tag.present?
+        if tag.destroy
+          puts "Deleted specialist sector: #{tag_id}"
+        else
+          puts "Could not delete specialist sector: #{tag_id}"
+        end
+      else
+        puts "Could not find specialist sector: #{tag_id}"
+      end
+    end
+  end
+
+  def self.down
+    tags_to_remove.each do |tag_id, title, parent_id|
+      tag = Tag.by_tag_id(tag_id, TAG_TYPE)
+
+      if tag.present?
+        puts "Specialist sector #{tag_id} already exists"
+      else
+        Tag.create!(tag_id: tag_id, title: title, parent_id: parent_id, tag_type: TAG_TYPE)
+        puts "Created specialist sector: #{title} (#{tag_id})"
+      end
+    end
+  end
+
+private
+  def self.tags_to_remove
+    [
+      ["working-at-sea/fishing", "Fishing", "working-at-sea"],
+      ["producing-distributing-food/inspections", "Inspections", "producing-distributing-food"],
+      ["keeping-farmed-animals/inspections", "Inspections", "keeping-farmed-animals"],
+    ]
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/71645968

This migration deletes three specialist sector tags if they exist. These have never been populated on GOV.UK, nor are they currently linked to, so it is not necessary to add redirects for these.
