### PR TITLE
Sends insert request for new specialist sectors

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -5,6 +5,8 @@ class RummageableArtefact
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["specialist-publisher"] +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"]
 
+  FORMATS_NOT_TO_AMEND = %W(specialist_sector)
+
   EXCEPTIONAL_SLUGS = %W(
     growthaccelerator
     technology-strategy-board
@@ -49,7 +51,7 @@ class RummageableArtefact
     # providing the indexable_content field to update Rummager. UI requests
     # and requests from apps that don't know about single registration, will
     # not include this field
-    if should_amend
+    if should_amend?
       logger.info "Posting amendments to Rummager: #{artefact_link}"
       search_index.amend artefact_link, artefact_hash
     else
@@ -66,8 +68,8 @@ class RummageableArtefact
     search_index.commit
   end
 
-  def should_amend
-    @artefact.indexable_content.nil?
+  def should_amend?
+    @artefact.indexable_content.nil? && FORMATS_NOT_TO_AMEND.exclude?(@artefact.kind)
   end
 
   def artefact_hash
@@ -79,7 +81,7 @@ class RummageableArtefact
 
     # When amending an artefact, requests with the "link" parameter will be
     # refused, because we can't amend the link within Rummager
-    rummageable_keys << "link" unless should_amend
+    rummageable_keys << "link" unless should_amend?
 
     result = {}
 

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -279,6 +279,18 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     rummageable_artefact.submit
   end
 
+  test "adds a rummageable artefact for specialist sectors without indexable content" do
+    artefact = build(:artefact, kind: "specialist_sector", indexable_content: nil)
+    rummageable_artefact = RummageableArtefact.new(artefact)
+
+    stub_search_index = stub("Rummageable::Index")
+    SearchIndex.expects(:instance).returns(stub_search_index)
+
+    stub_search_index.expects(:amend).with(rummageable_artefact.artefact_link, rummageable_artefact.artefact_hash).never
+    stub_search_index.expects(:add).with(rummageable_artefact.artefact_hash)
+    rummageable_artefact.submit
+  end
+
   test "amends a rummageable artefact without indexable content" do
     artefact = build(:artefact, indexable_content: nil)
     rummageable_artefact = RummageableArtefact.new(artefact)


### PR DESCRIPTION
When a new specialist sector artefact is created, Rummager needs to
register it instead of trying to update an existing artefact.

Since the specialist sector artefacts are created with an empty
indexable content attribute, an amend request was being sent out to
Rummager.

This PR adds the "specialist_sector" artefact kind to a FORMATS_NOT_TO_AMEND
constant, thus making sure that the correct request is sent to Rummager.
Since there are no cases in which specialist sector artefacts should
send an amend request to Rummager, this solution should not bring any
adverse side effects.

Renames `RummageableArtefact#should_amend` method to `should_amend?`

According to the style guide, predicate methods should end in a question mark
