### PR TITLE
Disallow updates to the tag_type field

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -50,19 +50,17 @@ class TagsController < ApplicationController
   end
 
   def update
-    if tag_parameters.has_key?('tag_id') && tag_parameters['tag_id'] != @tag.tag_id
-      render json: { errors: { tag_id: ["can't be changed"] } },
-             status: :unprocessable_entity
+    if disallowed_update_params.any?
+      render status: :unprocessable_entity,
+             json: {
+               errors: Hash[disallowed_update_params.map {|key|
+                 [key, ["can't be changed"]]
+               }]
+             }
       return
     end
 
-    if tag_parameters.has_key?('parent_id') && tag_parameters['parent_id'] != @tag.parent_id
-      render json: { errors: { parent_id: ["can't be changed"] } },
-             status: :unprocessable_entity
-      return
-    end
-
-    valid_tag_params = tag_parameters.except(:parent_id, :tag_id)
+    valid_tag_params = tag_parameters.except(disallowed_update_param_keys)
 
     respond_to do |format|
       if @tag.update_attributes(valid_tag_params)
@@ -121,6 +119,16 @@ private
     #
     params[:tag] ||
       params.slice(:tag_id, :tag_type, :title, :parent_id, :description)
+  end
+
+  def disallowed_update_param_keys
+    [:tag_id, :parent_id]
+  end
+
+  def disallowed_update_params
+    disallowed_update_param_keys.select {|key|
+      tag_parameters.has_key?(key) && tag_parameters[key] != @tag.send(key)
+    }
   end
 
   def find_tag

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -122,7 +122,7 @@ private
   end
 
   def disallowed_update_param_keys
-    [:tag_id, :parent_id]
+    [:tag_id, :parent_id, :tag_type]
   end
 
   def disallowed_update_params

--- a/test/integration/editing_tags_test.rb
+++ b/test/integration/editing_tags_test.rb
@@ -130,20 +130,24 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
       assert_equal 'Tea', @tag.title
     end
 
-    should 'return error when a change is requested to the tag_id' do
-      put tag_path(@tag), { tag_id: 'foo', format: 'json' }
-      body = JSON.parse(response.body)
+    context 'fields which cannot be changed' do
 
-      assert_equal 422, response.status
-      assert_match "can't be changed", body['errors']['tag_id'].first
-    end
+      should 'return error when a change is requested to the tag_id' do
+        put tag_path(@tag), { tag_id: 'foo', format: 'json' }
+        body = JSON.parse(response.body)
 
-    should 'return error when a change is requested to the parent_id' do
-      put tag_path(@tag), { parent_id: 'foo', format: 'json' }
-      body = JSON.parse(response.body)
+        assert_equal 422, response.status
+        assert_match "can't be changed", body['errors']['tag_id'].first
+      end
 
-      assert_equal 422, response.status
-      assert_match "can't be changed", body['errors']['parent_id'].first
+      should 'return error when a change is requested to the parent_id' do
+        put tag_path(@tag), { parent_id: 'foo', format: 'json' }
+        body = JSON.parse(response.body)
+
+        assert_equal 422, response.status
+        assert_match "can't be changed", body['errors']['parent_id'].first
+      end
+
     end
 
     should 'return an error when the tag does not exist' do

--- a/test/integration/editing_tags_test.rb
+++ b/test/integration/editing_tags_test.rb
@@ -148,6 +148,14 @@ class EditingTagsTest < ActionDispatch::IntegrationTest
         assert_match "can't be changed", body['errors']['parent_id'].first
       end
 
+      should 'return error when a change is requested to the tag_type' do
+        put tag_path(@tag), { tag_type: 'foo', format: 'json' }
+        body = JSON.parse(response.body)
+
+        assert_equal 422, response.status
+        assert_match "can't be changed", body['errors']['tag_type'].first
+      end
+
     end
 
     should 'return an error when the tag does not exist' do


### PR DESCRIPTION
The `tag_type` field should not be able to be changed through the `TagsController`, as it effectively moves the tag to another ID (which will break its taggings).

These changes disallow updates to this field, and refactors the code that enforced these validations to be clearer and reduce duplication.
