### PR TITLE
Update poltergeist to work with latest phantomjs (v2.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
   gem 'launchy'
   gem 'mocha', '0.13.3', :require => false
   gem 'webmock', require: false
-  gem 'poltergeist', '~> 1.5.0'
+  gem 'poltergeist', '~> 1.6.0'
 end
 
 gem 'debugger', group: [:test, :development]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.2.0)
       railties (>= 3.2.0)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nested_form (0.3.2)
@@ -237,7 +237,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     plek (1.9.0)
-    poltergeist (1.5.0)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -252,7 +252,7 @@ GEM
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.18)
       actionmailer (= 3.2.18)
@@ -332,7 +332,9 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
     webrobots (0.1.1)
-    websocket-driver (0.3.2)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     whenever (0.9.2)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
@@ -380,7 +382,7 @@ DEPENDENCIES
   nokogiri
   null_logger
   plek (~> 1.8)
-  poltergeist (~> 1.5.0)
+  poltergeist (~> 1.6.0)
   quiet_assets
   rails (= 3.2.18)
   rummageable (= 1.0.1)


### PR DESCRIPTION
I was seeing a bunch of tests failing with the following error:

```
Could not find an executable 'phantomjs' that matched the requirements '~> 1.8', '>= 1.8.1'. Found versions were {"/usr/local/bin/phantomjs"=>"2.0.0"}.
```

The error appears to be related to an incompatibility between poltergeist
v1.3.0 and phantomjs v2.0 which has been fixed in [this issue](https://github.com/teampoltergeist/poltergeist/issues/566) and [released
in poltergeist v1.6.0](https://github.com/teampoltergeist/poltergeist/blob/master/CHANGELOG.md#160).

The newer version of poltergeist seems to work ok with pre-2.0 versions of
phantomjs or at least it does with phantomjs v1.9.8.

c.f. https://github.com/alphagov/calculators/pull/112
