### PR TITLE
Remove draft smartdown artefacts

### DIFF
--- a/db/migrate/20140924101420_remove_draft_smartdown_artefacts.rb
+++ b/db/migrate/20140924101420_remove_draft_smartdown_artefacts.rb
@@ -1,0 +1,15 @@
+class RemoveDraftSmartdownArtefacts < Mongoid::Migration
+  def self.up
+    draft_slugs = %w(animal-example-simple animal-example-multiple employee-parental-leave student-finance-forms-transition)
+    draft_slugs.each do |slug|
+      artefact = Artefact.find_by_slug(slug)
+      if artefact
+        RummageableArtefact.new(artefact).delete
+        puts "Successfully deleted #{slug}" if artefact.destroy
+      end
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Added in error because of a bug in the smartanswers SmartdownAdapter::Registry class [fixed here](https://github.com/alphagov/smart-answers/pull/1144). Cleans up panopticon draft artefacts and search index items.
