### PR TITLE
Update docs for deleting a mainstream slug

### DIFF
--- a/lib/tasks/delete_mainstream_slug_from_search.rake
+++ b/lib/tasks/delete_mainstream_slug_from_search.rake
@@ -1,5 +1,4 @@
-desc "Delete mainstream slugs from search.\n
-See original documentation @ https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change"
+desc "Delete a mainstream slug from search"
 
 task :delete_mainstream_slug_from_search, [:slug] => :environment do |_task, args|
   slug = args[:slug]


### PR DESCRIPTION
This line will be removed from the original documentation. This code is relatively self documenting and means we no longer need to duplicate keeping documentation closer to the codebase.
