### PR TITLE
Stop prepending parent_id to tag_id on JSON create

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -26,7 +26,7 @@ class TagsController < ApplicationController
   def create
     @tag = form_object.new(tag_parameters)
 
-    if @tag.parent_id.present?
+    if @tag.parent_id.present? && request.format.html?
       @tag.tag_id = "#{@tag.parent_id}/#{@tag.tag_id}"
     end
 

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -105,10 +105,21 @@ class TagsControllerTest < ActionController::TestCase
       assert_template :new
     end
 
-    should "prepend the parent to a tag id when a parent is present" do
+    should "prepend the parent to a tag id when a parent is present given a html request" do
       Tag.any_instance.expects(:save).returns(true)
 
-      post :create, tag: @stub_atts.merge('tag_id' => 'families',
+      post :create, format: :html,
+                    tag: @stub_atts.merge('tag_id' => 'families',
+                                          'parent_id' => 'benefits')
+
+      assert_equal 'benefits/families', assigns(:tag).tag_id
+    end
+
+    should 'not prepend the parent_id to the tag_id given a json request' do
+      Tag.any_instance.expects(:save).returns(true)
+
+      post :create, format: :json,
+                    tag: @stub_atts.merge('tag_id' => 'benefits/families',
                                           'parent_id' => 'benefits')
 
       assert_equal 'benefits/families', assigns(:tag).tag_id

--- a/test/integration/creating_tags_test.rb
+++ b/test/integration/creating_tags_test.rb
@@ -85,7 +85,7 @@ class CreatingTagsTest < ActionDispatch::IntegrationTest
 
       params = {
         format: 'json',
-        tag_id: 'car-tax', # parent tag is prepended on creation
+        tag_id: 'driving/car-tax',
         tag_type: 'section',
         title: 'Car tax',
         parent_id: 'driving',


### PR DESCRIPTION
This changes the TagsController so that we no longer prepend the `parent_id` of a tag to its `tag_id` when creating a child tag through a JSON request.

This makes the behaviour of the JSON API more consistent with the update method, as the required value of `tag_id` will be the same across both the `create` and `update` methods.
