### PR TITLE
Override GDS::SSO.test_user with extra permissions

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -4,3 +4,16 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV['PANOPTICON_OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
 end
+
+# In development, if we want to be able to test API requests to the tags
+# endpoints, we need to override the permissions for the dummy user inserted by
+# GDS::SSO in the mock_bearer_token strategy.
+#
+# The easiest way to do this is just to override the GDS::SSO test user with a
+# new user we create here.
+#
+GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
+  u.name = 'Testy McTest'
+  u.permissions = ['signin', 'manage_tags']
+  u.save!
+end


### PR DESCRIPTION
In development, the "mock bearer token" strategy used for API requests returns a user which has only the `signin` permission by default. For requests to change tags to work, this user needs the `manage_tags` permission too. 

The easiest way to add this permission is to override the `GDS::SSO.test_user` variable with a new user that has all the necessary permissions. The test user takes precedence over the dummy user <sup>[1]</sup> so this user will always be selected.

A nice side effect of doing this is that it will no longer be required to have a user in the database when running this app in development, as the `GDS::SSO.test_user` field is checked first.

This file is overwritten on deploy, and the mock GDS::SSO strategies are not requested in production environments, so this will not have an effect on the production behaviour of the app.

[1] https://github.com/alphagov/gds-sso/blob/v9.3.0/lib/gds-sso/bearer_token.rb#L49
