### PR TITLE
Rake task to delete a slug from search

### DIFF
--- a/lib/tasks/delete_slug_from_search.rake
+++ b/lib/tasks/delete_slug_from_search.rake
@@ -2,5 +2,6 @@ desc "Delete mainstream slugs from search.\n
 See original documentation @ https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change"
 
 task :delete_mainstream_slug_from_search, [:slug] => :environment do |_task, args|
+  raise "Slug must be present!" if args[:slug].blank?
   SearchIndex.instance.delete(args[:slug])
 end

--- a/lib/tasks/delete_slug_from_search.rake
+++ b/lib/tasks/delete_slug_from_search.rake
@@ -2,6 +2,8 @@ desc "Delete mainstream slugs from search.\n
 See original documentation @ https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change"
 
 task :delete_mainstream_slug_from_search, [:slug] => :environment do |_task, args|
-  raise "Slug must be present!" if args[:slug].blank?
-  SearchIndex.instance.delete(args[:slug])
+  slug = args[:slug]
+  raise "Slug must be present!" if slug.blank?
+  slug = (slug =~ /^\// ? slug : "/#{slug}")
+  SearchIndex.instance.delete(slug)
 end

--- a/lib/tasks/delete_slug_from_search.rake
+++ b/lib/tasks/delete_slug_from_search.rake
@@ -1,0 +1,6 @@
+desc "Delete mainstream slugs from search.\n
+See original documentation @ https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change"
+
+task :delete_mainstream_slug_from_search, [:slug] => :environment do |_task, args|
+  SearchIndex.instance.delete(args[:slug])
+end


### PR DESCRIPTION
As part of changing a mainstream slug we need to first delete the slug from panopticon. This rake task will help to make that process easier.

See:
https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change
