### PR TITLE
Send public timestamp and change note to rummager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,13 +39,13 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "22.2.0"
+  gem "govuk_content_models", "24.2.0"
 end
 
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
 else
-  gem 'gds-sso', '9.3.0'
+  gem 'gds-sso', '10.0.0'
 end
 
 gem 'govuk_admin_template', '1.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    gds-sso (9.3.0)
+    gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -138,10 +138,10 @@ GEM
       bootstrap-sass (= 3.2.0.0)
       jquery-rails (= 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (22.2.0)
+    govuk_content_models (24.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 7.0.0, < 10.0.0)
+      gds-sso (>= 10.0.0)
       govspeak (~> 3.1.0)
       mongoid (~> 2.5)
       plek
@@ -352,11 +352,11 @@ DEPENDENCIES
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 10.10.0)
-  gds-sso (= 9.3.0)
+  gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.1.2)
-  govuk_content_models (= 22.2.0)
+  govuk_content_models (= 24.2.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -78,7 +78,16 @@ class RummageableArtefact
     # When we want to include additional links, this will become an issue
     rummageable_keys = %w{title description format section subsection
       indexable_content boost_phrases organisations additional_links
-      specialist_sectors}
+      specialist_sectors public_timestamp latest_change_note}
+
+    # If a key is in this list, and the corresponding value in the artefact is
+    # nil, then it will be omitted from the hash returned from this method
+    strip_nil_keys = %w{
+      indexable_content
+      description
+      public_timestamp
+      latest_change_note
+    }
 
     # When amending an artefact, requests with the "link" parameter will be
     # refused, because we can't amend the link within Rummager
@@ -87,7 +96,7 @@ class RummageableArtefact
     result = {}
 
     rummageable_keys.each_with_object(result) do |rummageable_key, hash|
-      strip_nils = ["indexable_content", "description"].include? rummageable_key
+      strip_nils = strip_nil_keys.include? rummageable_key
 
       # Use the relevant extraction method from this class if it exists
       if respond_to? "artefact_#{rummageable_key}"
@@ -137,6 +146,12 @@ class RummageableArtefact
 
   def artefact_specialist_sectors
     @artefact.specialist_sectors.map(&:tag_id)
+  end
+
+  def artefact_public_timestamp
+    if @artefact.public_timestamp
+      @artefact.public_timestamp.iso8601
+    end
   end
 
 private

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -79,6 +79,28 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
+  test "should include latest_change_note and public_timestamp if present" do
+    artefact = Artefact.new do |artefact|
+      artefact.name = "My artefact"
+      artefact.slug = "my-artefact"
+      artefact.kind = "guide"
+      artefact.latest_change_note = "Something has changed"
+      artefact.public_timestamp = Time.zone.parse('2014-01-01 12:00:00 +00:00')
+    end
+    # Note: the link is present if we are not amending
+    expected = {
+      "title" => "My artefact",
+      "format" => "guide",
+      "section" => nil,
+      "subsection" => nil,
+      "organisations" => [],
+      "specialist_sectors" => [],
+      "public_timestamp" => "2014-01-01T12:00:00+00:00",
+      "latest_change_note" => "Something has changed",
+    }
+    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+  end
+
   test "should work with no primary section" do
     artefact = Artefact.new do |artefact|
       artefact.name = "My artefact"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82952014

This changes Panopticon to support the new `public_timestamp` and `latest_change_note` fields added in alphagov/govuk_content_models#251. 

This also changes the `RummageableArtefact` model to include these new fields when rendering an artefact to be sent to Rummager.
