### PR TITLE
Request reindex of editions when topics go live

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,8 @@ group :test do
   gem 'poltergeist', '~> 1.5.0'
 end
 
+gem 'debugger', group: [:test, :development]
+
 group :import do
   gem 'nokogiri'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', "10.10.0"
+  gem 'gds-api-adapters', '16.5.0'
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       execjs
     coffee-script-source (1.7.1)
     colorize (0.5.8)
+    columnize (0.8.9)
     compass (0.12.2)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -88,6 +89,12 @@ GEM
       cucumber (>= 1.1.8)
       nokogiri (>= 1.5.0)
     database_cleaner (0.8.0)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.7)
     diff-lcs (1.1.3)
     domain_name (0.5.18)
       unf (>= 0.0.5, < 1.0.0)
@@ -347,6 +354,7 @@ DEPENDENCIES
   colorize (~> 0.5.8)
   cucumber-rails
   database_cleaner
+  debugger
   factory_girl (= 3.3.0)
   factory_girl_rails
   formtastic (= 2.3.0.rc4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,11 +113,12 @@ GEM
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
     fssm (0.2.10)
-    gds-api-adapters (10.10.0)
+    gds-api-adapters (16.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rack-cache
       rest-client (~> 1.6.3)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
@@ -359,7 +360,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 10.10.0)
+  gds-api-adapters (= 16.5.0)
   gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)

--- a/app/observers/update_specialist_sector_tag_artefact_observer.rb
+++ b/app/observers/update_specialist_sector_tag_artefact_observer.rb
@@ -2,10 +2,19 @@ class UpdateSpecialistSectorTagArtefactObserver < Mongoid::Observer
   observe :tag
 
   def after_update(tag)
-    update_artefact(tag) if tag.tag_type == 'specialist_sector'
+    if tag.tag_type == 'specialist_sector'
+      reindex_tagged_documents(tag) if tag.state_changed? && tag.live?
+      update_artefact(tag)
+    end
   end
 
 private
+
+  def reindex_tagged_documents(tag)
+    Panopticon.whitehall_admin_api.reindex_specialist_sector_editions(tag.tag_id)
+    Panopticon.publisher_api.reindex_topic_editions(tag.tag_id)
+  end
+
   def update_artefact(tag)
     artefact = Artefact.where(kind: 'specialist_sector', slug: tag.tag_id).first
     artefact.update_attributes(name: tag.title, state: tag.state) if artefact

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ require 'govuk/client/url_arbiter'
 
 module Panopticon
   mattr_accessor :need_api
+  mattr_accessor :whitehall_admin_api
+  mattr_accessor :publisher_api
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/publisher_api.rb
+++ b/config/initializers/publisher_api.rb
@@ -1,0 +1,8 @@
+# This file is replaced on deploy
+
+require 'gds_api/base'
+require 'gds_api/publisher'
+
+Panopticon.publisher_api = GdsApi::Publisher.new(Plek.current.find("publisher"),
+  bearer_token: ENV["panopticon_publisher_api_bearer_token"] || "not a real bearer token"
+)

--- a/config/initializers/whitehall_admin_api.rb
+++ b/config/initializers/whitehall_admin_api.rb
@@ -1,0 +1,8 @@
+# This file is replaced on deploy
+
+require 'gds_api/base'
+require 'gds_api/whitehall_admin_api'
+
+Panopticon.whitehall_admin_api = GdsApi::WhitehallAdminApi.new(Plek.current.find("whitehall-admin"),
+  bearer_token: ENV["panopticon_whitehall_admin_api_bearer_token"] || "not a real bearer token"
+)

--- a/features/managing_tags.feature
+++ b/features/managing_tags.feature
@@ -17,3 +17,10 @@ Feature: Managing tags
     And a draft tag exists
     When I publish the tag
     Then the tag should appear as live
+
+  @stub-topic-reindex-endpoints
+  Scenario: Publishing a topic (aka specialist sector) tag
+    Given I am a user who can edit tags
+    And a draft topic tag exists
+    When I publish the tag
+    Then Whitehall and Publisher should have been asked to reindex tagged editions

--- a/features/step_definitions/tags_steps.rb
+++ b/features/step_definitions/tags_steps.rb
@@ -6,6 +6,10 @@ Given /^a draft tag exists$/ do
   @tag = create(:draft_tag)
 end
 
+Given /^a draft topic tag exists$/ do
+  @tag = create(:draft_tag, tag_type: "specialist_sector")
+end
+
 When /^I create a new tag$/ do
   visit new_tag_path
   fill_in_tag_attributes_in_form
@@ -41,4 +45,9 @@ end
 Then /^the tag should appear as live$/ do
   visit edit_tag_path(@tag)
   assert_state_on_edit_form 'live'
+end
+
+Then /^Whitehall and Publisher should have been asked to reindex tagged editions$/ do
+  assert_whitehall_received_reindex_request_for(@tag.tag_id)
+  assert_publisher_received_reindex_request_for(@tag.tag_id)
 end

--- a/features/support/topic_reindex_endpoints.rb
+++ b/features/support/topic_reindex_endpoints.rb
@@ -1,0 +1,10 @@
+require 'gds_api/test_helpers/whitehall_admin_api'
+require 'gds_api/test_helpers/publisher'
+
+include GdsApi::TestHelpers::WhitehallAdminApi
+include GdsApi::TestHelpers::Publisher
+
+Before('@stub-topic-reindex-endpoints') do
+  stub_all_whitehall_admin_api_requests
+  stub_all_publisher_api_requests
+end

--- a/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
+++ b/test/unit/observers/update_specialist_sector_tag_artefact_observer_test.rb
@@ -4,13 +4,22 @@ class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
   setup do
     stub_all_router_api_requests
     stub_all_rummager_requests
-    
-    @tag = FactoryGirl.create(:draft_tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
+    Panopticon.whitehall_admin_api.stubs(reindex_specialist_sector_editions: nil)
+    Panopticon.publisher_api.stubs(reindex_topic_editions: nil)
+
+    @tag = FactoryGirl.create(:draft_tag,
+      tag_type: 'specialist_sector',
+      tag_id: 'oil-and-gas/licensing',
+      parent_id: 'oil-and-gas'
+    )
   end
 
   context 'when an artefact exists for the tag' do
     setup do
-      @artefact = FactoryGirl.create(:artefact, kind: 'specialist_sector', slug: 'oil-and-gas')
+      @artefact = FactoryGirl.create(:artefact,
+        kind: 'specialist_sector',
+        slug: 'oil-and-gas/licensing'
+      )
     end
 
     should 'update the artefact name' do
@@ -21,6 +30,20 @@ class UpdateSpecialistSectorTagArtefactObserverTest < ActiveSupport::TestCase
     should 'update the artefact state' do
       @tag.publish!
       assert_equal 'live', @artefact.reload.state
+    end
+
+    should 'trigger reindex of tagged documents on publish' do
+      Panopticon.whitehall_admin_api.expects(:reindex_specialist_sector_editions).with('oil-and-gas/licensing').once
+      Panopticon.publisher_api.expects(:reindex_topic_editions).with('oil-and-gas/licensing').once
+
+      @tag.publish!
+    end
+
+    should 'not trigger reindex of tagged documents on non-publish saves' do
+      Panopticon.whitehall_admin_api.expects(:reindex_specialist_sector_editions).never
+      Panopticon.publisher_api.expects(:reindex_topic_editions).never
+
+      @tag.update_attributes(title: 'A brand new title')
     end
   end
 


### PR DESCRIPTION
Sends reindex requests to Whitehall and Publisher
to request the async reindexing of tagged editions
when topics go live.

This prevents search getting out of date, which will
in future be handled by the content store pipeline.

https://www.pivotaltracker.com/story/show/83216144
