### PR TITLE
Adding migration to rename three visas-immigration subsections

### DIFF
--- a/db/migrate/20140807094712_more_updates_to_some_visa_and_immigration_subsections.rb
+++ b/db/migrate/20140807094712_more_updates_to_some_visa_and_immigration_subsections.rb
@@ -1,0 +1,68 @@
+class MoreUpdatesToSomeVisaAndImmigrationSubsections < Mongoid::Migration
+  def self.up
+
+    self.renamed_sections.each do |old_slug, new_slug|
+      old_tag_id = "#{self.parent_id}/#{old_slug}"
+      new_tag_id = "#{self.parent_id}/#{new_slug}"
+
+      section = Tag.where(tag_id: old_tag_id, tag_type: 'section').first
+      if section.present?
+        section.update_attributes!(tag_id: new_tag_id)
+        puts "Renamed #{old_tag_id} -> #{new_tag_id}"
+
+        tagged_artefacts = Artefact.where(:tag_ids => old_tag_id)
+        tagged_artefacts.each do |artefact|
+          artefact.section_ids = (artefact.section_ids - [old_tag_id] + [new_tag_id])
+          artefact.save!
+
+          if artefact.save
+            puts "\t -> Updated tags for #{artefact.slug}"
+          else
+            puts "\t -> Could not update tags for #{artefact.slug}"
+          end
+        end
+      else
+        puts "Skipping rename: couldn't find #{old_tag_id}"
+      end
+    end
+  end
+
+  def self.down
+
+    self.renamed_sections.each do |old_slug, new_slug|
+      old_tag_id = "#{self.parent_id}/#{old_slug}"
+      new_tag_id = "#{self.parent_id}/#{new_slug}"
+
+      section = Tag.where(tag_id: new_tag_id, tag_type: 'section').first
+      if section.present?
+        section.update_attributes!(tag_id: old_tag_id)
+        puts "Reverted #{new_tag_id} -> #{old_tag_id}"
+
+        tagged_artefacts = Artefact.where(:tag_ids => new_tag_id)
+        tagged_artefacts.each do |artefact|
+          artefact.section_ids = (artefact.section_ids - [new_tag_id] + [old_tag_id])
+          if artefact.save
+            puts "\t -> Updated tags for #{artefact.slug}"
+          else
+            puts "\t -> Could not update tags for #{artefact.slug}"
+          end
+        end
+      else
+        puts "Skipping revert: couldn't find #{new_tag_id}"
+      end
+    end
+  end
+
+  private
+  def self.parent_id
+    "visas-immigration"
+  end
+
+  def self.renamed_sections
+    [
+      ["study-visas", "student-visas"],
+      ["short-stay-visas", "tourist-short-stay-visas"],
+      ["long-stay-visas", "family-visas"],
+    ]
+  end
+end


### PR DESCRIPTION
There are no whitehall mainstream categories with these parent tags.

I've opened a PR to add redirects to support these changes - https://github.gds/gds/router-data/pull/138
