### PR TITLE
Include specialist sector in data sent to Rummager

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -75,7 +75,8 @@ class RummageableArtefact
     # This won't cope with nested values, but we don't have any of those yet
     # When we want to include additional links, this will become an issue
     rummageable_keys = %w{title description format section subsection
-      indexable_content boost_phrases organisations additional_links}
+      indexable_content boost_phrases organisations additional_links
+      specialist_sectors}
 
     # When amending an artefact, requests with the "link" parameter will be
     # refused, because we can't amend the link within Rummager
@@ -130,6 +131,10 @@ class RummageableArtefact
 
   def artefact_organisations
     @artefact.organisation_ids
+  end
+
+  def artefact_specialist_sectors
+    @artefact.specialist_sectors.map(&:tag_id)
   end
 
 private

--- a/test/integration/artefact_search_indexing_test.rb
+++ b/test/integration/artefact_search_indexing_test.rb
@@ -55,6 +55,8 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
     FactoryGirl.create(:tag, tag_type: "section", tag_id: "a-section/subsection", title: "A Subsection", parent_id: "a-section")
     FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
     FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
+    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
+                       parent_id: "working-sea")
 
     new_artefact = FactoryGirl.build(
       :artefact,
@@ -63,7 +65,7 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
       slug: "my-artefact",
       kind: "guide", state: "live",
       organisations: ["cabinet-office"],
-      specialist_sectors: ["working-sea"]
+      specialist_sectors: ["working-sea/health-safety"]
     )
 
     expected_hash_of_attributes_to_index = {
@@ -72,7 +74,7 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
       "section" => "a-section",
       "subsection" => "subsection",
       "organisations" => ["cabinet-office"],
-      "specialist_sectors" => ["working-sea"],
+      "specialist_sectors" => ["working-sea/health-safety"],
     }
 
     mock_search_index = mock()

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -8,6 +8,14 @@ class RummageableArtefactTest < ActiveSupport::TestCase
 
     FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
     FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "department-for-transport", title: "Department for Transport")
+
+    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "oil-and-gas", title: "Oil and Gas")
+    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "oil-and-gas/licensing", title: "Licensing",
+                       parent_id: "oil-and-gas")
+
+    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
+    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
+                       parent_id: "working-sea")
   end
 
   test "should extract artefact attributes" do
@@ -23,6 +31,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "section" => nil,
       "subsection" => nil,
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -42,6 +51,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "section" => nil,
       "subsection" => nil,
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -62,6 +72,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "subsection" => nil,
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -101,6 +112,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "subsection" => nil,
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -121,6 +133,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "subsection" => "batman",
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -140,6 +153,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "subsection" => nil,
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
+      "specialist_sectors" => [],
     }
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
@@ -161,6 +175,35 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [
         "cabinet-office",
         "department-for-transport"
+      ],
+      "specialist_sectors" => [],
+      "indexable_content" => "Blah blah blah index this"
+    }
+    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+  end
+
+  test "should include specialist sectors" do
+    artefact = Artefact.new do |artefact|
+      artefact.name = "My artefact"
+      artefact.slug = "my-artefact"
+      artefact.kind = "guide"
+      artefact.indexable_content = "Blah blah blah index this"
+      artefact.organisation_ids = []
+      artefact.specialist_sectors = [
+        'oil-and-gas/licensing',
+        'working-sea/health-safety'
+      ]
+    end
+    expected = {
+      "link" => "/my-artefact",
+      "title" => "My artefact",
+      "format" => "guide",
+      "subsection" => nil,
+      "section" => nil,
+      "organisations" => [],
+      "specialist_sectors" => [
+        'oil-and-gas/licensing',
+        'working-sea/health-safety'
       ],
       "indexable_content" => "Blah blah blah index this"
     }


### PR DESCRIPTION
Adds an array of specialist sectors to content sent to Rummager

Story: https://www.pivotaltracker.com/story/show/73292504
