### PR TITLE
Register email signup routes for topics.

### DIFF
--- a/app/forms/specialist_sector_tag_form.rb
+++ b/app/forms/specialist_sector_tag_form.rb
@@ -36,7 +36,8 @@ private
     {
       name: tag.title,
       slug: slug,
-      paths: ["/#{slug}"],
+      paths: paths,
+      prefixes: prefixes,
       kind: "specialist_sector",
       owning_app: "panopticon",
       rendering_app: "collections",
@@ -46,5 +47,17 @@ private
 
   def slug
     tag.tag_id
+  end
+
+  def paths
+    child? ? [] : ["/#{slug}"]
+  end
+
+  def prefixes
+    child? ? ["/#{slug}"] : []
+  end
+
+  def child?
+    slug.include?('/')
   end
 end

--- a/db/migrate/20141017135549_register_prefix_routes_for_sectors.rb
+++ b/db/migrate/20141017135549_register_prefix_routes_for_sectors.rb
@@ -1,0 +1,37 @@
+class RegisterPrefixRoutesForSectors < Mongoid::Migration
+  def self.up
+    sectors = Artefact.where(kind: 'specialist_sector').to_a
+    sectors.each do |sector_artefact|
+      next unless sector_artefact.slug.include?('/') # Child tags only
+
+      update_routes(sector_artefact, prefixes: sector_artefact.paths, paths: [])
+    end
+  end
+
+  def self.down
+    sectors = Artefact.where(kind: 'specialist_sector').to_a
+    sectors.each do |sector_artefact|
+      next unless sector_artefact.slug.include?('/') # Child tags only
+
+      update_routes(sector_artefact, prefixes: [], paths: sector_artefact.prefixes)
+    end
+  end
+
+  def self.update_routes(artefact, options = {})
+    prefixes = options.fetch(:prefixes).dup
+    paths = options.fetch(:paths).dup
+
+    puts "Updating #{artefact.slug}"
+    puts "-- Setting paths to #{paths}"
+    puts "-- Setting prefixes to #{prefixes}"
+
+    routeable_artefact = RoutableArtefact.new(artefact)
+    routeable_artefact.delete(skip_commit: true)
+
+    artefact.update_attributes!(prefixes: prefixes, paths: paths)
+    artefact.reload
+
+    routeable_artefact = RoutableArtefact.new(artefact)
+    routeable_artefact.submit
+  end
+end

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -71,8 +71,44 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       assert_equal 'collections', artefact.rendering_app
       assert_equal 'Oil and gas', artefact.name
       assert_equal 'oil-and-gas', artefact.slug
-      assert_equal ['/oil-and-gas'], artefact.paths
       assert_equal 'live', artefact.state
+    end
+
+    should 'set paths for a parent tag' do
+      subject = SpecialistSectorTagForm.new(
+        title: 'Oil and gas',
+        tag_type: 'specialist_sector',
+        tag_id: 'oil-and-gas',
+      )
+      subject.state = 'live'
+
+      assert_difference 'Artefact.count', 1 do
+        subject.save
+      end
+
+      artefact = Artefact.last
+      assert_equal ['/oil-and-gas'], artefact.paths
+      assert_equal [], artefact.prefixes
+    end
+
+    should 'set prefixes for a child tag' do
+      parent_tag = FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
+
+      subject = SpecialistSectorTagForm.new(
+        title: 'Licensing',
+        tag_type: 'specialist_sector',
+        tag_id: 'oil-and-gas/licensing',
+        parent_id: parent_tag.tag_id
+      )
+      subject.state = 'live'
+
+      assert_difference 'Artefact.count', 1 do
+        subject.save
+      end
+
+      artefact = Artefact.last
+      assert_equal [], artefact.paths
+      assert_equal ['/oil-and-gas/licensing'], artefact.prefixes
     end
 
     should 'create a draft artefact for a draft tag' do

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -30,20 +30,6 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
         assert subject.errors[:tag_id].include?('is already taken')
       end
     end
-
-    context 'with a two-part slug' do
-      setup do
-        FactoryGirl.create(:artefact, slug: 'oil-and-gas')
-      end
-
-      subject do
-        SpecialistSectorTagForm.new(
-          title: 'Fields and wells',
-          tag_type: 'specialist_sector',
-          tag_id: 'oil-and-gas/fields-and-wells',
-        )
-      end
-    end
   end
 
   context '#save' do


### PR DESCRIPTION
Registers a prefix route for child topics and
deletes the exact route.

The copy to the array is because FOR SOME REASON
mongo/id returns the same item twice during an
each if you modify the item as it passes, with bad
data to boot.

WHY.  WHY.  WHY MONGO WHY.
