### PR TITLE
Bump govuk_content_models to 22.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "20.2.0"
+  gem "govuk_content_models", "22.1.2"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,6 @@ GEM
       nokogiri (>= 1.5.0)
     database_cleaner (0.8.0)
     diff-lcs (1.1.3)
-    differ (0.1.2)
     domain_name (0.5.18)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
@@ -139,9 +138,8 @@ GEM
       bootstrap-sass (= 3.2.0.0)
       jquery-rails (= 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (20.2.0)
+    govuk_content_models (22.1.2)
       bson_ext
-      differ
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 7.0.0, < 10.0.0)
       govspeak (~> 3.1.0)
@@ -358,7 +356,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.1.2)
-  govuk_content_models (= 20.2.0)
+  govuk_content_models (= 22.1.2)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
This version bump adds the new artefact type of MAIB Reports being published by specialist_publisher
