### PR TITLE
Add organisation slug changer rake task

### DIFF
--- a/lib/organisation_slug_changer.rb
+++ b/lib/organisation_slug_changer.rb
@@ -1,0 +1,64 @@
+class OrganisationSlugChanger
+  def initialize(old_slug, new_slug, logger = nil)
+    @old_slug = old_slug
+    @new_slug = new_slug
+    @logger = logger || Logger.new(nil)
+  end
+
+  def call
+    if organisation.present?
+      change_organisation_slug
+    else
+      logger.info "No organisation tag found with id #{old_slug}, skipping..."
+    end
+  end
+
+  def change_organisation_slug
+    update_organisation_slug
+    update_associated_artefacts
+    reindex_updated_artefacts
+  end
+
+private
+  attr_reader(
+    :old_slug,
+    :new_slug,
+  )
+
+  def organisation
+    @organisation ||= Tag.where(:tag_id => old_slug, :tag_type => 'organisation').first
+  end
+
+  def associated_artefacts
+    Artefact.where(:tag_ids => old_slug)
+  end
+
+  def update_associated_artefacts
+    associated_artefacts.each { |a| update_artefact(a) }
+  end
+
+  def reindexable_artefacts
+    Artefact.where(:state => 'live', :tag_ids => new_slug, :owning_app.ne => 'whitehall')
+  end
+
+  def update_organisation_slug
+    organisation.update_attributes!(:tag_id => new_slug)
+    logger.info "Renamed #{old_slug} => #{new_slug}"
+  end
+
+  def update_artefact(artefact)
+    artefact.organisation_ids = (artefact.organisation_ids - [old_slug] + [new_slug])
+    artefact.save!
+    logger.info "   -> Updated tags for #{artefact.slug}"
+  end
+
+  def reindex_artefact(artefact)
+    RummageableArtefact.new(artefact).submit
+    logger.info "   -> Reindexed #{artefact.slug}"
+  end
+
+  def reindex_updated_artefacts
+    logger.info "Reindexing #{reindexable_artefacts.count} updated artefacts in search"
+    reindexable_artefacts.each { |a| reindex_artefact(a) }
+  end
+end

--- a/lib/tasks/change_organisation_slug.rake
+++ b/lib/tasks/change_organisation_slug.rake
@@ -1,0 +1,30 @@
+desc "Change an organisation slug (DANGER!).\n
+
+This rake task changes an organisation slug in panopticon.
+
+It performs the following steps:
+- changes the organisation slug
+- changes associated artefacts to use the new slug (org slug is used as
+  foreign key)
+- reindexes the updated artefacts in search
+
+It is one part of an inter-related set of steps which must be carefully
+coordinated.
+
+For reference:
+
+https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#changing-an-organisations-slug"
+
+task :change_organisation_slug, [:old_slug, :new_slug] => :environment do |_task, args|
+  logger = Logger.new(STDOUT)
+  if args[:old_slug].present? && args[:new_slug].present?
+    ::OrganisationSlugChanger.new(
+      args[:old_slug],
+      args[:new_slug],
+      logger: logger,
+    ).call
+  else
+    logger.error("Please specifiy [old_slug,new_slug] arguments")
+    exit(1)
+  end
+end

--- a/test/unit/organisation_slug_changer_test.rb
+++ b/test/unit/organisation_slug_changer_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+require 'organisation_slug_changer'
+
+class OrganisationSlugChangerTest < ActiveSupport::TestCase
+  setup do
+    disable_observers!
+
+    @organisation = FactoryGirl.create(
+      :live_tag,
+      tag_type: "organisation",
+      tag_id: "organisation-1",
+      title: "Organisation One"
+    )
+
+    @new_slug = 'new-slug'
+
+    @slug_changer = OrganisationSlugChanger.new(
+      @organisation.tag_id,
+      @new_slug
+    )
+  end
+
+  test 'it changes the organisation tag_id' do
+    @slug_changer.call
+
+    assert_equal @new_slug, @organisation.reload.tag_id
+  end
+
+  test 'updates the organisation_ids of associated artefacts' do
+    stub_rummageable_artefact!
+
+    artefact = create_associated_artefact(@organisation)
+
+    @slug_changer.call
+
+    assert_equal [@new_slug], artefact.reload.organisation_ids
+  end
+
+  test 'it reindexes the updated artefacts in search' do
+    artefact = create_associated_artefact(@organisation)
+
+    rummageable_artefact = stub("rummageable_artefact")
+    rummageable_artefact.expects(:submit)
+    RummageableArtefact.expects(:new).with(artefact).returns(rummageable_artefact)
+
+    @slug_changer.call
+  end
+
+  test 'it does not index an artefact which is owned by whitehall' do
+    artefact = create_associated_artefact(@organisation, owning_app: "whitehall")
+
+    RummageableArtefact.expects(:new).with(artefact).never
+
+    @slug_changer.call
+  end
+
+  def create_associated_artefact(organisation, extra_attributes = {})
+    attributes = {
+      organisations: [organisation.tag_id]
+    }.merge(extra_attributes)
+    FactoryGirl.create(:live_artefact, attributes)
+  end
+
+  def disable_observers!
+    UpdateRouterObserver.any_instance.stubs(:after_save)
+    UpdateSearchObserver.any_instance.stubs(:after_save)
+  end
+
+  def stub_rummageable_artefact!
+    RummageableArtefact.any_instance.stubs(:submit)
+  end
+end


### PR DESCRIPTION
This rake task performs the following steps:
- updates the org slug
- updates associated artefacts to use the new slug (since org slug is used as
  foreign key)
- reindexes the updated artefacts in search

It is one part of an inter-related set of steps which must be carefully coordinated. The idea of using rake tasks in each app is that all of the rake tasks can then be deployed independently and then the execution of the rake tasks can be coordinated without needing to tie-in with deployments.

https://www.pivotaltracker.com/story/show/80284724
