### PR TITLE
Update govuk_content_models to 20.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "20.1.0"
+  gem "govuk_content_models", "20.2.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       bootstrap-sass (= 3.2.0.0)
       jquery-rails (= 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (20.1.0)
+    govuk_content_models (20.2.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -148,7 +148,7 @@ GEM
       mongoid (~> 2.5)
       plek
       state_machine
-    hashie (3.2.0)
+    hashie (3.3.1)
     hike (1.2.3)
     htmlentities (4.3.2)
     http-cookie (1.0.2)
@@ -230,7 +230,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    plek (1.8.1)
+    plek (1.9.0)
     poltergeist (1.5.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -358,7 +358,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.1.2)
-  govuk_content_models (= 20.1.0)
+  govuk_content_models (= 20.2.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
This allows `finder_email_signup` artefacts to be added.
