### PR TITLE
Add gosuperfast to exceptional slugs

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -8,6 +8,7 @@ class RummageableArtefact
   FORMATS_NOT_TO_AMEND = %W(specialist_sector)
 
   EXCEPTIONAL_SLUGS = %W(
+    gosuperfast
     growthaccelerator
     technology-strategy-board
     enterprise-finance-guarantee


### PR DESCRIPTION
We're seeing significant search traffic trying to find it, but it's currently excluded from our search index.  This commit enables indexing of it.
