### PR TITLE
Add a minimal JSON view for artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -16,7 +16,11 @@ class ArtefactsController < ApplicationController
 
     @scope = @scope.order_by([[sort_column, sort_direction]])
     @artefacts = @scope.page(params[:page]).per(ITEMS_PER_PAGE)
-    respond_with @artefacts
+    if params[:minimal]
+      respond_with (@artefacts.map { |a| MinimalArtefactPresenter.new(a) })
+    else
+      respond_with @artefacts
+    end
   end
 
   def search_relatable_items

--- a/app/presenters/minimal_artefact_presenter.rb
+++ b/app/presenters/minimal_artefact_presenter.rb
@@ -1,0 +1,17 @@
+# Present an artefact with a bare minimum of information.
+#
+# This speeds up the importer for the URL arbiter
+# <https://github.com/alphagov/url-arbiter> by not loading up tag information.
+class MinimalArtefactPresenter
+  def initialize(artefact)
+    @artefact = artefact
+  end
+
+  def as_json(options = {})
+    {
+      slug: @artefact.slug,
+      name: @artefact.name,
+      owning_app: @artefact.owning_app,
+    }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module Panopticon
     config.assets.precompile += %W(html5.js)
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/presenters)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -142,6 +142,30 @@ class ArtefactsControllerTest < ActionController::TestCase
 
         assert_template "index"
       end
+
+      context "minimal view" do
+        setup do
+          get :index, format: :json, minimal: 1
+          @json = JSON.parse(response.body)
+        end
+
+        should "include a list of results" do
+          assert_equal 10, @json.count
+        end
+
+        should "include artefact names" do
+          @json.each do |artefact_json|
+            assert artefact_json["name"].present?
+          end
+        end
+
+        should "not include tag information" do
+          @json.each do |artefact_json|
+            refute artefact_json.include? "tag_ids"
+            refute artefact_json.include? "tags"
+          end
+        end
+      end
     end
 
     context "GET new" do

--- a/test/unit/presenters/minimal_artefact_presenter_test.rb
+++ b/test/unit/presenters/minimal_artefact_presenter_test.rb
@@ -1,0 +1,32 @@
+require_relative '../../test_helper'
+
+class MinimalArtefactPresenterTest < ActiveSupport::TestCase
+
+  context "with an artefact" do
+    setup do
+      @artefact = Artefact.new(
+        id: 12,
+        slug: "cheese-benefit",
+        name: "Cheese benefit",
+        owning_app: "publisher",
+      )
+      @presenter = MinimalArtefactPresenter.new(@artefact)
+    end
+
+    should "present the artefact as a hash" do
+      assert @presenter.as_json.is_a? Hash
+    end
+
+    should "include the name, slug and owning app" do
+      assert_equal "Cheese benefit", @presenter.as_json[:name]
+      assert_equal "cheese-benefit", @presenter.as_json[:slug]
+      assert_equal "publisher", @presenter.as_json[:owning_app]
+    end
+
+    should "not include any tag information" do
+      refute @presenter.as_json.include? :tag_ids
+      refute @presenter.as_json.include? :tags
+    end
+  end
+
+end


### PR DESCRIPTION
This view lets the [URL arbiter](https://github.com/alphagov/url-arbiter) seed its initial data set more quickly. Part of this is because the view can skip tag lookups; part is simply that there is less JSON to serialise. The response time on my dev VM dropped from 600-3000ms per page to 50-100ms.

Tested together with the importer, limited to 20,000 of the 100,000 or so artefacts, the time taken dropped from 6 minutes to 90 seconds.
