### PR TITLE
Correct the slugs and type in the RPA migration

### DIFF
--- a/db/migrate/20140602152302_remove_rpa_specialist_sectors.rb
+++ b/db/migrate/20140602152302_remove_rpa_specialist_sectors.rb
@@ -1,5 +1,5 @@
 class RemoveRpaSpecialistSectors < Mongoid::Migration
-  TAG_TYPE = "specialist-sector"
+  TAG_TYPE = "specialist_sector"
 
   def self.up
     tags_to_remove.each do |tag_id, _, _|
@@ -33,7 +33,7 @@ class RemoveRpaSpecialistSectors < Mongoid::Migration
 private
   def self.tags_to_remove
     [
-      ["working-at-sea/fishing", "Fishing", "working-at-sea"],
+      ["working-sea/fishing", "Fishing", "working-sea"],
       ["producing-distributing-food/inspections", "Inspections", "producing-distributing-food"],
       ["keeping-farmed-animals/inspections", "Inspections", "keeping-farmed-animals"],
     ]


### PR DESCRIPTION
The migration was intended to remove some unused tags, but had an
incorrect tag type and an incorrect slug, so failed to work in
production.

This migration was run on staging, but not on production, and the
database has been synced from production to staging since then.
Therefore, we're just leaving the migration date as it is.
