### PR TITLE
Fix display of need IDs in artefacts table

### DIFF
--- a/app/views/artefacts/index.html.erb
+++ b/app/views/artefacts/index.html.erb
@@ -30,7 +30,7 @@
             <td>
               <% if artefact.need_ids %>
                 <% artefact.need_ids.each do |need_id| %>
-                  <%= content_tag "span", need_id, :class => "label need-id" %>
+                  <%= content_tag "span", need_id, :class => "label label-default need-id" %>
                 <% end %>
               <% end %>
             </td>


### PR DESCRIPTION
Bootstrap 3 requires a `label-default` class

Before:
![screen shot 2014-08-29 at 15 01 38](https://cloud.githubusercontent.com/assets/319055/4091116/0be6a690-2f85-11e4-925d-2b4eb0dfa0f3.png)

After:
![screen shot 2014-08-29 at 15 01 46](https://cloud.githubusercontent.com/assets/319055/4091117/0bebbfae-2f85-11e4-8194-861fe37eaac4.png)
