### PR TITLE
Remove section and sector tag controls for Publisher content.

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -30,7 +30,11 @@ class Artefact
   end
 
   def allow_specialist_sector_tag_changes?
-    owning_app != 'whitehall'
+    owning_app != 'publisher' && owning_app != 'whitehall'
+  end
+
+  def allow_section_tag_changes?
+    owning_app != 'publisher'
   end
 
 end

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -1,21 +1,29 @@
 <div class="well">
   <%= f.inputs "Tags" do %>
-    <div class="section-tags fieldset-section">
-      <label for="artefact[sections][]" class="section-label">Sections</label>
+    <% if f.object.allow_section_tag_changes? %>
+      <div class="section-tags fieldset-section">
+        <label for="artefact[sections][]" class="section-label">Sections</label>
 
-      <p>The first section will be the primary section the content lives in. This will form the content breadcrumb.</p>
-      <div class="add-vertical-margins nested-item-group">
-        <% if f.object.section_ids.length > 0 %>
-          <% f.object.section_ids.each do | section_id | %>
-            <%= render :partial => 'artefact_section', :locals => {:section_id => section_id, :tag_collection => tag_collection} %>
+        <p>The first section will be the primary section the content lives in. This will form the content breadcrumb.</p>
+        <div class="add-vertical-margins nested-item-group">
+          <% if f.object.section_ids.length > 0 %>
+            <% f.object.section_ids.each do | section_id | %>
+              <%= render :partial => 'artefact_section', :locals => {:section_id => section_id, :tag_collection => tag_collection} %>
+            <% end %>
+          <% else %>
+            <%= render :partial => 'artefact_section', :locals => {:section_id => nil, :tag_collection => tag_collection} %>
           <% end %>
-        <% else %>
-          <%= render :partial => 'artefact_section', :locals => {:section_id => nil, :tag_collection => tag_collection} %>
-        <% end %>
-      </div>
+        </div>
 
-      <button id="add-section" class="btn btn-success" type="button">Add another section</button>
-    </div>
+        <button id="add-section" class="btn btn-success" type="button">Add another section</button>
+      </div>
+    <% else %>
+      <p>
+        Sections and specialist sectors for Publisher content are now managed
+        in the Publisher app under the names "Mainstream browse pages" and
+        "Topics".
+      </p>
+    <% end %>
 
     <div class="legacy-source-tags fieldset-section">
       <label for="artefact_legacy_source_ids" class="section-label">Legacy sources</label>

--- a/features/editing.feature
+++ b/features/editing.feature
@@ -28,20 +28,18 @@ Feature: Editing artefacts
     Then I should be redirected to Publisher
 
   Scenario: Add a section
-    Given an artefact exists
+    Given a non-publisher artefact exists
       And a section exists
     When I add the section to the artefact
-    Then I should be redirected to Publisher
-      And the API should say that the artefact has the section
+    Then the API should say that the artefact has the section
 
   Scenario: Remove a section
-    Given an artefact exists
+    Given a non-publisher artefact exists
       And two sections exist
       And the artefact has both sections
     When I remove the second section from the artefact
-    Then I should be redirected to Publisher
-      And the API should say that the artefact has the first section
-      And the API should say that the artefact does not have the second section
+    Then the API should say that the artefact has the first section
+    And the API should say that the artefact does not have the second section
 
   @javascript
   Scenario: Editing an item that's draft
@@ -52,7 +50,7 @@ Feature: Editing artefacts
     Then rummager should not be notified
 
   Scenario: Editing a live item
-    Given an artefact exists
+    Given a non-publisher artefact exists
       And the first artefact is live
       And a section exists
     When I add the section to the artefact

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -14,6 +14,10 @@ Given /^the first artefact is live$/ do
   end
 end
 
+Given /^a non-publisher artefact exists$/ do
+  @artefact = create_artefact("smart-answers")
+end
+
 Given /^two non-publisher artefacts exist$/ do
   @artefact, @related_artefact = create_two_artefacts("smart-answers")
 end

--- a/features/support/artefacts.rb
+++ b/features/support/artefacts.rb
@@ -1,7 +1,7 @@
 require 'govuk_content_models/test_helpers/factories'
 
-def create_artefact
-  FactoryGirl.create :artefact, :name => 'Child Benefit rates', :need_ids => ['100001']
+def create_artefact(owning_app="publisher")
+  FactoryGirl.create :artefact, :name => 'Child Benefit rates', :need_ids => ['100001'], owning_app: owning_app
 end
 
 def create_two_artefacts(owning_app="publisher")

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -15,7 +15,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
       @artefact = FactoryGirl.create(:artefact,
                                      name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
-                                     owning_app: "publisher", language: "en", business_proposition: true,
+                                     owning_app: "smart-answers", language: "en", business_proposition: true,
                                      section_ids: ["business/employing-people"], legacy_source_ids: ["businesslink"])
     end
 
@@ -35,8 +35,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       end
 
       within ".owning-app" do
-        assert page.has_content? "This content is managed in Publisher"
-        assert page.has_link? "Edit in Publisher"
+        assert page.has_content? "This content is managed in Smart-answers"
       end
 
       within ".section-tags" do
@@ -64,6 +63,18 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       visit "/artefacts/#{@artefact.id}/edit"
 
       assert page.has_no_field? "Slug"
+    end
+
+    should "not show collections fields for Publisher content" do
+      publisher_artefact = FactoryGirl.create(:artefact, :draft, owning_app: "publisher")
+      visit "/artefacts/#{publisher_artefact.id}/edit"
+      assert page.has_no_select?("artefact[sections][]")
+      assert page.has_no_select?("artefact[specialist_sector_ids][]")
+
+      non_publisher_artefact = FactoryGirl.create(:artefact, :draft, :non_publisher)
+      visit "/artefacts/#{non_publisher_artefact.id}/edit"
+      assert page.has_select?("artefact[sections][]")
+      assert page.has_select?("artefact[specialist_sector_ids][]")
     end
 
     should "permit changes to the slug for a draft artefact" do
@@ -176,7 +187,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'charities', title: 'Charities')
       FactoryGirl.create(:live_tag, tag_type: 'specialist_sector', tag_id: 'charities/starting-a-charity', title: 'Starting a charity', parent_id: 'charities')
 
-      @artefact = FactoryGirl.create(:artefact, :name => "VAT")
+      @artefact = FactoryGirl.create(:artefact, :non_publisher, :name => "VAT")
     end
 
     should "allow adding specialist sectors to artefacts" do
@@ -289,7 +300,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       FactoryGirl.create(:live_tag, tag_type: 'section', tag_id: 'visas-immigration', title: 'Visas and immigration')
       FactoryGirl.create(:live_tag, tag_type: 'section', tag_id: 'visas-immigration/student-visas', title: 'Student visas', parent_id: 'visas-immigration')
 
-      @artefact = FactoryGirl.create(:artefact, :name => 'VAT')
+      @artefact = FactoryGirl.create(:artefact, :non_publisher, :name => 'VAT')
     end
 
     should 'allow adding sections to artefacts' do

--- a/test/unit/enhancements/artefact_test.rb
+++ b/test/unit/enhancements/artefact_test.rb
@@ -58,8 +58,8 @@ class ArtefactTest < ActiveSupport::TestCase
   end
 
   context '#allow_specialist_sector_tag_changes?' do
-    should 'be true for a non-whitehall artefact' do
-      artefact = FactoryGirl.build(:artefact, owning_app: 'publisher')
+    should 'be true for a non-whitehall non-publisher artefact' do
+      artefact = FactoryGirl.build(:artefact, owning_app: 'smart-answers')
 
       assert artefact.allow_specialist_sector_tag_changes?
     end
@@ -68,6 +68,26 @@ class ArtefactTest < ActiveSupport::TestCase
       artefact = FactoryGirl.build(:whitehall_draft_artefact)
 
       assert_equal false, artefact.allow_specialist_sector_tag_changes?
+    end
+
+    should 'be false for a publisher artefact' do
+      artefact = FactoryGirl.build(:artefact, owning_app: 'publisher')
+
+      assert_equal false, artefact.allow_specialist_sector_tag_changes?
+    end
+  end
+
+  context '#allow_section_tag_changes?' do
+    should 'be true for a non-publisher artefact' do
+      artefact = FactoryGirl.build(:artefact, :non_publisher)
+
+      assert artefact.allow_section_tag_changes?
+    end
+
+    should 'be false for a publisher artefact' do
+      artefact = FactoryGirl.build(:artefact, owning_app: 'publisher')
+
+      assert_equal false, artefact.allow_section_tag_changes?
     end
   end
 


### PR DESCRIPTION
DO NOT MERGE WITHOUT:
- [x] Code review
- [x] Coordination with these tickets: https://github.com/alphagov/publisher/pull/270 and https://github.com/alphagov/publisher/pull/276

https://www.pivotaltracker.com/story/show/79293166

This functionality is moving to Publisher.

Before:
![screenshot 2014-10-27 13 24 58](https://cloud.githubusercontent.com/assets/109225/4791832/f66e6426-5de0-11e4-9cab-b764a10ab37d.png)

After:
![screenshot 2014-10-27 13 32 46](https://cloud.githubusercontent.com/assets/109225/4791834/fb34b1fe-5de0-11e4-8bbe-6e664e9559cf.png)
