### PR TITLE
Disable validations when saving after non-Maslow need_id strip

### DIFF
--- a/db/migrate/20140904173800_remove_all_non_maslow_need_ids.rb
+++ b/db/migrate/20140904173800_remove_all_non_maslow_need_ids.rb
@@ -8,7 +8,7 @@ class RemoveAllNonMaslowNeedIds < Mongoid::Migration
       old_need_ids = artefact.need_ids
       new_need_ids = artefact.need_ids.select(&maslow_need)
       artefact.need_ids = new_need_ids
-      artefact.save!
+      artefact.save!(validate: false)
       puts "Updated need_ids for artefact #{artefact.id.to_s}: #{old_need_ids.inspect} => #{new_need_ids}"
     end
   end


### PR DESCRIPTION
Since removing non-Maslow need_ids can touch archived artefacts as well,
the migration fails if validations are run upon saving.
