### PR TITLE
Remove manuals artefacts

### DIFF
--- a/db/migrate/20141107140840_remove_manuals_artefacts.rb
+++ b/db/migrate/20141107140840_remove_manuals_artefacts.rb
@@ -1,0 +1,8 @@
+class RemoveManualsArtefacts < Mongoid::Migration
+  def self.up
+    Artefact.where(owning_app: "specialist-publisher", rendering_app: "manuals-frontend").destroy_all
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Manuals are no longer being published to the Content Store, rather than the Content API.
This change purges the current data in the shared DB, because accessing the content in the
Content API now returns 503.
