### PR TITLE
Bump govuk_content_models for DFID IDFs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "16.0.0"
+  gem "govuk_content_models", "16.1.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (~> 2.0.3)
-    govuk_content_models (16.0.0)
+    govuk_content_models (16.1.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -344,7 +344,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.3.0)
   gelf
-  govuk_content_models (= 16.0.0)
+  govuk_content_models (= 16.1.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
In order for DFID editors to publish international development funds from specialist-publisher we had to add the kind to the artefact in govuk_content_models and bump it here.
