### PR TITLE
Don't delete routes for Whitehall artefacts

### DIFF
--- a/app/observers/update_router_observer.rb
+++ b/app/observers/update_router_observer.rb
@@ -3,8 +3,11 @@ class UpdateRouterObserver < Mongoid::Observer
 
   def after_save(artefact)
     RoutableArtefact.new(artefact).submit if artefact.live?
-    # Relying on current behaviour where this does not raise errors
-    # if done more than once, or done on artefacts never put live
-    RoutableArtefact.new(artefact).delete if artefact.archived?
+
+    unless artefact.owning_app == 'whitehall'
+      # Relying on current behaviour where this does not raise errors
+      # if done more than once, or done on artefacts never put live
+      RoutableArtefact.new(artefact).delete if artefact.archived?
+    end
   end
 end

--- a/test/unit/observers/update_router_observer_test.rb
+++ b/test/unit/observers/update_router_observer_test.rb
@@ -32,4 +32,11 @@ class UpdateRouterObserverTest < ActiveSupport::TestCase
     artefact = build(:archived_artefact)
     assert artefact.save
   end
+
+  should 'not delete an artefact owned by Whitehall from the router' do
+    RoutableArtefact.expects(:new).never
+
+    artefact = build(:archived_artefact, owning_app: 'whitehall')
+    assert artefact.save
+  end
 end

--- a/test/unit/observers/update_router_observer_test.rb
+++ b/test/unit/observers/update_router_observer_test.rb
@@ -1,0 +1,35 @@
+require_relative '../../test_helper'
+
+class UpdateRouterObserverTest < ActiveSupport::TestCase
+  setup do
+    stub_all_router_api_requests
+    stub_all_rummager_requests
+  end
+
+  should 'not register a draft artefact with the router' do
+    RoutableArtefact.expects(:new).never
+
+    artefact = build(:draft_artefact)
+    assert artefact.save
+  end
+
+  should 'submit a live artefact into the router' do
+    mock_routable_artefact = mock("RoutableArtefact")
+    RoutableArtefact.stubs(:new).returns(mock_routable_artefact)
+
+    mock_routable_artefact.expects(:submit)
+
+    artefact = build(:live_artefact)
+    assert artefact.save
+  end
+
+  should 'delete an archived artefact from the router' do
+    mock_routable_artefact = mock("RoutableArtefact")
+    RoutableArtefact.stubs(:new).returns(mock_routable_artefact)
+
+    mock_routable_artefact.expects(:delete)
+
+    artefact = build(:archived_artefact)
+    assert artefact.save
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/77730146

At the moment, Panopticon is deleting routes from the router for any artefact which is archived. This includes Whitehall artefacts which have been "unpublished". This causes issues because "unpublished" Whitehall content often has a custom redirect or "gone" page which specifies the reason for unpublishing. When Panopticon deletes the route, the Router serves its own generic "gone" page instead.

This pull request changes the observer which interacts with the Router API, changing it so that it no longer deletes routes for artefacts which are owned by Whitehall. It also adds new unit test coverage for the observer.
