### PR TITLE
Bump govuk_content_models version to 18.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "~> 17.1", ">= 17.1.1"
+  gem "govuk_content_models", "18.0.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_content_models (17.1.1)
+    govuk_content_models (18.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -258,8 +258,9 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    rest-client (1.6.8)
+      mime-types (~> 1.16)
+      rdoc (>= 2.4.2)
     rummageable (1.0.1)
       multi_json
       null_logger
@@ -294,7 +295,7 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    tzinfo (0.3.40)
+    tzinfo (0.3.41)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
@@ -343,7 +344,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.3.0)
   gelf
-  govuk_content_models (~> 17.1, >= 17.1.1)
+  govuk_content_models (= 18.0.0)
   jquery-rails (= 2.0.2)
   jquery-ui-rails (= 3.0.1)
   kaminari (= 0.14.1)


### PR DESCRIPTION
Adds new Artefact kinds for drug_safety_updates and medical_safety_alerts
