### PR TITLE
Upgrade govuk_content_models, hence govspeak, and hence nokogiri.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "28.5.0"
+  gem "govuk_content_models", "28.6.2"
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,10 +133,10 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (3.1.1)
+    govspeak (3.3.0)
       htmlentities (~> 4)
       kramdown (~> 1.4.1)
-      nokogiri (~> 1.5.10)
+      nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
     govuk-client-url_arbiter (0.0.2)
       multi_json (~> 1.0)
@@ -146,11 +146,11 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.5.0)
+    govuk_content_models (28.6.2)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
+      govspeak (~> 3.1)
       mongoid (~> 2.5)
       plek
       state_machine
@@ -196,6 +196,7 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     metaclass (0.0.1)
     mime-types (1.25.1)
+    mini_portile (0.6.2)
     minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
@@ -216,7 +217,8 @@ GEM
     nested_form (0.3.2)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
-    nokogiri (1.5.11)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     ntlm-http (0.1.1)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -365,7 +367,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 1.4.0)
-  govuk_content_models (= 28.5.0)
+  govuk_content_models (= 28.6.2)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
I was seeing the following test failure when running on OS X Yosemite with the
default `libxml` provided by Apple:

```
ERROR (0:00:26.315) test: ListingTags should display tags in alphabetical order grouped by their parent.
      Unable to find css "li.parent-tag:nth-of-type(2)"
    @ .bundle/gems/gems/capybara-2.1.0/lib/capybara/node/finders.rb:41:in `block in find'
      .bundle/gems/gems/capybara-2.1.0/lib/capybara/node/base.rb:81:in `synchronize'
      .bundle/gems/gems/capybara-2.1.0/lib/capybara/node/finders.rb:30:in `find'
      .bundle/gems/gems/capybara-2.1.0/lib/capybara/session.rb:354:in `block (2 levels) in <class:Session>'
      .bundle/gems/gems/capybara-2.1.0/lib/capybara/session.rb:221:in `within'
      .bundle/gems/gems/capybara-2.1.0/lib/capybara/dsl.rb:51:in `block (2 levels) in <module:DSL>'
      test/integration/listing_tags_test.rb:34:in `block (2 levels) in <class:ListingTagsTest>'
      [...truncated...]
```

I believe this was because the version of the `nokogiri` gem specified in
`Gemfile.lock`, i.e. v1.5.11, was incompatible with the version of `libxml`
available by default in OS X Yosemite.

The `govuk_content_models` gem pinned at `v28.5.0` in the `Gemfile` was
constraining `govspeak` to `~> 3.1.0` which in turn was constraining `nokogiri`
to `~> 1.5.10`. Thus I was prevented from upgrading `nokogiri` to a version
supported by my `libxml` version.

A [pull request](https://github.com/alphagov/govuk_content_models/pull/298) relaxing the former constraint was merged and [released](https://github.com/alphagov/govuk_content_models/pull/299)
in `govuk_content_models` v3.3.0.

This commit upgrades `govuk_content_models` to this new version and upgrades
`nokogiri` to v1.6.6.2 which is the latest version. This fixes my failing test
and all the tests pass on my laptop.

The upgrade of `govuk_content_models` should be ok, because it's just a minor
version change, but I'm not familiar enough with the code to know for sure.
You can see the relevant changes in this [GitHub comparison](https://github.com/alphagov/govuk_content_models/compare/v28.5.0...v28.6.2). The most
significant commits appear to be [this one](c0255a9a3caae30b3d2b8e6195ad089a4e85baa8) and [this one](8af15ef06bea1173d017bfbb912e9b788028c10c).
