### PR TITLE
Fix error when attempting to create without a slug

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -250,7 +250,7 @@ class ArtefactsController < ApplicationController
 
       # url-arbiter would reject this request, therefore rely on our model validation to make
       # the error messaging better
-      return if parameters_to_use['owning_app'].blank?
+      return if @artefact.slug.blank? || parameters_to_use['owning_app'].blank?
 
       Rails.application.url_arbiter_api.reserve_path("/#{@artefact.slug}", "publishing_app" => parameters_to_use['owning_app'])
     rescue GOVUK::Client::Errors::Conflict => e

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -196,6 +196,22 @@ class ArtefactsControllerTest < ActionController::TestCase
           Artefact.any_instance.stubs(:need)
           post :create, :artefact => { :slug => 'not/valid', :owning_app => 'smart-answers', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
         end
+
+        should "not blow up if not given a slug" do
+          # simulate the error that url-arbiter would return if it was called
+          url_arbiter_returns_validation_error_for("/", "path" => ["can't be blank"])
+
+          post :create, :artefact => {
+            :owning_app => 'smart-answers',
+            :slug => '',
+            :kind => 'smart-answer',
+            :name => 'Whatever',
+            :need_ids => '100001'
+          }
+
+          assert_template('new')
+          assert_equal ["can't be blank"], assigns[:artefact].errors[:slug]
+        end
       end
 
       should "redirect to GET edit" do


### PR DESCRIPTION
This was attempting to register the blank slug with url-arbiter, which
returned a validation error.  This avoids calling url-arbiter for these
requests because we know they'll be invalid.
