### PR TITLE
Make specialist_sector_cleanup non-interactive

### DIFF
--- a/lib/tasks/specialist_sector_cleanup.rake
+++ b/lib/tasks/specialist_sector_cleanup.rake
@@ -1,39 +1,30 @@
 desc "Deleting specialist sectors"
 task :specialist_sector_cleanup => :environment do
-  puts "Which specialist sector is being deleted?"
-  slug = STDIN.gets.chomp
+  if ENV['SLUG'].present?
+    slug = ENV.fetch('SLUG')
+    tag = Tag.where(tag_id: slug, tag_type: "specialist_sector").first
 
-  tag = Tag.where(tag_id: slug, tag_type: "specialist_sector").first
+    if tag
+      puts "Tag #{slug} found"
 
-  if tag
-    puts "Tag #{slug} found"
+      if tag.live?
+        puts "WARNING! This sector has been published.  You will need to redirect its URL"
+      end
 
-    if tag.live?
-      puts "WARNING! This sector has been published.  You will need to redirect its URL"; puts
-    end
-
-    puts "What would you like to do?"
-    puts "1. Delete the tag, removing it from the search index"
-    puts "2. Do nothing [default]"
-
-    case STDIN.gets.chomp
-    when "1"
       # Archiving the artefact will trigger its removal from the search index.
       artefact = Artefact.where(slug: slug, kind: "specialist_sector").first
-      puts "Archiving artefact"
+      puts "Archiving artefact \"#{artefact.id}\""
       artefact.state = "archived"
       artefact.save
 
-      puts "Deleting tag"
+      puts "Deleting tag \"#{tag.tag_id}\""
       tag.destroy
-    when "2", ""
-      puts "Doing nothing"
-      exit
     else
-      puts "Invalid option"
-      exit
+      puts "The sector '#{slug}' could not be found"
     end
   else
-    puts "The sector '#{slug}' could not be found"
+    puts "Error: the slug of the sector was not provided."
+    puts "Run this task again, setting the SLUG environment variable."
+    puts "\teg. rake specialist_sector_cleanup SLUG=\"the-slug\""
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/83309174

So that we can run the task easily using Fabric, we need to remove the interactivity from the `specialist_sector_cleanup` Rake task.

The task performs only one operation, so the removal of interactivity is not a significant functionality regression.

I've also added some additional output in cases where the sector slug is not provided.
