### PR TITLE
Add state attribute to tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "12.2.0"
+  gem "govuk_content_models", "13.3.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (12.2.0)
+    govuk_content_models (13.3.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 12.2.0)
+  govuk_content_models (= 13.3.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/db/migrate/20140704121335_set_all_tags_to_live.rb
+++ b/db/migrate/20140704121335_set_all_tags_to_live.rb
@@ -1,0 +1,11 @@
+class SetAllTagsToLive < Mongoid::Migration
+  def self.up
+    Tag.update_all(state: 'live')
+  end
+
+  def self.down
+    Tag.all.each {|tag|
+      tag.unset(:state)
+    }
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/73970734

This bumps govuk_content_models to include the new `state` attribute for a Tag, and adds a data migration which updates the `state` of every existing tag to be `live`.
