### PR TITLE
Fix the JSON representation of the artefacts index.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "16.1.0"
+  gem "govuk_content_models", "~> 17.1", ">= 17.1.1"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,16 +123,17 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (1.5.1)
+    govspeak (2.0.2)
       htmlentities (~> 4)
-      kramdown (~> 0.13.3)
-      sanitize (~> 2.0.3)
-    govuk_content_models (16.1.0)
+      kramdown (~> 1.4.1)
+      nokogiri (~> 1.5.10)
+      sanitize (~> 2.1.0)
+    govuk_content_models (17.1.1)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 7.0.0, < 10.0.0)
-      govspeak (>= 1.0.1, < 2.0.0)
+      govspeak (~> 2.0.0)
       mongoid (~> 2.5)
       plek
       state_machine
@@ -155,7 +156,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.7.4)
-    kramdown (0.13.8)
+    kramdown (1.4.1)
     launchy (2.1.2)
       addressable (~> 2.3)
     libv8 (3.16.14.3)
@@ -179,7 +180,6 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     metaclass (0.0.1)
     mime-types (1.25.1)
-    mini_portile (0.5.3)
     minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -200,8 +200,7 @@ GEM
     nested_form (0.3.2)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.5.11)
     ntlm-http (0.1.1)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -265,7 +264,7 @@ GEM
       multi_json
       null_logger
       rest-client
-    sanitize (2.0.6)
+    sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.2.12)
     sass-rails (3.2.6)
@@ -344,7 +343,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.3.0)
   gelf
-  govuk_content_models (= 16.1.0)
+  govuk_content_models (~> 17.1, >= 17.1.1)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -11,7 +11,8 @@ class ArtefactsController < ApplicationController
 
   def index
     @filters = params.slice(:section, :specialist_sector, :kind, :state, :search, :owned_by)
-    @scope = apply_filters(artefact_scope, @filters)
+    @scope = artefact_scope.without(:actions)
+    @scope = apply_filters(@scope, @filters)
 
     @scope = @scope.order_by([[sort_column, sort_direction]])
     @artefacts = @scope.page(params[:page]).per(ITEMS_PER_PAGE)

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -15,7 +15,7 @@ class ArtefactsController < ApplicationController
 
     @scope = @scope.order_by([[sort_column, sort_direction]])
     @artefacts = @scope.page(params[:page]).per(ITEMS_PER_PAGE)
-    respond_with @artefacts, @tag_collection
+    respond_with @artefacts
   end
 
   def search_relatable_items

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -44,7 +44,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           @controller.expects(:artefact_scope).returns(@scope)
 
           # stub out the extra calls which get made on the scope object
-          @scope.stubs(:order_by => @scope, :page => @scope, :per => @scope, :where => @scope)
+          @scope.stubs(:order_by => @scope, :page => @scope, :per => @scope, :where => @scope, :without => @scope)
           @scope.stubs(:not_owned_by).with('panopticon').returns(@scope)
 
           # we aren't testing the template behaviour here, so don't try and render the template

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -6,6 +6,21 @@ class ArtefactsAPITest < ActiveSupport::TestCase
     create_test_user
   end
 
+  context "artefacts index" do
+    should "return list of artefacts as JSON" do
+      FactoryGirl.create(:artefact, :name => 'Alpha', :slug => 'alpha')
+      FactoryGirl.create(:artefact, :name => 'Bravo', :slug => 'bravo')
+      FactoryGirl.create(:artefact, :name => 'Charlie', :slug => 'charlie')
+
+      get "/artefacts.json"
+      assert_equal 200, last_response.status
+      data = JSON.parse(last_response.body)
+
+      slugs = data.map {|item| item["slug"] }
+      assert_equal %w(alpha bravo charlie), slugs
+    end
+  end
+
   context "show artefact" do
     should "return the JSON representation of the artefact" do
       artefact = FactoryGirl.create(:artefact, :slug => 'wibble', :name => "Wibble", :need_ids => ["100001", "100002"])

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -18,6 +18,9 @@ class ArtefactsAPITest < ActiveSupport::TestCase
 
       slugs = data.map {|item| item["slug"] }
       assert_equal %w(alpha bravo charlie), slugs
+
+      # Including the actions in the index is expensive, and unnecessary
+      refute data.first.has_key?("actions")
     end
   end
 


### PR DESCRIPTION
Calling `respond_with` with more than one resource only really makes
sense in contexts where it's expected to create a redirect (eg in a
create action), and therefore calls `polymorphic_url`.  In this case it
was causing the json view of the index to render `@tag_collection`
instead of the artefacts.
