### PR TITLE
Bump govuk_content_models to 28.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "28.0.1"
+  gem "govuk_content_models", "28.5.0"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.0.1)
+    govuk_content_models (28.5.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -365,7 +365,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.4.0)
-  govuk_content_models (= 28.0.1)
+  govuk_content_models (= 28.5.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
This is so we can publish `european_structural_investment_fund` and `countryside_stewardship_grant` artefacts from Specialist Publisher
