### PR TITLE
Bump govuk_content_models to v13.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "13.3.0"
+  gem "govuk_content_models", "13.4.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (13.3.0)
+    govuk_content_models (13.4.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 13.3.0)
+  govuk_content_models (= 13.4.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
Introduces new format type for SpecialistDocument Artefacts which will allow aaib_report and cma_case format artefacts to be registered with panopticon.
