### PR TITLE
Tag travel advice and business support content with organisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "11.2.0"
+  gem "govuk_content_models", "11.3.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (11.2.0)
+    govuk_content_models (11.3.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 11.2.0)
+  govuk_content_models (= 11.3.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/db/migrate/20140604100157_tag_organisations_to_travel_advice_and_business_support.rb
+++ b/db/migrate/20140604100157_tag_organisations_to_travel_advice_and_business_support.rb
@@ -1,0 +1,74 @@
+class TagOrganisationsToTravelAdviceAndBusinessSupport < Mongoid::Migration
+  def self.up
+    add_organisation_tags_to_artefacts(
+      non_archived_artefacts_of_kind('travel-advice'),
+      'foreign-commonwealth-office'
+    )
+
+    add_organisation_tags_to_artefacts(
+      non_archived_artefacts_of_kind('business_support'),
+      'department-for-business-innovation-skills'
+    )
+  end
+
+  def self.down
+    remove_organisation_tags_from_artefacts(
+      non_archived_artefacts_of_kind('travel-advice'),
+      'foreign-commonwealth-office'
+    )
+
+    remove_organisation_tags_from_artefacts(
+      non_archived_artefacts_of_kind('business_support'),
+      'department-for-business-innovation-skills'
+    )
+  end
+
+private
+  def self.non_archived_artefacts_of_kind(kind)
+    Artefact.of_kind(kind).where(:state.ne => 'archived')
+  end
+
+  def self.add_organisation_tags_to_artefacts(artefacts, tag_id)
+    puts "Tagging #{artefacts.size} artefacts with organisation '#{tag_id}'"
+
+    longest_slug_length = artefacts.max_by {|a| a.slug.length }.slug.length
+
+    artefacts.each do |artefact|
+      print "#{artefact.slug.ljust(longest_slug_length+5)}"
+
+      # append the tag id and then run uniq over the array
+      artefact.organisation_ids = (artefact.organisation_ids + [tag_id]).uniq
+
+      if artefact.save
+        print "Added"
+      else
+        print "Error\n"
+        print artefact.errors.full_messages.join("\n\t\t")
+      end
+
+      print "\n"
+    end
+  end
+
+  def self.remove_organisation_tags_from_artefacts(artefacts, tag_id)
+    puts "Removing organisation '#{tag_id}' from #{artefacts.size} artefacts"
+
+    longest_slug_length = artefacts.max_by {|a| a.slug.length }.slug.length
+
+    artefacts.each do |artefact|
+      print "#{artefact.slug.ljust(longest_slug_length+5)}"
+
+      # remove the tag id and reassign to organisation_ids
+      artefact.organisation_ids = (artefact.organisation_ids - [tag_id])
+
+      if artefact.save
+        print "Removed"
+      else
+        print "Error\n"
+        print artefact.errors.full_messages.join("\n\t\t")
+      end
+
+      print "\n"
+    end
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/72452126

This adds a new migration to tag every ‘travel-advice’ artefact with the FCO, and every ‘business_support’ artefact with BIS.
