### PR TITLE
Remove international-development section tag

### DIFF
--- a/db/migrate/20140902100317_remove_international_development_fund_tag.rb
+++ b/db/migrate/20140902100317_remove_international_development_fund_tag.rb
@@ -1,6 +1,14 @@
+require "gds_api/router"
+
 class RemoveInternationalDevelopmentFundTag < Mongoid::Migration
+  def self.router_api
+    @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
+  end
+
   def self.up
     Tag.by_tag_id("citizenship/international-development", "section").destroy
+    router_api.add_redirect_route('/browse/citizenship/international-development', 'exact', '/international-development-funding')
+    router_api.commit_routes
   end
 
   def self.down

--- a/db/migrate/20140902100317_remove_international_development_fund_tag.rb
+++ b/db/migrate/20140902100317_remove_international_development_fund_tag.rb
@@ -1,0 +1,9 @@
+class RemoveInternationalDevelopmentFundTag < Mongoid::Migration
+  def self.up
+    Tag.by_tag_id("citizenship/international-development", "section").destroy
+  end
+
+  def self.down
+    raise IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This is to be replaced with a redirect to the new international development fund finder.
