### PR TITLE
Add a script to redirect a specialist sector

### DIFF
--- a/lib/tasks/specialist_sector_redirect.rake
+++ b/lib/tasks/specialist_sector_redirect.rake
@@ -1,0 +1,52 @@
+require 'gds_api/publishing_api'
+
+desc "Redirect old specialist sectors"
+task :specialist_sector_redirect => :environment do
+  if ENV['OLD_SLUG'].present? && ENV['NEW_SLUG'].present?
+    old_slug = ENV.fetch('OLD_SLUG')
+    new_slug = ENV.fetch('NEW_SLUG')
+    old_tag = Tag.where(tag_id: old_slug, tag_type: "specialist_sector").first
+    new_tag = Tag.where(tag_id: new_slug, tag_type: "specialist_sector").first
+
+    if old_tag && new_tag
+      puts "Old and new tags found"
+      was_live = old_tag.live?
+
+      # Archiving the artefact will trigger its removal from the search index.
+      artefact = Artefact.where(slug: old_slug, kind: "specialist_sector").first
+      puts "Archiving artefact \"#{artefact.id}\""
+      artefact.state = "archived"
+      artefact.save
+
+      puts "Deleting tag \"#{old_tag.tag_id}\""
+      old_tag.destroy
+
+      if was_live
+        publishing_api = GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+        document_for_publishing_api = {
+          base_path: "/#{old_slug}",
+          format: "redirect",
+          publishing_app: "collections-publisher",
+          update_type: "major",
+          redirects: [
+            {"path" => "/#{old_slug}", "type" => "prefix", "destination" => "/#{new_slug}"},
+          ]
+        }
+        publishing_api.put_content_item("/#{old_slug}", document_for_publishing_api)
+      else
+        puts "This sector had not been published.  Not setting a redirect"
+      end
+    else
+      unless old_tag
+        puts "Old sector '#{old_slug}' could not be found"
+      end
+      unless new_tag
+        puts "New sector '#{new_slug}' could not be found"
+      end
+    end
+  else
+    puts "Error: old and new slugs were not provided."
+    puts "Run this task again, setting the OLD_SLUG and NEW_SLUG environment variables."
+    puts "\teg. rake specialist_sector_redirect OLD_SLUG='old-slug' NEW_SLUG='new-slug'"
+  end
+end


### PR DESCRIPTION
Currently, when changing a slug for a specialist sector, we first
archive the sector at the old slug (causing it to return a 410 Gone HTTP
status), and then apply a change with router-data to redirect the old
slug to the new one.

Instead, this commit adds a script to redirect a sector to a new slug,
archiving the sector in panopticon, and then registering the old slug as
a redirect content item in the content store.

The repository that this script lives in is awkward to get right: I've
chosen to put it in panopticon, because it lives in panopticon, and uses
govuk_content_models to archive the topic.  However, collections-publisher
is the publishing app for "curated" sectors, so we register the document
as having "collections-publisher" as the owning app.  In the near future,
collections-publisher will take ownership of topics, so this is a
convenient "lie".

This script should only exist until collections-publisher takes
ownership of topics, which is work we hope to complete in the next few
weeks.  However, we also have potentially a lot of topic slug changes to
do in the next few weeks, so making this process easy at the cost of
some code mess seems like a good tradeoff.

It's also worth noting that when the topic is archived, a "gone" route
will be set up in the router, but this will be overwritten within
seconds by the redirect route from the content store.  This is unlikely
to affect users, so I don't think it's worth trying to avoid this at the
cost of a more intrusive script.
