### PR TITLE
Update specialist_sector artefact before registration

### DIFF
--- a/app/observers/update_specialist_sector_tag_artefact_observer.rb
+++ b/app/observers/update_specialist_sector_tag_artefact_observer.rb
@@ -3,8 +3,8 @@ class UpdateSpecialistSectorTagArtefactObserver < Mongoid::Observer
 
   def after_update(tag)
     if tag.tag_type == 'specialist_sector'
-      reindex_tagged_documents(tag) if tag.state_changed? && tag.live?
       update_artefact(tag)
+      reindex_tagged_documents(tag) if tag.state_changed? && tag.live?
     end
   end
 


### PR DESCRIPTION
When a specialist sector is updated, we should update its artefact
before triggering a reindex of its content.  This avoids errors in the
reindexing causing the tag and artefact state to get out of sync (and
also means that if the reindex depended on the value of the artefact, we
wouldn't have a race condition).
