### PR TITLE
Update libv8 to fix error on bundle install on OS X Yosemite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     kramdown (1.4.2)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)


### PR DESCRIPTION
I was seeing the following compilation error when running bundle install:

```
../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
```

I believe the problem was [fixed](https://github.com/cowboyd/libv8/pull/124) between version 3.16.14.3 and version 3.16.14.7
of libv8 and a simple bundle update libv8 seems to have done the trick.
