### PR TITLE
Integrate with url-arbiter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'plek', '1.7.0'
+gem 'plek', '~> 1.8'
 
 gem 'nested_form', '0.3.2'
 
@@ -15,6 +15,8 @@ if ENV['API_DEV']
 else
   gem 'gds-api-adapters', "10.10.0"
 end
+
+gem 'govuk-client-url_arbiter', '0.0.2'
 
 gem 'rails', '3.2.18'
 gem 'unicorn', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,10 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
+    govuk-client-url_arbiter (0.0.2)
+      multi_json (~> 1.0)
+      plek (~> 1.8)
+      rest-client (~> 1.6)
     govuk_admin_template (1.1.2)
       bootstrap-sass (= 3.2.0.0)
       jquery-rails (= 3.1.1)
@@ -226,7 +230,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    plek (1.7.0)
+    plek (1.8.1)
     poltergeist (1.5.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -352,6 +356,7 @@ DEPENDENCIES
   gds-api-adapters (= 10.10.0)
   gds-sso (= 9.3.0)
   gelf
+  govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.1.2)
   govuk_content_models (= 18.0.0)
   jquery-ui-rails (= 5.0.0)
@@ -367,7 +372,7 @@ DEPENDENCIES
   nested_form (= 0.3.2)
   nokogiri
   null_logger
-  plek (= 1.7.0)
+  plek (~> 1.8)
   poltergeist (~> 1.5.0)
   quiet_assets
   rails (= 3.2.18)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ if defined?(Bundler)
   # Bundler.require(:default, :assets, Rails.env)
 end
 
+require 'govuk/client/url_arbiter'
+
 module Panopticon
   mattr_accessor :need_api
 
@@ -61,5 +63,9 @@ module Panopticon
     # When saving a specialist sector tag we want to update the title of the
     # associated artefact
     config.mongoid.observers << :update_specialist_sector_tag_artefact_observer
+
+    def url_arbiter_api
+      @url_arbiter_api ||= GOVUK::Client::URLArbiter.new
+    end
   end
 end

--- a/config/initializers/url_arbiter_feature_flag.rb
+++ b/config/initializers/url_arbiter_feature_flag.rb
@@ -1,0 +1,3 @@
+# This file potentially overwritten on deploy
+
+ENABLE_URL_ARBITER = Rails.env.development? || Rails.env.test?

--- a/features/creating.feature
+++ b/features/creating.feature
@@ -4,6 +4,7 @@ Feature: Creating artefacts
 
   Background:
     Given I am an admin
+    And I have stubbed url-arbiter
 
   Scenario: Creating artefacts directly in panopticon
     When I visit the homepage

--- a/features/registering_resources.feature
+++ b/features/registering_resources.feature
@@ -6,6 +6,7 @@ Feature: Registering resources
   Background:
     # Router registration is tested in test/integration/artefact_router_registration_test.rb
     Given I have stubbed the router
+    And I have stubbed url-arbiter
 
   Scenario: Creating a smart answer
     When I put a new smart answer's details into panopticon

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -6,6 +6,10 @@ Given /^I have stubbed search$/ do
   stub_search
 end
 
+Given /^I have stubbed url-arbiter$/ do
+  stub_url_arbiter
+end
+
 When /^I put a new smart answer's details into panopticon$/ do
   prepare_registration_environment
 

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -1,4 +1,7 @@
+require 'govuk/client/test_helpers/url_arbiter'
+
 module RegistrationInfo
+  include GOVUK::Client::TestHelpers::URLArbiter
 
   SEARCH_ROOT = "http://search.dev.gov.uk/mainstream"
 
@@ -72,6 +75,11 @@ module RegistrationInfo
     Artefact.observers.disable :update_search_observer do
       @artefact = Artefact.create!(example_smart_answer)
     end
+    url_arbiter_has_registration_for("/#{@artefact.slug}", @artefact.owning_app)
+  end
+
+  def stub_url_arbiter
+    stub_default_url_arbiter_responses
   end
 end
 

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -509,6 +509,8 @@ class ArtefactsControllerTest < ActionController::TestCase
           name: "Whatever",
           need_ids: ['100001']
         )
+        url_arbiter_has_registration_for("/whatever", "publisher")
+
         put :update, id: artefact.id, "CONTENT_TYPE" => "application/json", owning_app: 'smart-answers'
         assert_equal 409, response.status
         assert response.body.include? "publisher"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ require 'webmock/minitest'
 WebMock.disable_net_connect!(:allow_localhost => true)
 require 'govuk_content_models/test_helpers/factories'
 
+require 'govuk/client/test_helpers/url_arbiter'
+
 DatabaseCleaner.strategy = :truncation
 # initial clean
 DatabaseCleaner.clean
@@ -25,11 +27,14 @@ DatabaseCleaner.clean
 class ActiveSupport::TestCase
   include Rack::Test::Methods
   include FactoryGirl::Syntax::Methods
+  include GOVUK::Client::TestHelpers::URLArbiter
 
   def clean_db
     DatabaseCleaner.clean
   end
   set_callback :teardown, :before, :clean_db
+
+  set_callback :setup, :before, :stub_default_url_arbiter_responses
 
   def app
     Panopticon::Application


### PR DESCRIPTION
This changes the ownership check to use url-arbiter instead of a local check.

This is feature-flagged (url-arbiter isn't in production yet), and when disabled the original check still applies.
