### PR TITLE
Fixes the display of pagination links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,13 +51,17 @@
 
 
 /* Pagination tweaks copied from Migratorator */
-.pagination span.current, .pagination span.gap {
-  float: left;
-  padding: 0 14px;
-  line-height: 34px;
-  text-decoration: none;
-  border: 1px solid #DDD;
-  border-left-width: 0;
+.pagination {
+  a,
+  span.current,
+  span.gap {
+    float: left;
+    padding: 0 14px;
+    line-height: 34px;
+    text-decoration: none;
+    border: 1px solid #DDD;
+    border-left-width: 0;
+  }
 }
 .pagination span.current { background: #eee; }
 .pagination span:first-child, .pagination span:first-child a {


### PR DESCRIPTION
Only `.current` and `.gap` were styled, regular page links weren't.

I mentioned this to @fofr and he's considering rolling it into the admin gem.
