### PR TITLE
Migration to remove all non-Maslow needs from artefacts

### DIFF
--- a/db/migrate/20140904173800_remove_all_non_maslow_need_ids.rb
+++ b/db/migrate/20140904173800_remove_all_non_maslow_need_ids.rb
@@ -1,0 +1,18 @@
+class RemoveAllNonMaslowNeedIds < Mongoid::Migration
+  def self.up
+    artefacts_with_needs = Artefact.where(:need_ids.nin => [[], nil])
+    maslow_need = lambda { |need_id| need_id =~ /^\d{6}$/ }
+    artefacts_with_non_maslow_needs = artefacts_with_needs.reject {|a| a.need_ids.all?(&maslow_need) }
+
+    artefacts_with_non_maslow_needs.each do |artefact|
+      old_need_ids = artefact.need_ids
+      new_need_ids = artefact.need_ids.select(&maslow_need)
+      artefact.need_ids = new_need_ids
+      artefact.save!
+      puts "Updated need_ids for artefact #{artefact.id.to_s}: #{old_need_ids.inspect} => #{new_need_ids}"
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Some artefacts have old need_ids which predate Maslow (these are ones
that aren't 6 digits). There old needs are either in Need-o-tron or
in spreadsheets. All old needs that were salvageable have now been
imported into Maslow and the artefacts retagged with the new Maslow need
through the Panopticon UI.

All remaining non-Maslow need_ids can now be removed.
