### PR TITLE
Add a workflow to publish tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "13.4.0"
+  gem "govuk_content_models", "16.0.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (13.4.0)
+    govuk_content_models (16.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.2.2)
   gelf
-  govuk_content_models (= 13.4.0)
+  govuk_content_models (= 16.0.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -107,3 +107,8 @@ ul.tags-list {
   padding-right: 4px;
   font-family: monospace;
 }
+
+.take-care {
+  @extend .alert;
+  @extend .alert-info;
+}

--- a/app/assets/stylesheets/tags.scss
+++ b/app/assets/stylesheets/tags.scss
@@ -12,6 +12,15 @@
 ul.tags-list {
   margin: 0;
 
+  .draft {
+    background: #d53880;
+    padding: 1px 6px 0px;
+    color: #fff;
+    display: inline-block;
+    margin-left: 4px;
+    font-size: 14px;
+  }
+
   li.parent-tag {
     list-style: none;
     display: block;
@@ -71,6 +80,10 @@ ul.tags-list {
     margin: 0px;
     padding: 8px;
     position: relative;
+
+    .draft {
+      font-size: 13px;
+    }
 
     a.tag-id {
       font-size: 13px;

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -43,6 +43,7 @@ class ArtefactsController < ApplicationController
   end
 
   def edit
+    @artefact_form = ArtefactForm.new(@artefact)
   end
 
   def create
@@ -88,6 +89,7 @@ class ArtefactsController < ApplicationController
         if saved && (continue_editing || (@artefact.owning_app != "publisher"))
           redirect_to edit_artefact_path(@artefact)
         else
+          @artefact_form = ArtefactForm.new(@artefact)
           respond_with @artefact, status: status_to_use
         end
       end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -3,7 +3,7 @@ class TagsController < ApplicationController
   TAG_TYPES = ['section', 'specialist_sector']
 
   before_filter :require_tags_permission
-  before_filter :find_tag, only: [:edit, :update]
+  before_filter :find_tag, only: [:edit, :update, :publish]
   helper_method :artefacts_in_section
 
   def index
@@ -55,7 +55,17 @@ class TagsController < ApplicationController
     end
   end
 
-  private
+  def publish
+    if @tag.draft?
+      @tag.publish!
+      flash[:notice] = 'Tag has been published'
+    else
+      flash[:error] = 'Tag is already live'
+    end
+    redirect_to edit_tag_path(@tag)
+  end
+
+private
   def require_tags_permission
     authorise_user!("manage_tags")
   end

--- a/app/forms/artefact_form.rb
+++ b/app/forms/artefact_form.rb
@@ -1,0 +1,26 @@
+class ArtefactForm < BasicObject
+  def initialize(object)
+    @artefact = object
+  end
+
+  def specialist_sector_ids
+    artefact.specialist_sector_ids(draft: true)
+  end
+
+  def specialist_sectors
+    artefact.specialist_sectors(draft: true)
+  end
+
+  def to_model
+    self
+  end
+
+  alias_method :send, :__send__
+
+private
+  attr_reader :artefact
+
+  def method_missing(method, *args, &block)
+    artefact.send(method, *args, &block)
+  end
+end

--- a/app/forms/artefact_form.rb
+++ b/app/forms/artefact_form.rb
@@ -11,6 +11,14 @@ class ArtefactForm < BasicObject
     artefact.specialist_sectors(draft: true)
   end
 
+  def sections
+    artefact.sections(draft: true)
+  end
+
+  def section_ids
+    artefact.section_ids(draft: true)
+  end
+
   def to_model
     self
   end

--- a/app/forms/specialist_sector_tag_form.rb
+++ b/app/forms/specialist_sector_tag_form.rb
@@ -40,7 +40,7 @@ private
       kind: "specialist_sector",
       owning_app: "panopticon",
       rendering_app: "collections",
-      state: "live"
+      state: tag.state,
     }
   end
 

--- a/app/observers/update_specialist_sector_tag_artefact_observer.rb
+++ b/app/observers/update_specialist_sector_tag_artefact_observer.rb
@@ -8,6 +8,6 @@ class UpdateSpecialistSectorTagArtefactObserver < Mongoid::Observer
 private
   def update_artefact(tag)
     artefact = Artefact.where(kind: 'specialist_sector', slug: tag.tag_id).first
-    artefact.update_attributes(name: tag.title) if artefact
+    artefact.update_attributes(name: tag.title, state: tag.state) if artefact
   end
 end

--- a/app/views/artefacts/edit.html.erb
+++ b/app/views/artefacts/edit.html.erb
@@ -4,5 +4,5 @@
 <% if "whitehall" == @artefact.owning_app %>
   <%= render 'whitehall_form', artefact: @artefact, tag_collection: @tag_collection %>
 <% else %>
-  <%= render 'form', artefact: @artefact, tag_collection: @tag_collection %>
+  <%= render 'form', artefact: @artefact_form, tag_collection: @tag_collection %>
 <% end %>

--- a/app/views/tags/_curated_list.html.erb
+++ b/app/views/tags/_curated_list.html.erb
@@ -1,26 +1,22 @@
-<div class="row-fluid">
-  <div class="span10">
-    <div class="well">
-      <%= f.inputs do %>
-        <label class="section-label">Curated artefacts <span class="hint">(click and drag to reorder)</span></label>
-        <p>The artefacts you choose will appear at the top of the section’s browse page. Any other artefacts in the section will appear below them.</p>
+<div class="well">
+  <%= f.inputs do %>
+    <label class="section-label">Curated artefacts <span class="hint">(click and drag to reorder)</span></label>
+    <p>The artefacts you choose will appear at the top of the section’s browse page. Any other artefacts in the section will appear below them.</p>
 
-        <div class="curated-artefact-group">
-          <% if @curated_list.usable_artefacts.any? %>
-            <% @curated_list.usable_artefacts.each do |artefact| %>
-              <%= render :partial => 'curated_artefact', :locals => { artefact_id: artefact.id, is_template: false } %>
-            <% end %>
-          <% else %>
-            <%= render :partial => 'curated_artefact', :locals => { artefact_id: nil, is_template: false } %>
-          <% end %>
-        </div>
-
-        <%= render :partial => 'curated_artefact', :locals => { artefact_id: nil, is_template: true } %>
-
-        <button id="add-curated-artefact" class="btn btn-success" type="button">Add another artefact</button>
+    <div class="curated-artefact-group">
+      <% if @curated_list.usable_artefacts.any? %>
+        <% @curated_list.usable_artefacts.each do |artefact| %>
+          <%= render :partial => 'curated_artefact', :locals => { artefact_id: artefact.id, is_template: false } %>
+        <% end %>
+      <% else %>
+        <%= render :partial => 'curated_artefact', :locals => { artefact_id: nil, is_template: false } %>
       <% end %>
     </div>
-  </div>
+
+    <%= render :partial => 'curated_artefact', :locals => { artefact_id: nil, is_template: true } %>
+
+    <button id="add-curated-artefact" class="btn btn-success" type="button">Add another artefact</button>
+  <% end %>
 </div>
 
 <%= content_for :extra_javascript do %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -27,7 +27,7 @@
         </div>
       <% end %>
 
-      <div class="well" style="clear: both">
+      <div class="well">
         <%= f.input :title, input_html: { class: "span5" } %>
 
         <%= f.input :description, as: :text,

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -3,7 +3,12 @@
   <div class="artefact-title">
     <h1><%= @tag.tag_type.humanize %>: <%= @tag.title %></h1>
     <h2>
-      <%= link_to public_tag_path(@tag), public_tag_url(@tag) %>
+      <% if @tag.live? %>
+        <%= link_to public_tag_path(@tag), public_tag_url(@tag) %>
+      <% else %>
+        <%= public_tag_path(@tag) %>
+      <% end %>
+      <span class="state state-<%= @tag.state %>"><%= @tag.state %></span>
     </h2>
   </div>
 </header>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -56,3 +56,7 @@
     <%= f.submit :value => "Save this #{@tag.tag_type.humanize.downcase}", :class => "btn btn-primary" %>
   </div>
 <% end %>
+
+<% if @tag.can_publish? %>
+  <%= button_to "Publish this #{@tag.tag_type.humanize.downcase}", publish_tag_path, method: :put %>
+<% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -45,7 +45,12 @@
     <%= render partial: 'curated_list', locals: { f: f } %>
   <% end %>
 
-  <div class="alert alert-info">Take care! All changes to tags appear immediately to users. If you're not sure what you're doing, please ask a developer.</div>
+  <% if @tag.live? %>
+    <div class="take-care">
+      Take care! This change will appear immediately to users.
+      If you're not sure about something, please ask a developer.
+    </div>
+  <% end %>
 
   <div class="form-actions">
     <%= f.submit :value => "Save this #{@tag.tag_type.humanize.downcase}", :class => "btn btn-primary" %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -13,21 +13,21 @@
   </div>
 </header>
 
-<%= semantic_form_for @tag do |f| %>
-  <% if f.object.errors.count > 0 %>
-    <div class="form-errors">
-      <ul>
-        <% f.object.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<div class="row-fluid">
+  <div class="span9">
 
-  <div class="row-fluid">
-    <div class="span10">
+    <%= semantic_form_for @tag do |f| %>
+      <% if f.object.errors.count > 0 %>
+        <div class="form-errors">
+          <ul>
+            <% f.object.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
-      <div class="well">
+      <div class="well" style="clear: both">
         <%= f.input :title, input_html: { class: "span5" } %>
 
         <%= f.input :description, as: :text,
@@ -37,26 +37,31 @@
                                   }
                                   %>
       </div>
-    </div>
+
+      <% if @curated_list.present? %>
+        <%= render partial: 'curated_list', locals: { f: f } %>
+      <% end %>
+
+      <% if @tag.live? %>
+        <div class="take-care">
+          Take care! This change will appear immediately to users.
+          If you're not sure about something, please ask a developer.
+        </div>
+      <% end %>
+
+      <div class="form-actions">
+        <%= f.submit :value => "Save this #{@tag.tag_type.humanize.downcase}", :class => "btn btn-primary" %>
+      </div>
+    <% end %>
   </div>
 
+  <div class="span3">
+    <% if @tag.can_publish? %>
+      <div class="well">
+        <p>Publishing this tag will make it appear live on the site to users. Once you publish a tag, it can't be unpublished.</p>
 
-  <% if @curated_list.present? %>
-    <%= render partial: 'curated_list', locals: { f: f } %>
-  <% end %>
-
-  <% if @tag.live? %>
-    <div class="take-care">
-      Take care! This change will appear immediately to users.
-      If you're not sure about something, please ask a developer.
-    </div>
-  <% end %>
-
-  <div class="form-actions">
-    <%= f.submit :value => "Save this #{@tag.tag_type.humanize.downcase}", :class => "btn btn-primary" %>
+        <%= button_to "Publish this #{@tag.tag_type.humanize.downcase}", publish_tag_path, method: :put, class: 'btn btn-danger' %>
+      </div>
+    <% end %>
   </div>
-<% end %>
-
-<% if @tag.can_publish? %>
-  <%= button_to "Publish this #{@tag.tag_type.humanize.downcase}", publish_tag_path, method: :put %>
-<% end %>
+</div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -13,7 +13,13 @@
   <% @parents.each do |parent, children| %>
     <li class="parent-tag">
       <div class="details">
-        <h2><span class="tag-type"><%= parent.tag_type.humanize %>:</span> <%= parent.title %></h2>
+        <h2>
+          <span class="tag-type"><%= parent.tag_type.humanize %>:</span>
+          <%= parent.title %>
+          <% if parent.draft? %>
+            <span class="draft">draft</span>
+          <% end %>
+        </h2>
         <div class="actions">
           <%= link_to new_tag_path(type: parent.tag_type, parent_id: parent.tag_id), class: 'btn' do %>
             <i class="icon-plus"></i> Add child tag
@@ -28,6 +34,9 @@
             <h3>
               <%= link_to tag.title, edit_tag_path(tag) %>
               <%= link_to tag.tag_id, public_tag_url(tag), class: 'tag-id' %>
+              <% if tag.draft? %>
+                <span class="draft">draft</span>
+              <% end %>
             </h3>
             <div class="actions">
               <%= link_to 'Edit tag', edit_tag_path(tag), class: 'btn' %>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -64,8 +64,6 @@
     </div>
   </div>
 
-  <div class="alert alert-info">Take care! All changes to tags appear immediately to users. If you're not sure what you're doing, please ask a developer.</div>
-
   <div class="form-actions">
     <%= f.submit :value => "Create tag", :class => "btn btn-primary" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,12 @@ Panopticon::Application.routes.draw do
       get :search_relatable_items, constraints: { format: :json }
     end
   end
-  resources :tags
+  
+  resources :tags do
+    member do
+      put :publish
+    end
+  end
 
   root :to => redirect("/artefacts")
 end

--- a/features/managing_tags.feature
+++ b/features/managing_tags.feature
@@ -4,6 +4,7 @@ Feature: Managing tags
     Given I am a user who can edit tags
     When I create a new tag
     Then the tag should appear in the list
+    And the tag should be marked as draft in the list
 
   Scenario: Editing a tag
     Given I am a user who can edit tags

--- a/features/managing_tags.feature
+++ b/features/managing_tags.feature
@@ -11,3 +11,9 @@ Feature: Managing tags
     And a tag exists
     When I edit the tag
     Then the updated tag should appear in the list
+
+  Scenario: Publishing a tag
+    Given I am a user who can edit tags
+    And a draft tag exists
+    When I publish the tag
+    Then the tag should appear as live

--- a/features/step_definitions/tags_steps.rb
+++ b/features/step_definitions/tags_steps.rb
@@ -2,6 +2,10 @@ Given /^a tag exists$/ do
   @tag = create(:tag)
 end
 
+Given /^a draft tag exists$/ do
+  @tag = create(:draft_tag)
+end
+
 When /^I create a new tag$/ do
   visit new_tag_path
   fill_in_tag_attributes_in_form
@@ -12,6 +16,11 @@ When /^I edit the tag$/ do
   visit edit_tag_path(@tag)
   fill_in_updated_tag_attributes_in_form
   click_on "Save"
+end
+
+When /^I publish the tag$/ do
+  visit edit_tag_path(@tag)
+  click_on "Publish"
 end
 
 Then /^the tag should appear in the list$/ do
@@ -27,4 +36,9 @@ end
 Then /^the tag should be marked as draft in the list$/ do
   visit tags_path
   assert_draft_tag_in_list
+end
+
+Then /^the tag should appear as live$/ do
+  visit edit_tag_path(@tag)
+  assert_state_on_edit_form 'live'
 end

--- a/features/step_definitions/tags_steps.rb
+++ b/features/step_definitions/tags_steps.rb
@@ -23,3 +23,8 @@ Then /^the updated tag should appear in the list$/ do
   visit tags_path
   assert_updated_tag_present_in_list
 end
+
+Then /^the tag should be marked as draft in the list$/ do
+  visit tags_path
+  assert_draft_tag_in_list
+end

--- a/features/support/sections.rb
+++ b/features/support/sections.rb
@@ -1,7 +1,7 @@
 require 'govuk_content_models/test_helpers/factories'
 
 def create_section
-  FactoryGirl.create(:tag,
+  FactoryGirl.create(:live_tag,
     tag_id: "crime",
     tag_type: "section",
     title: "Crime"
@@ -10,7 +10,7 @@ end
 
 def create_sections
   section = create_section
-  subsection = FactoryGirl.create(:tag,
+  subsection = FactoryGirl.create(:live_tag,
     tag_id: "crime/batman",
     tag_type: "section",
     title: "Batman",

--- a/features/support/tags_helper.rb
+++ b/features/support/tags_helper.rb
@@ -27,6 +27,10 @@ module TagsHelper
       assert page.has_selector?(".draft", text: "draft")
     end
   end
+
+  def assert_state_on_edit_form(state)
+    assert page.has_selector?(".state-#{state}", text: state)
+  end
 end
 
 World(TagsHelper)

--- a/features/support/tags_helper.rb
+++ b/features/support/tags_helper.rb
@@ -21,6 +21,12 @@ module TagsHelper
       assert page.has_content? "Section: Driving"
     end
   end
+
+  def assert_draft_tag_in_list
+    within ".tags-list li:first" do
+      assert page.has_selector?(".draft", text: "draft")
+    end
+  end
 end
 
 World(TagsHelper)

--- a/lib/importers/mainstream_organisation_tag_importer.rb
+++ b/lib/importers/mainstream_organisation_tag_importer.rb
@@ -35,7 +35,7 @@ module Importers
         need['organisation_ids']
       }.flatten
 
-      organisation_ids = (artefact.organisation_ids + organisation_ids_to_add).uniq
+      organisation_ids = (artefact.organisation_ids(draft: true) + organisation_ids_to_add).uniq
 
       artefact.organisation_ids = organisation_ids
       artefact.save

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -22,23 +22,32 @@ class OrganisationImporter
     existing_tag = Tag.where(tag_type: TAG_TYPE, tag_id: tag_id).first
 
     if existing_tag.present?
+      logger.info "Found existing tag: #{tag_id}"
+
       if existing_tag.title != organisation.title
         if existing_tag.update_attributes(title: organisation.title)
-          logger.info "Found existing tag: #{tag_id}; updated title to '#{existing_tag.title}'"
+          logger.info "Updated title to '#{existing_tag.title}'"
         else
           log_error_and_notify_airbrake(organisation,
-                                        "Found existing tag: #{tag_id}; could not update title: #{existing_tag.errors.full_messages}")
+                                        "Could not update title: #{existing_tag.errors.full_messages}")
         end
-      else
-        logger.info "Found existing tag: #{tag_id}"
+      end
+
+      if existing_tag.draft?
+        if existing_tag.publish
+          logger.info "Published tag"
+        else
+          log_error_and_notify_airbrake(organisation,
+                                        "Could not publish tag: #{existing_tag.errors.full_messages}")
+        end
       end
     else
       new_tag = Tag.new(tag_type: TAG_TYPE,
                         tag_id: tag_id,
                         title: organisation.title)
 
-      if new_tag.save
-        logger.info "Created organisation tag: #{tag_id}"
+      if new_tag.save && new_tag.publish
+        logger.info "Created and published organisation tag: #{tag_id}"
       else
         log_error_and_notify_airbrake(organisation,
                                       "Could not create organisation tag: #{tag_id} - #{new_tag.errors.full_messages}")

--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -46,11 +46,19 @@ class OrganisationImporter
                         tag_id: tag_id,
                         title: organisation.title)
 
-      if new_tag.save && new_tag.publish
-        logger.info "Created and published organisation tag: #{tag_id}"
+      logger.info "Creating organisation tag: #{tag_id}"
+
+      if new_tag.save
+        logger.info "Created tag"
+        if new_tag.publish
+          logger.info "Published tag"
+        else
+          log_error_and_notify_airbrake(organisation,
+                                        "Could not publish tag: #{new_tag.errors.full_messages}")
+        end
       else
         log_error_and_notify_airbrake(organisation,
-                                      "Could not create organisation tag: #{tag_id} - #{new_tag.errors.full_messages}")
+                                      "Could not create tag: #{new_tag.errors.full_messages}")
       end
     end
   end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -230,10 +230,10 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "assign list of sections" do
-        FactoryGirl.create(:tag, :tag_type => 'section', :tag_id => 'kablooey', :title => 'Kablooey')
-        FactoryGirl.create(:tag, :tag_type => 'section', :tag_id => 'fooey', :title => 'Fooey')
-        FactoryGirl.create(:tag, :tag_type => 'section', :tag_id => 'gooey', :title => 'Gooey')
-        FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
+        FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'kablooey', :title => 'Kablooey')
+        FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'fooey', :title => 'Fooey')
+        FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'gooey', :title => 'Gooey')
+        FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
 
         artefact = FactoryGirl.create(:artefact)
 
@@ -380,7 +380,7 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "Include section ID" do
-        FactoryGirl.create(:tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
+        FactoryGirl.create(:live_tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
         artefact = Artefact.create! :slug => 'whatever', :kind => 'guide', :owning_app => 'publisher', :name => 'Whatever', :need_ids => ['100001']
         artefact.sections = ['crime']
         artefact.save!
@@ -391,8 +391,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "Include tag_ids" do
-        FactoryGirl.create(:tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
-        FactoryGirl.create(:tag, :tag_id => 'businesslink', :tag_type => 'legacy_source', :title => 'Business Link')
+        FactoryGirl.create(:live_tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
+        FactoryGirl.create(:live_tag, :tag_id => 'businesslink', :tag_type => 'legacy_source', :title => 'Business Link')
         artefact = Artefact.create! :slug => 'whatever', :kind => 'guide', :owning_app => 'publisher', :name => 'Whatever', :need_ids => ['100001']
         artefact.sections = ['crime']
         artefact.legacy_sources = ['businesslink']
@@ -440,8 +440,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "Update our primary section and ensure it persists into sections" do
-        tag1 = FactoryGirl.create(:tag, tag_id: "crime", title: "Crime", tag_type: "section")
-        tag2 = FactoryGirl.create(:tag, tag_id: "education", title: "Education", tag_type: "section")
+        tag1 = FactoryGirl.create(:live_tag, tag_id: "crime", title: "Crime", tag_type: "section")
+        tag2 = FactoryGirl.create(:live_tag, tag_id: "education", title: "Education", tag_type: "section")
 
         artefact = Artefact.create!(:slug => 'whatever', :kind => 'guide',
                                     :owning_app => 'publisher', :name => 'Whatever', :need_ids => ['100001'])
@@ -455,8 +455,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "Update the specialist sectors and ensure it persists into tags" do
-        tag1 = FactoryGirl.create(:tag, tag_id: "fizzy-drinks", title: "Fizzy drinks", tag_type: "specialist_sector")
-        tag2 = FactoryGirl.create(:tag, tag_id: "confectionery", title: "Confectionery", tag_type: "specialist_sector")
+        tag1 = FactoryGirl.create(:live_tag, tag_id: "fizzy-drinks", title: "Fizzy drinks", tag_type: "specialist_sector")
+        tag2 = FactoryGirl.create(:live_tag, tag_id: "confectionery", title: "Confectionery", tag_type: "specialist_sector")
 
         artefact = Artefact.new(:slug => 'a-history-of-chocolate', :kind => 'guide',
                                     :owning_app => 'publisher', :name => 'A history of chocolate', :need_ids => ['100001'])

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -278,4 +278,25 @@ class TagsControllerTest < ActionController::TestCase
     end
   end
 
+  context 'PUT publish' do
+    should 'publish a draft tag' do
+      tag = create(:draft_tag)
+      Tag.any_instance.expects(:publish!).returns(true)
+
+      put :publish, id: tag.id
+
+      assert_match /published/, @controller.flash[:notice]
+      assert_redirected_to edit_tag_path(tag)
+    end
+
+    should 'redirect with an error for a live tag' do
+      tag = create(:live_tag)
+
+      put :publish, id: tag.id
+
+      assert_match /already live/, @controller.flash[:error]
+      assert_redirected_to edit_tag_path(tag)
+    end
+  end
+
 end

--- a/test/integration/artefact_search_indexing_test.rb
+++ b/test/integration/artefact_search_indexing_test.rb
@@ -45,17 +45,17 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
     @artefact = FactoryGirl.create(:artefact, kind: "answer", slug: "new-enterprise-allowance", state: "live")
 
     RummageableArtefact.any_instance.expects(:submit)
-    RummageableArtefact.any_instance.expects(:delete).never 
+    RummageableArtefact.any_instance.expects(:delete).never
     @artefact.kind = "business_support"
     @artefact.save!
   end
 
   test "should request an amend to the search index, with a slug and an hash of the artefact attributes to be indexed" do
-    FactoryGirl.create(:tag, tag_type: "section", tag_id: "a-section", title: "A Section")
-    FactoryGirl.create(:tag, tag_type: "section", tag_id: "a-section/subsection", title: "A Subsection", parent_id: "a-section")
-    FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "a-section", title: "A Section")
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "a-section/subsection", title: "A Subsection", parent_id: "a-section")
+    FactoryGirl.create(:live_tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
                        parent_id: "working-sea")
 
     new_artefact = FactoryGirl.build(

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -262,6 +262,149 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context 'editing sections' do
+    setup do
+      # use javascript for the section tests
+      Capybara.current_driver = Capybara.javascript_driver
+
+      FactoryGirl.create(:live_tag, tag_type: 'section', tag_id: 'visas-immigration', title: 'Visas and immigration')
+      FactoryGirl.create(:live_tag, tag_type: 'section', tag_id: 'visas-immigration/student-visas', title: 'Student visas', parent_id: 'visas-immigration')
+
+      @artefact = FactoryGirl.create(:artefact, :name => 'VAT')
+    end
+
+    should 'allow adding sections to artefacts' do
+      visit "/artefacts"
+      click_on "VAT"
+
+      within '.section-tags' do
+        assert page.has_selector?('div.nested-item', count: 1)
+
+        within '.nested-item-group div:nth-of-type(1)' do
+          assert page.has_select?('artefact[sections][]',
+            options: ['Select a section', 'Student visas', 'Visas and immigration'],
+          )
+
+          select 'Student visas', :from => 'artefact[sections][]'
+        end
+
+        click_on 'Add another section'
+
+        within '.nested-item-group div:nth-of-type(2)' do
+          assert page.has_select?('artefact[sections][]',
+            options: ['Select a section', 'Student visas', 'Visas and immigration'],
+          )
+
+          select 'Visas and immigration', :from => 'artefact[sections][]'
+        end
+      end
+
+      click_on 'Save and continue editing'
+
+      @artefact.reload
+
+      assert_equal 'visas-immigration/student-visas', @artefact.primary_section.tag_id
+      assert_equal ['visas-immigration/student-visas', 'visas-immigration'], @artefact.section_ids
+    end
+
+    should 'allow removing sections from artefacts' do
+      @artefact.section_ids = ['visas-immigration/student-visas', 'visas-immigration']
+      @artefact.save!
+
+      visit '/artefacts'
+      click_on 'VAT'
+
+      within '.section-tags' do
+        assert page.has_selector?('div.nested-item', count: 2)
+
+        within '.nested-item-group div:nth-of-type(1)' do
+          assert page.has_select?('artefact[sections][]',
+            options: ['Select a section', 'Student visas', 'Visas and immigration'],
+            selected: 'Student visas',
+          )
+        end
+
+        within '.nested-item-group div:nth-of-type(2)' do
+          assert page.has_select?('artefact[sections][]',
+            options: ['Select a section', 'Student visas', 'Visas and immigration'],
+            selected: 'Visas and immigration',
+          )
+        end
+
+        # delete the first section
+        within '.nested-item-group div:nth-of-type(1)' do
+          click_on 'Remove this section'
+        end
+      end
+
+      click_on 'Save and continue editing'
+
+      @artefact.reload
+      assert_equal 'visas-immigration', @artefact.primary_section.tag_id
+      assert_equal ['visas-immigration'], @artefact.section_ids
+    end
+
+    context 'draft sections' do
+      setup do
+        FactoryGirl.create(:draft_tag, tag_type: 'section', tag_id: 'visas-immigration/family-visas', title: 'Family visas', parent_id: 'visas-immigration')
+      end
+
+      should 'allow tagging draft sections to artefacts' do
+        visit '/artefacts'
+        click_on 'VAT'
+
+        within '.section-tags' do
+          assert page.has_select?('artefact[sections][]',
+            options: ['Select a section', 'Family visas', 'Student visas', 'Visas and immigration'],
+          )
+
+          select 'Family visas', :from => 'artefact[sections][]'
+        end
+
+        click_on 'Save and continue editing'
+
+        @artefact.reload
+        assert_equal ['visas-immigration/family-visas'], @artefact.section_ids(true)
+      end
+
+      should 'allow removal of draft sections from artefacts' do
+        @artefact.section_ids = ['visas-immigration/student-visas', 'visas-immigration/family-visas']
+        @artefact.save!
+
+        visit '/artefacts'
+        click_on 'VAT'
+
+        within '.section-tags' do
+          assert page.has_selector?('div.nested-item', count: 2)
+
+          within '.nested-item-group div:nth-of-type(1)' do
+            assert page.has_select?('artefact[sections][]',
+              options: ['Select a section', 'Family visas', 'Student visas', 'Visas and immigration'],
+              selected: 'Student visas',
+            )
+          end
+
+          within '.nested-item-group div:nth-of-type(2)' do
+            assert page.has_select?('artefact[sections][]',
+              options: ['Select a section', 'Family visas', 'Student visas', 'Visas and immigration'],
+              selected: 'Family visas',
+            )
+          end
+
+          # delete the second (draft) section
+          within '.nested-item-group div:nth-of-type(2)' do
+            click_on 'Remove this section'
+          end
+        end
+
+        click_on 'Save and continue editing'
+
+        @artefact.reload
+        assert_equal ['visas-immigration/student-visas'], @artefact.section_ids(true)
+      end
+    end
+  end
+
   context "editing organisations" do
     setup do
       FactoryGirl.create(:live_tag, tag_type: 'organisation', tag_id: 'hm-revenue-customs', title: 'HM Revenue and Customs')

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -9,9 +9,9 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
   context "editing a publisher artefact" do
     setup do
-      FactoryGirl.create(:tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
-      FactoryGirl.create(:tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
-      FactoryGirl.create(:tag, tag_type: "legacy_source", tag_id: "businesslink", parent_id: nil, title: "Business Link")
+      FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
+      FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
+      FactoryGirl.create(:live_tag, tag_type: "legacy_source", tag_id: "businesslink", parent_id: nil, title: "Business Link")
 
       @artefact = FactoryGirl.create(:artefact,
                                      name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
@@ -136,9 +136,9 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
   context "editing legacy_sources" do
     setup do
-      @bl   = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
-      @dg   = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'directgov', :title => 'Directgov')
-      @dvla = FactoryGirl.create(:tag, :tag_type => 'legacy_source', :tag_id => 'dvla', :title => 'DVLA')
+      @bl   = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
+      @dg   = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'directgov', :title => 'Directgov')
+      @dvla = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'dvla', :title => 'DVLA')
       @a = FactoryGirl.create(:artefact, :name => "VAT")
     end
 
@@ -172,10 +172,10 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
   context "editing specialist_sectors" do
     setup do
-      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas/fields-and-wells', title: 'Fields and wells', parent_id: 'oil-and-gas')
-      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'charities', title: 'Charities')
-      FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'charities/starting-a-charity', title: 'Starting a charity', parent_id: 'charities')
+      FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas', title: 'Oil and gas')
+      FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas/fields-and-wells', title: 'Fields and wells', parent_id: 'oil-and-gas')
+      FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'charities', title: 'Charities')
+      FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'charities/starting-a-charity', title: 'Starting a charity', parent_id: 'charities')
 
       @artefact = FactoryGirl.create(:artefact, :name => "VAT")
     end
@@ -220,9 +220,9 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
   context "editing organisations" do
     setup do
-      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'hm-revenue-customs', title: 'HM Revenue and Customs')
-      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'driver-vehicle-licensing-agency', title: 'Driver and Vehicle Licensing Agency')
-      FactoryGirl.create(:tag, tag_type: 'organisation', tag_id: 'cabinet-office', title: 'Cabinet Office')
+      FactoryGirl.create(:live_tag, tag_type: 'organisation', tag_id: 'hm-revenue-customs', title: 'HM Revenue and Customs')
+      FactoryGirl.create(:live_tag, tag_type: 'organisation', tag_id: 'driver-vehicle-licensing-agency', title: 'Driver and Vehicle Licensing Agency')
+      FactoryGirl.create(:live_tag, tag_type: 'organisation', tag_id: 'cabinet-office', title: 'Cabinet Office')
 
       @artefact = FactoryGirl.create(:artefact, :name => "VAT")
     end

--- a/test/integration/artefacts_index_test.rb
+++ b/test/integration/artefacts_index_test.rb
@@ -101,8 +101,8 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
     end
 
     should "filter by section tag" do
-      FactoryGirl.create(:tag, tag_id: 'driving', tag_type: 'section', title: 'Driving')
-      FactoryGirl.create(:tag, tag_id: 'driving/learning-to-drive', tag_type: 'section', title: 'Learning to drive', parent_id: 'driving')
+      FactoryGirl.create(:live_tag, tag_id: 'driving', tag_type: 'section', title: 'Driving')
+      FactoryGirl.create(:live_tag, tag_id: 'driving/learning-to-drive', tag_type: 'section', title: 'Learning to drive', parent_id: 'driving')
 
       FactoryGirl.create(:artefact, name: 'VAT rates', slug: 'vat-rates', section_ids: [])
       FactoryGirl.create(:artefact, name: 'Guide to driving', slug: 'guide-to-driving', section_ids: ['driving'])
@@ -134,8 +134,8 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
     end
 
     should "filter by specialist_sector tag" do
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
+      FactoryGirl.create(:live_tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
+      FactoryGirl.create(:live_tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
 
       FactoryGirl.create(:artefact, name: 'Something else', slug: 'something-else', specialist_sector_ids: [])
       FactoryGirl.create(:artefact, name: 'Oil and gas licensing', slug: 'oil-and-gas-licensing', specialist_sector_ids: ['oil-and-gas'])
@@ -329,11 +329,11 @@ class ArtefactsIndexTest < ActionDispatch::IntegrationTest
     end
 
     should "filter by multiple tag criteria" do
-      FactoryGirl.create(:tag, tag_id: 'driving', tag_type: 'section', title: 'Driving')
-      FactoryGirl.create(:tag, tag_id: 'driving/learning-to-drive', tag_type: 'section', title: 'Learning to drive', parent_id: 'driving')
+      FactoryGirl.create(:live_tag, tag_id: 'driving', tag_type: 'section', title: 'Driving')
+      FactoryGirl.create(:live_tag, tag_id: 'driving/learning-to-drive', tag_type: 'section', title: 'Learning to drive', parent_id: 'driving')
 
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
-      FactoryGirl.create(:tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
+      FactoryGirl.create(:live_tag, tag_id: 'oil-and-gas', tag_type: 'specialist_sector', title: 'Oil and gas')
+      FactoryGirl.create(:live_tag, tag_id: 'oil-and-gas/wells', tag_type: 'specialist_sector', title: 'Wells', parent_id: 'oil-and-gas')
 
       FactoryGirl.create(:artefact, name: 'Motor incidents involving wells', specialist_sector_ids: ["oil-and-gas/wells"], section_ids: ["driving/learning-to-drive"])
       FactoryGirl.create(:artefact, name: 'Driving forward the oil and gas industry', specialist_sector_ids: ["oil-and-gas"], section_ids: ["driving"])

--- a/test/integration/editing_tags_test.rb
+++ b/test/integration/editing_tags_test.rb
@@ -28,13 +28,19 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
         assert page.has_selector?('.state-live', text: 'live')
       end
 
-      within 'form' do
+      within 'form.tag' do
         assert page.has_field?('Title', with: @tag.title)
         assert page.has_field?('Description', with: @tag.description)
         assert page.has_button?('Save this section')
       end
 
       assert page.has_selector?('.take-care')
+    end
+
+    should 'not display a publish button' do
+      visit edit_tag_path(@tag)
+
+      assert page.has_no_button?('Publish this section')
     end
 
     should 'display errors when a tag cannot be saved' do
@@ -104,17 +110,27 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
         assert page.has_selector?('.state-draft', text: 'draft')
       end
 
-      within 'form' do
+      within 'form.tag' do
         assert page.has_field?('Title', with: @tag.title)
         assert page.has_field?('Description', with: @tag.description)
         assert page.has_button?('Save this section')
       end
+
+      assert page.has_button?('Publish this section')
     end
 
     should 'not display a "Take care!" notice' do
       visit edit_tag_path(@tag)
 
       assert page.has_no_selector?('.take-care')
+    end
+
+    should 'display a notice when the tag is published' do
+      visit edit_tag_path(@tag)
+
+      click_on 'Publish this section'
+
+      assert page.has_content? 'Tag has been published'
     end
   end
 

--- a/test/integration/editing_tags_test.rb
+++ b/test/integration/editing_tags_test.rb
@@ -9,72 +9,105 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
     # fire off a bunch of web requests
     stub_all_router_api_requests
     stub_all_rummager_requests
-
-    @tag = create(:tag, tag_type: 'section',
-                        tag_id: 'driving',
-                        title: 'Driving',
-                        description: 'Car tax, MOTs and driving licences')
   end
 
-  should 'display the form for an existing tag' do
-    visit edit_tag_path(@tag)
-
-    within "header.artefact-header" do
-      assert page.has_content?('Section: Driving')
-      assert page.has_link?('/browse/driving', href: 'http://www.dev.gov.uk/browse/driving')
+  context 'editing a live tag' do
+    setup do
+      @tag = create(:live_tag, tag_type: 'section',
+                               tag_id: 'driving',
+                               title: 'Driving',
+                               description: 'Car tax, MOTs and driving licences')
     end
 
-    within 'form' do
-      assert page.has_field?('Title', with: @tag.title)
-      assert page.has_field?('Description', with: @tag.description)
-      assert page.has_button?('Save this section')
-    end
-  end
+    should 'display the form' do
+      visit edit_tag_path(@tag)
 
-  should 'display errors when a tag cannot be saved' do
-    visit edit_tag_path(@tag)
+      within "header.artefact-header" do
+        assert page.has_content?('Section: Driving')
+        assert page.has_link?('/browse/driving', href: 'http://www.dev.gov.uk/browse/driving')
+        assert page.has_selector?('.state-live', text: 'live')
+      end
 
-    fill_in 'Title', with: ''
-    click_on 'Save this section'
-
-    assert page.has_content? "Title can't be blank"
-  end
-
-  should 'display a notice when the tag is saved' do
-    visit edit_tag_path(@tag)
-
-    click_on 'Save this section'
-
-    assert page.has_content? 'Tag has been updated'
-  end
-
-  should 'show the curated list for a tag' do
-    child_tag = create(:tag, title: 'MOT',
-                             tag_id: 'driving/mot',
-                             tag_type: 'section',
-                             parent_id: 'driving')
-    artefacts = create_list(:live_artefact, 5, kind: 'answer',
-                                               section_ids: [child_tag.tag_id])
-    curated_list = create(:curated_list, slug: child_tag.tag_id.gsub('/','-'),
-                                         tag_ids: [child_tag.tag_id],
-                                         artefact_ids: artefacts.map(&:id))
-
-    visit edit_tag_path(child_tag)
-
-    within ".curated-artefact-group" do
-      assert page.has_selector?('.curated-artefact', count: 5)
-
-      artefacts.each_with_index do |artefact, i|
-        selector = ".curated-artefact:nth-of-type(#{i+1})"
-
-        within(selector) do
-          assert page.has_select?('curated_list[artefact_ids][]', selected: artefact.name)
-          assert page.has_button?('Remove curated item')
-        end
+      within 'form' do
+        assert page.has_field?('Title', with: @tag.title)
+        assert page.has_field?('Description', with: @tag.description)
+        assert page.has_button?('Save this section')
       end
     end
 
-    assert page.has_button?('Add another artefact')
+    should 'display errors when a tag cannot be saved' do
+      visit edit_tag_path(@tag)
+
+      fill_in 'Title', with: ''
+      click_on 'Save this section'
+
+      assert page.has_content? "Title can't be blank"
+    end
+
+    should 'display a notice when the tag is saved' do
+      visit edit_tag_path(@tag)
+
+      click_on 'Save this section'
+
+      assert page.has_content? 'Tag has been updated'
+    end
+
+    should 'show the curated list for a tag' do
+      child_tag = create(:tag, title: 'MOT',
+                               tag_id: 'driving/mot',
+                               tag_type: 'section',
+                               parent_id: 'driving')
+      artefacts = create_list(:live_artefact, 5, kind: 'answer',
+                                                 section_ids: [child_tag.tag_id])
+      curated_list = create(:curated_list, slug: child_tag.tag_id.gsub('/','-'),
+                                           tag_ids: [child_tag.tag_id],
+                                           artefact_ids: artefacts.map(&:id))
+
+      visit edit_tag_path(child_tag)
+
+      within ".curated-artefact-group" do
+        assert page.has_selector?('.curated-artefact', count: 5)
+
+        artefacts.each_with_index do |artefact, i|
+          selector = ".curated-artefact:nth-of-type(#{i+1})"
+
+          within(selector) do
+            assert page.has_select?('curated_list[artefact_ids][]', selected: artefact.name)
+            assert page.has_button?('Remove curated item')
+          end
+        end
+      end
+
+      assert page.has_button?('Add another artefact')
+    end
+  end # given an existing live tag
+
+  context 'editing a draft tag' do
+    setup do
+      @tag = create(:draft_tag, tag_type: 'section',
+                                tag_id: 'driving',
+                                title: 'Driving',
+                                description: 'Car tax, MOTs and driving licences')
+    end
+
+    should 'display the form' do
+      visit edit_tag_path(@tag)
+
+      within 'header.artefact-header' do
+        assert page.has_content?('Section: Driving')
+
+        assert page.has_no_link?('/browse/driving')
+        assert page.has_content?('/browse/driving')
+
+        assert page.has_selector?('.state-draft', text: 'draft')
+      end
+
+      within 'form' do
+        assert page.has_field?('Title', with: @tag.title)
+        assert page.has_field?('Description', with: @tag.description)
+        assert page.has_button?('Save this section')
+      end
+    end
   end
 
 end

--- a/test/integration/editing_tags_test.rb
+++ b/test/integration/editing_tags_test.rb
@@ -33,6 +33,8 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
         assert page.has_field?('Description', with: @tag.description)
         assert page.has_button?('Save this section')
       end
+
+      assert page.has_selector?('.take-care')
     end
 
     should 'display errors when a tag cannot be saved' do
@@ -107,6 +109,12 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
         assert page.has_field?('Description', with: @tag.description)
         assert page.has_button?('Save this section')
       end
+    end
+
+    should 'not display a "Take care!" notice' do
+      visit edit_tag_path(@tag)
+
+      assert page.has_no_selector?('.take-care')
     end
   end
 

--- a/test/integration/listing_tags_test.rb
+++ b/test/integration/listing_tags_test.rb
@@ -7,12 +7,12 @@ class ListingTagsTest < ActionDispatch::IntegrationTest
   end
 
   should "display tags in alphabetical order grouped by their parent" do
-    business = create(:tag, tag_id: "business", title: "Business", tag_type: "section")
+    business = create(:live_tag, tag_id: "business", title: "Business", tag_type: "section")
     children = [
-      create(:tag, tag_id: "business/setting-up", title: "Setting up", tag_type: "section", parent_id: business.tag_id),
-      create(:tag, tag_id: "business/manufacturing", title: "Manufacturing", tag_type: "section", parent_id: business.tag_id)
+      create(:live_tag, tag_id: "business/setting-up", title: "Setting up", tag_type: "section", parent_id: business.tag_id),
+      create(:live_tag, tag_id: "business/manufacturing", title: "Manufacturing", tag_type: "section", parent_id: business.tag_id)
     ]
-    driving = create(:tag, tag_id: "driving", title: "Driving", tag_type: "section")
+    driving = create(:live_tag, tag_id: "driving", title: "Driving", tag_type: "section")
 
     visit tags_path
 
@@ -43,6 +43,40 @@ class ListingTagsTest < ActionDispatch::IntegrationTest
 
         assert page.has_link?('Edit tag', href: edit_tag_path(driving))
         assert page.has_link?('Add child tag', href: new_tag_path(type: 'section', parent_id: 'driving'))
+      end
+    end
+  end
+
+  should 'display a draft label on draft tags' do
+    draft_tag = create(:draft_tag, tag_id: 'business', title: 'Business', tag_type: 'section')
+    child_draft_tag = create(:draft_tag, tag_id: "business/setting-up", title: "Setting up", tag_type: "section", parent_id: draft_tag.tag_id)
+
+    visit tags_path
+
+    within 'ul.tags-list li.parent-tag' do
+      assert page.has_content?('Section: Business')
+      assert page.has_selector?('.draft', text: 'draft')
+
+      within '.children li' do
+        assert page.has_content?('Setting up')
+        assert page.has_selector?('.draft', text: 'draft')
+      end
+    end
+  end
+
+  should 'not display a draft label on live tags' do
+    live_tag = create(:live_tag, tag_id: 'business', title: 'Business', tag_type: 'section')
+    child_live_tag = create(:live_tag, tag_id: "business/setting-up", title: "Setting up", tag_type: "section", parent_id: live_tag.tag_id)
+
+    visit tags_path
+
+    within 'ul.tags-list li.parent-tag' do
+      assert page.has_content?('Section: Business')
+      assert page.has_no_selector?('.draft')
+
+      within '.children li' do
+        assert page.has_content?('Setting up')
+        assert page.has_no_selector?('.draft')
       end
     end
   end

--- a/test/unit/artefact/filter_scopes_test.rb
+++ b/test/unit/artefact/filter_scopes_test.rb
@@ -4,10 +4,10 @@ class Artefact::FilterScopesTest < ActiveSupport::TestCase
 
   context "with_tags" do
     setup do
-      @tag_one = FactoryGirl.create(:tag, tag_type: "section", tag_id: "business")
-      @tag_two = FactoryGirl.create(:tag, tag_type: "section", tag_id: "tax")
-      @tag_three = FactoryGirl.create(:tag, tag_type: "section", tag_id: "driving")
-      @tag_four = FactoryGirl.create(:tag, tag_type: "section", tag_id: "benefits")
+      @tag_one = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business")
+      @tag_two = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "tax")
+      @tag_three = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "driving")
+      @tag_four = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "benefits")
 
       @artefact_one = FactoryGirl.create(:artefact, slug: "low-hanging-fruit", tag_ids: [@tag_one.tag_id])
       @artefact_two = FactoryGirl.create(:artefact, slug: "something-about-tax", tag_ids: [@tag_two.tag_id])
@@ -49,11 +49,11 @@ class Artefact::FilterScopesTest < ActiveSupport::TestCase
 
   context "with_parent_tag" do
     setup do
-      @tag_one = FactoryGirl.create(:tag, tag_type: "section", tag_id: "business")
-      @tag_two = FactoryGirl.create(:tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business")
-      @tag_three = FactoryGirl.create(:tag, tag_type: "section", tag_id: "business/starting-up", parent_id: "business")
-      @tag_four = FactoryGirl.create(:tag, tag_type: "section", tag_id: "driving")
-      @tag_five = FactoryGirl.create(:tag, tag_type: "section", tag_id: "driving/tax-discs", parent_id: "driving")
+      @tag_one = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business")
+      @tag_two = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business")
+      @tag_three = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/starting-up", parent_id: "business")
+      @tag_four = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "driving")
+      @tag_five = FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "driving/tax-discs", parent_id: "driving")
 
       @artefact_one = FactoryGirl.create(:artefact, slug: "starting-a-company", tag_ids: [@tag_three.tag_id])
       @artefact_two = FactoryGirl.create(:artefact, slug: "business-overview", tag_ids: [@tag_one.tag_id])

--- a/test/unit/forms/artefact_form_test.rb
+++ b/test/unit/forms/artefact_form_test.rb
@@ -1,0 +1,38 @@
+require_relative '../../test_helper'
+
+class ArtefactFormTest < ActiveSupport::TestCase
+
+  setup do
+    @artefact = mock('Artefact')
+  end
+
+  subject do
+    ArtefactForm.new(@artefact)
+  end
+
+  should 'send requests to the artefact' do
+    @artefact.expects(:foo).returns('bar')
+
+    assert_equal 'bar', subject.foo
+  end
+
+  should 'return itself for #to_model' do
+    assert_equal subject, subject.to_model
+  end
+
+  context '#specialist_sector_ids' do
+    should 'call the artefact, including the draft argument' do
+      @artefact.expects(:specialist_sector_ids).with(has_entry(:draft, true)).returns('foo')
+
+      assert_equal 'foo', subject.specialist_sector_ids
+    end
+  end
+
+  context '#specialist_sectors' do
+    should 'call the artefact, including the draft argument' do
+      @artefact.expects(:specialist_sectors).with(has_entry(:draft, true)).returns('foo')
+
+      assert_equal 'foo', subject.specialist_sectors
+    end
+  end
+end

--- a/test/unit/forms/artefact_form_test.rb
+++ b/test/unit/forms/artefact_form_test.rb
@@ -35,4 +35,20 @@ class ArtefactFormTest < ActiveSupport::TestCase
       assert_equal 'foo', subject.specialist_sectors
     end
   end
+
+  context '#section_ids' do
+    should 'call the artefact, including the draft argument' do
+      @artefact.expects(:section_ids).with(has_entry(:draft, true)).returns('foo')
+
+      assert_equal 'foo', subject.section_ids
+    end
+  end
+
+  context '#sections' do
+    should 'call the artefact, including the draft argument' do
+      @artefact.expects(:sections).with(has_entry(:draft, true)).returns('foo')
+
+      assert_equal 'foo', subject.sections
+    end
+  end
 end

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -80,8 +80,8 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
         title: 'Oil and gas',
         tag_type: 'specialist_sector',
         tag_id: 'oil-and-gas',
-        state: 'draft',
       )
+      subject.state = 'draft'
 
       assert_difference 'Artefact.count', 1 do
         subject.save

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -52,15 +52,14 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       stub_all_rummager_requests
     end
 
-    subject do
-      SpecialistSectorTagForm.new(
+    should 'create a live artefact for a live tag' do
+      subject = SpecialistSectorTagForm.new(
         title: 'Oil and gas',
         tag_type: 'specialist_sector',
         tag_id: 'oil-and-gas',
       )
-    end
+      subject.state = 'live'
 
-    should 'create an artefact for the tag' do
       assert_difference 'Artefact.count', 1 do
         subject.save
       end
@@ -74,6 +73,23 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       assert_equal 'oil-and-gas', artefact.slug
       assert_equal ['/oil-and-gas'], artefact.paths
       assert_equal 'live', artefact.state
+    end
+
+    should 'create a draft artefact for a draft tag' do
+      subject = SpecialistSectorTagForm.new(
+        title: 'Oil and gas',
+        tag_type: 'specialist_sector',
+        tag_id: 'oil-and-gas',
+        state: 'draft',
+      )
+
+      assert_difference 'Artefact.count', 1 do
+        subject.save
+      end
+
+      artefact = Artefact.last
+
+      assert_equal 'draft', artefact.state
     end
   end
 end

--- a/test/unit/helpers/tags_helper_test.rb
+++ b/test/unit/helpers/tags_helper_test.rb
@@ -5,12 +5,12 @@ class TagsHelperTest < ActiveSupport::TestCase
 
   context "grouped_options_for_tags_of_type" do
     setup do
-      Tag.create!(tag_type: "section", tag_id: "tax", title: "Tax")
-      Tag.create!(tag_type: "section", tag_id: "driving", title: "Driving")
-      Tag.create!(tag_type: "section", tag_id: "driving/car-tax", title: "Car tax", parent_id: "driving")
-      Tag.create!(tag_type: "section", tag_id: "driving/mot", title: "MOT", parent_id: "driving")
+      create(:live_tag, tag_type: "section", tag_id: "tax", title: "Tax")
+      create(:live_tag, tag_type: "section", tag_id: "driving", title: "Driving")
+      create(:live_tag, tag_type: "section", tag_id: "driving/car-tax", title: "Car tax", parent_id: "driving")
+      create(:live_tag, tag_type: "section", tag_id: "driving/mot", title: "MOT", parent_id: "driving")
 
-      Tag.create!(tag_type: "legacy_source", tag_id: "directgov", title: "Directgov")
+      create(:live_tag, tag_type: "legacy_source", tag_id: "directgov", title: "Directgov")
     end
 
     should "return a hierarchy of parent tags and their children" do

--- a/test/unit/importers/mainstream_organisation_tag_importer_test.rb
+++ b/test/unit/importers/mainstream_organisation_tag_importer_test.rb
@@ -11,8 +11,8 @@ module Importers
 
     def stub_need_with_organisation_ids(need_id, *organisations)
       organisations.each do |organisation|
-        next if Tag.by_tag_id(organisation, 'organisation')
-        create(:tag, tag_type: 'organisation', tag_id: organisation)
+        next if Tag.by_tag_id(organisation, type: 'organisation', draft: true)
+        create(:live_tag, tag_type: 'organisation', tag_id: organisation)
       end
 
       stub_need = {
@@ -86,7 +86,7 @@ module Importers
     end
 
     should 'not remove existing organisation tags from the artefact' do
-      create(:tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
+      create(:live_tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
       artefact = create(:draft_artefact, owning_app: 'publisher',
                                          need_ids: ['100001'],
                                          organisation_ids: ['ministry-of-defence'])
@@ -113,7 +113,7 @@ module Importers
     end
 
     should 'not tag an organisation to an artefact to which it is already tagged' do
-      create(:tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
+      create(:live_tag, tag_type: 'organisation', tag_id: 'ministry-of-defence')
       artefact = create(:draft_artefact, owning_app: 'publisher',
                                          need_ids: ['100001'],
                                          organisation_ids: ['ministry-of-defence'])
@@ -144,7 +144,7 @@ module Importers
 
     should 'retry if fetching a need times out' do
       artefact = create(:draft_artefact, owning_app: 'publisher', need_ids: ['100001'])
-      create(:tag, tag_type: 'organisation', tag_id: "hm-treasury")
+      create(:live_tag, tag_type: 'organisation', tag_id: "hm-treasury")
 
       stub_need = {
         "organisation_ids" => ["hm-treasury"]

--- a/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
+++ b/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
@@ -2,7 +2,7 @@ require_relative '../../test_helper'
 
 class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
   setup do
-    @tag = FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
+    @tag = FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
   end
 
   context 'when an artefact exists for the tag' do

--- a/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
+++ b/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
@@ -2,7 +2,10 @@ require_relative '../../test_helper'
 
 class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
   setup do
-    @tag = FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
+    stub_all_router_api_requests
+    stub_all_rummager_requests
+    
+    @tag = FactoryGirl.create(:draft_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
   end
 
   context 'when an artefact exists for the tag' do
@@ -13,6 +16,11 @@ class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
     should 'update the artefact name' do
       @tag.update_attributes(title: 'A brand new title')
       assert_equal 'A brand new title', @artefact.reload.name
+    end
+
+    should 'update the artefact state' do
+      @tag.publish!
+      assert_equal 'live', @artefact.reload.state
     end
   end
 

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -3,18 +3,18 @@ require 'test_helper'
 class RummageableArtefactTest < ActiveSupport::TestCase
 
   setup do
-    FactoryGirl.create(:tag, tag_type: "section", tag_id: "crime", title: "Crime")
-    FactoryGirl.create(:tag, tag_type: "section", tag_id: "crime/batman", title: "Batman", parent_id: "crime")
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "crime", title: "Crime")
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "crime/batman", title: "Batman", parent_id: "crime")
 
-    FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
-    FactoryGirl.create(:tag, tag_type: "organisation", tag_id: "department-for-transport", title: "Department for Transport")
+    FactoryGirl.create(:live_tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
+    FactoryGirl.create(:live_tag, tag_type: "organisation", tag_id: "department-for-transport", title: "Department for Transport")
 
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "oil-and-gas", title: "Oil and Gas")
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "oil-and-gas/licensing", title: "Licensing",
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "oil-and-gas", title: "Oil and Gas")
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "oil-and-gas/licensing", title: "Licensing",
                        parent_id: "oil-and-gas")
 
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
-    FactoryGirl.create(:tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "working-sea", title: "Working at sea")
+    FactoryGirl.create(:live_tag, tag_type: "specialist_sector", tag_id: "working-sea/health-safety", title: "Health and safety",
                        parent_id: "working-sea")
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/67644106

This changes Panopticon to add a workflow to publish tags. 

The content models bump (based on changes in alphagov/govuk_content_models#198) makes all tags draft by default, and adds a state machine allowing the tag to be published. Draft tags are now marked in the list with a pink 'draft' label, and then can be published from their edit pages. 

The state of an artefact for a tag (eg. a specialist sector) is kept in sync with the tag, so we won't ever have a 'live' artefact associated with a 'draft' tag. Additionally, the artefact edit form has been updated to support tagging draft tags to artefacts. The behaviour to prevent draft tags appearing in api responses has already been added to the Content API in alphagov/govuk_content_api#194.

The test suite has been updated to use the new `live_tag` factory where `tag` was previously used. Finally, the `OrganisationImporter` has also been updated to ensure all the organisation tags that it creates are in the `live` state.
