### PR TITLE
Hide the sectors tag field for Whitehall artefacts

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -29,4 +29,8 @@ class Artefact
     (owning_app == "whitehall" ? "[Whitehall] " : "[Mainstream] ") + name
   end
 
+  def allow_specialist_sector_tag_changes?
+    owning_app != 'whitehall'
+  end
+
 end

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -26,14 +26,16 @@
                   :input_html => { :multiple => true, :class => "chosen-select" } %>
     </div>
 
-    <div class="specialist-sector-tags fieldset-section">
-      <label for="artefact_specialist_sector_ids" class="section-label">Specialist sectors</label>
+    <% if f.object.allow_specialist_sector_tag_changes? %>
+      <div class="specialist-sector-tags fieldset-section">
+        <label for="artefact_specialist_sector_ids" class="section-label">Specialist sectors</label>
 
-      <%= f.input :specialist_sector_ids,
-                  :label => false,
-                  :collection => grouped_options_for_tags_of_type('specialist_sector'),
-                  :input_html => { :multiple => true, :class => "chosen-select" } %>
-    </div>
+        <%= f.input :specialist_sector_ids,
+                    :label => false,
+                    :collection => grouped_options_for_tags_of_type('specialist_sector'),
+                    :input_html => { :multiple => true, :class => "chosen-select" } %>
+      </div>
+    <% end %>
 
     <div class="organisation-tags fieldset-section">
       <label for="artefact_organisation_ids" class="section-label">Organisations</label>

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -216,6 +216,25 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       assert_equal ["charities/starting-a-charity"], @artefact.specialist_sector_ids
     end
 
+    should 'not display specialist sector tags for whitehall artefacts' do
+      artefact = create(:artefact, name: 'Policy',
+                                   kind: 'publication',
+                                   slug: 'government/publications/foo',
+                                   owning_app: 'whitehall',
+                                   specialist_sector_ids: ["oil-and-gas/fields-and-wells", "charities/starting-a-charity"])
+
+      visit '/artefacts'
+      click_on 'Policy'
+
+      assert page.has_no_selector?('select#artefact_specialist_sector_ids')
+
+      click_on 'Save and continue editing'
+
+      # check to make sure that specialist sectors are not removed when saved
+      artefact.reload
+      assert_equal ["oil-and-gas/fields-and-wells", "charities/starting-a-charity"], artefact.specialist_sector_ids
+    end
+
     context 'draft specialist sectors' do
       setup do
         create(:draft_tag, tag_type: 'specialist_sector', tag_id: 'schools-colleges', title: 'Schools and colleges')

--- a/test/unit/enhancements/artefact_test.rb
+++ b/test/unit/enhancements/artefact_test.rb
@@ -57,4 +57,18 @@ class ArtefactTest < ActiveSupport::TestCase
     end
   end
 
+  context '#allow_specialist_sector_tag_changes?' do
+    should 'be true for a non-whitehall artefact' do
+      artefact = FactoryGirl.build(:artefact, owning_app: 'publisher')
+
+      assert artefact.allow_specialist_sector_tag_changes?
+    end
+
+    should 'be false for a whitehall artefact' do
+      artefact = FactoryGirl.build(:whitehall_draft_artefact)
+
+      assert_equal false, artefact.allow_specialist_sector_tag_changes?
+    end
+  end
+
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/79283798

The canonical source of the topics (nèe specialist sectors) for a Whitehall artefact is Whitehall, therefore we should not allow these to be edited in Panopticon as the changes are not propagated back to the Whitehall editions.

We're addressing this issue now as we're now going to be registering Whitehall content directly with the content store in addition to Panopticon, so the need for a single place where Whitehall editions can be tagged with topics is important.
