### PR TITLE
Index the "unimoney" campaign

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -20,6 +20,7 @@ class RummageableArtefact
     start-up-loans
     new-enterprise-allowance
     helping-your-business-grow-internationally
+    unimoney
   )
 
   def initialize(artefact)

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -237,6 +237,16 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     assert RummageableArtefact.new(artefact).should_be_indexed?
   end
 
+  should "index campaigns with an acceptable slug" do
+    artefact = Artefact.new do |artefact|
+      artefact.slug = "unimoney"
+      artefact.state = "live"
+      artefact.kind = "campaign"
+    end
+
+    assert RummageableArtefact.new(artefact).should_be_indexed?
+  end
+
   test "should not index content formats managed by Whitehall" do
     artefact = Artefact.new do |artefact|
       artefact.state = "live"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/76862090

At the moment, all artefacts of the "campaign" format are excluded from being indexed in search. 

We want to index the "unimoney" campaign in search, and we can do that by including this in the list of exceptional slugs.

Once this is deployed, there will be an additional step required to republish the campaign so that it will be inserted into the search index.
