### PR TITLE
Remove "Panopticon" from the 'formats not to index' list

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -3,8 +3,7 @@ class RummageableArtefact
   FORMATS_NOT_TO_INDEX = %W(business_support completed_transaction campaign) +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["whitehall"] +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["specialist-publisher"] +
-    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"] +
-    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["panopticon"]
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"]
 
   EXCEPTIONAL_SLUGS = %W(
     growthaccelerator


### PR DESCRIPTION
In order to index specialist sector artefacts in the search index, we need to remove Panopticon from the list of formats not to index.

At present, the only format owned by Panopticon is specialist sectors, so this will not affect any other formats.

This should not be merged until after alphagov/rummager#253
