### PR TITLE
Adding migration to rename 'housing'... to 'housing-local-services'...

### DIFF
--- a/db/migrate/20140926081837_rename_housing_browse_category.rb
+++ b/db/migrate/20140926081837_rename_housing_browse_category.rb
@@ -69,7 +69,7 @@ class RenameHousingBrowseCategory < Mongoid::Migration
           t.gsub(from, to)
         end
         
-        if a.save!
+        if a.save
           puts "\t -> Rewritten section_ids to #{a.section_ids} for #{a.slug}"
         else
           puts "\t -> Couldn't update #{a.slug}"

--- a/db/migrate/20140926081837_rename_housing_browse_category.rb
+++ b/db/migrate/20140926081837_rename_housing_browse_category.rb
@@ -1,0 +1,112 @@
+class RenameHousingBrowseCategory < Mongoid::Migration
+
+  OLD_PARENT_TAG = "housing"
+  NEW_PARENT_TAG = "housing-local-services"
+
+  OLD_PARENT_TAG_SEARCH_TERM = "housing/"
+  NEW_PARENT_TAG_SEARCH_TERM = "housing-local-services/"
+
+
+  def self.up
+
+    puts "[1/4] Creating parent tag"
+    parent = Tag.find_or_create_by(tag_id: NEW_PARENT_TAG, title: "Housing and local services", tag_type: "section")
+    parent.publish
+    puts "\tCreated #{parent.inspect}"
+
+    puts "[2/4] Creating child tags for new parent"
+    create_categories_for_parent
+
+    puts "[3/4] retagging artefacts"
+    retag_artefacts
+
+    puts "[4/4] removing old parent tag"
+    parent_tag = Tag.where(tag_id: OLD_PARENT_TAG, tag_type: 'section').first
+    if  parent_tag.destroy
+      puts "\tDeleted #{parent_tag.tag_id}"
+    else
+      puts "\tCould not find parent tag to delete"
+    end
+  end
+
+  def self.down
+
+    puts "[1/4] Recreating old parent tag"
+    parent = Tag.find_or_create_by(tag_id: OLD_PARENT_TAG, title: "Housing and local services", tag_type: "section")
+    parent.publish
+    puts "\tCreated #{parent.inspect}"
+
+    puts "[2/4] retagging artefacts"
+    retag_artefacts(false)
+
+    puts "[3/4] Deleting child tags for new parent"
+    destroy_categories_for_parent
+
+    puts "[4/4] Deleting new parent tag"
+    parent_tag = Tag.where(tag_id: NEW_PARENT_TAG, tag_type: 'section').first
+    if  parent_tag.destroy
+      puts "\tDeleted #{parent_tag.tag_id}"
+    else
+      puts "\tCould not find parent tag to delete"
+    end
+
+  end
+
+  def self.retag_artefacts(new_parent=true)
+
+    from, to = new_parent ? [OLD_PARENT_TAG_SEARCH_TERM, NEW_PARENT_TAG_SEARCH_TERM] : [NEW_PARENT_TAG_SEARCH_TERM, OLD_PARENT_TAG_SEARCH_TERM]
+
+    artefacts = Artefact.any_in(tag_ids: [Regexp.new(from)])
+
+    puts "Found artefacts:\n#{artefacts.all.map(&:slug)}"
+
+    artefacts.all.each do |a|
+
+      puts "Artefact '#{a.slug}' has sections_ids : #{a.section_ids} and a state : #{a.state}"
+
+      unless a.state == "archived"
+        a.section_ids = a.section_ids.map do |t|
+          t.gsub(from, to)
+        end
+        
+        if a.save!
+          puts "\t -> Rewritten section_ids to #{a.section_ids} for #{a.slug}"
+        else
+          puts "\t -> Couldn't update #{a.slug}"
+        end
+      end
+    end
+
+  end
+
+  def self.categories
+    [
+      { title: "Council Tax", slug: "council-tax"},
+      { title: "Council housing and housing association", slug: "council-housing-association"},
+      { title: "Being a landlord and renting out a room", slug: "landlords"},
+      { title: "Local councils and services", slug: "local-councils"},
+      { title: "Noise, neighbours, pets and pests", slug: "noise-neighbours"},
+      { title: "Owning and renting a property", slug: "owning-renting-property"},
+      { title: "Planning permission and building regulations", slug: "planning-permission"},
+      { title: "Recycling, rubbish, streets and roads", slug: "recycling-rubbish"},
+      { title: "Repossessions, emergency housing and evictions", slug: "repossessions-evictions"},
+      { title: "Safety and the environment in your community", slug: "safety-environment"},
+    ]
+  end
+
+  def self.create_categories_for_parent
+    categories.each do |category|
+      created = Tag.create!(tag_id: "#{NEW_PARENT_TAG}/#{category[:slug]}", title: category[:title], tag_type: 'section', parent_id: "#{NEW_PARENT_TAG}")
+      created.publish
+      puts "\tCreated #{created.inspect}"
+    end
+  end
+
+  def self.destroy_categories_for_parent
+    Tag.where(parent_id: NEW_PARENT_TAG).each do |tag|
+      tag.destroy
+      puts "\tDeleted #{tag.tag_id}"
+    end
+  end
+
+end

--- a/test/unit/rename_housing_browse_category_test.rb
+++ b/test/unit/rename_housing_browse_category_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+require_relative '../../db/migrate/20140926081837_rename_housing_browse_category'
+
+class RenameHousingBrowseCategoryTest < ActiveSupport::TestCase
+  setup do
+    stub_all_router_api_requests
+    stub_all_rummager_requests
+  end
+
+  test "self.up renames 'housing' categories" do
+    FactoryGirl.create(:tag, tag_id: "housing", title: "Housing", tag_type: 'section', state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/landlords", title: "Housing and landlords", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/owning-renting-property", title: "Owning and renting property", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/council-housing-association", title: "Council housing and housing association", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "something", title: "Something", tag_type: "section", state: "live")
+    FactoryGirl.create(:tag, tag_id: "dwp", title: "DWP", tag_type: 'organisation', state: "live")
+    artefact1 = FactoryGirl.create(:artefact, slug: "park-mobile-homes", state: "live")
+    artefact1.sections = ["housing/landlords", "housing/owning-renting-property", "housing/council-housing-association", "something"]
+    artefact1.organisations = ["dwp"]
+    artefact1.save!
+
+    artefact2 = FactoryGirl.create(:artefact, slug: "scaffolding-rules", state: "live")
+    artefact2.section_ids = ["housing/landlords", "something"]
+    artefact2.save!
+
+    artefact3 = FactoryGirl.create(:artefact, slug: "expensive-rents", state: "archived")
+    artefact3.section_ids = ["housing/landlords", "something"]
+    artefact3.save!
+
+
+    RenameHousingBrowseCategory.up
+
+    assert Tag.where(tag_id: "housing-local-services").exists?
+    assert Tag.where(tag_id: "housing-local-services/owning-renting-property").exists?
+    assert Tag.where(tag_id: "housing-local-services/council-housing-association").exists?
+    assert Tag.where(tag_id: "housing-local-services/landlords", parent_id: "housing-local-services").exists?
+    assert Tag.where(tag_id: "something").exists?
+    assert Tag.where(tag_id: "dwp").exists?
+
+    retagged_artefacts = Artefact.any_in(tag_ids: [/housing-local-services/]).all
+
+    assert_equal 2, retagged_artefacts.size
+
+    assert retagged_artefacts.first.section_ids.include?("housing-local-services/landlords")
+    assert retagged_artefacts.first.section_ids.include?("housing-local-services/owning-renting-property")
+    assert retagged_artefacts.first.section_ids.include?("housing-local-services/council-housing-association")
+    assert retagged_artefacts.first.organisation_ids.include?("dwp")
+    assert retagged_artefacts.last.section_ids.include?("housing-local-services/landlords")
+    refute retagged_artefacts.last.section_ids.include?("housing-local-services/owning-renting-property")
+
+    assert_equal 3, Artefact.any_in(tag_ids: [/something/]).count
+  end
+
+  test "self.down undoes renaming" do
+    FactoryGirl.create(:tag, tag_id: "housing", title: "Housing", tag_type: 'section', state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/landlords", title: "Housing and landlords", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/owning-renting-property", title: "Owning and renting property", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing/council-housing-association", title: "Council housing and housing association", tag_type: 'section', parent_id: "housing", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing-local-services", title: "Housing", tag_type: 'section', state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing-local-services/landlords", title: "Housing and landlords", tag_type: 'section', parent_id: "housing-local-services", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing-local-services/owning-renting-property", title: "Owning and renting property", tag_type: 'section', parent_id: "housing-local-services", state: "live")
+    FactoryGirl.create(:tag, tag_id: "housing-local-services/council-housing-association", title: "Council housing and housing association", tag_type: 'section', parent_id: "housing-local-services", state: "live")
+    FactoryGirl.create(:tag, tag_id: "something", title: "Something", tag_type: 'section', state: "live")
+    artefact1 = FactoryGirl.create(:artefact, slug: "park-mobile-homes", state: "live")
+    artefact1.section_ids = ["housing-local-services/landlords", "housing-local-services/owning-renting-property", "something"]
+    artefact1.save!
+
+    artefact2 = FactoryGirl.create(:artefact, slug: "expensive-rents", state: "archived")
+    artefact2.section_ids = ["housing-local-services/landlords", "something"]
+    artefact2.save!
+
+    artefact3 = FactoryGirl.create(:artefact, slug: "scaffolding-rules", state: "live")
+    artefact3.section_ids = ["housing-local-services/landlords", "something"]
+    artefact3.save!
+
+
+    RenameHousingBrowseCategory.down
+
+    assert Tag.where(tag_id: "housing").exists?
+    assert Tag.where(tag_id: "housing/landlords", parent_id: "housing").exists?
+    assert Tag.where(tag_id: "something").exists?
+
+    retagged_artefacts = Artefact.any_in(tag_ids: [/housing/]).all
+
+    puts retagged_artefacts.first.inspect
+    assert_equal 3, retagged_artefacts.size
+    assert retagged_artefacts.first.tag_ids.include?("housing/landlords")
+    assert retagged_artefacts.first.tag_ids.include?("housing/owning-renting-property")
+    assert retagged_artefacts.last.tag_ids.include?("housing/landlords")
+    refute retagged_artefacts.last.tag_ids.include?("housing/owning-renting-property")
+
+    assert_equal 3, Artefact.any_in(tag_ids: [/something/]).count
+
+  end
+
+end


### PR DESCRIPTION
Renaming the tag 'housing' to 'housing-local-services' so 'housing' can be reused as a topic.

There is a Whitehall PR for retagging detailed guides (https://github.com/alphagov/whitehall/pull/1796) and a Router-data PR (https://github.gds/gds/router-data/pull/198) for redirecting the browse categories.
