### PR TITLE
Don't show the 'archive' tab for an archived artefact

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -42,7 +42,9 @@ class ArtefactsController < ApplicationController
   end
 
   def archive
-
+    if @artefact.archived?
+      redirect_to root_path
+    end
   end
 
   def new

--- a/app/views/artefacts/_artefact_header.html.erb
+++ b/app/views/artefacts/_artefact_header.html.erb
@@ -15,7 +15,9 @@
   <li class="<%= "active" if controller.action_name == "history" %>">
     <%= link_to "History", history_artefact_path(@artefact) %>
   </li>
-  <li class="<%= "active" if controller.action_name == "archive" %>">
-    <%= link_to "Archive", archive_artefact_path(@artefact) %>
-  </li>
+  <% unless @artefact.archived? %>
+    <li class="<%= "active" if controller.action_name == "archive" %>">
+      <%= link_to "Archive", archive_artefact_path(@artefact) %>
+      </li>
+  <% end %>
 </ul>

--- a/features/archiving.feature
+++ b/features/archiving.feature
@@ -1,0 +1,20 @@
+Feature: Archiving artefacts
+  In order to maintain current content on GOV.UK
+  I want to archive artefacts
+
+  Background:
+    Given I am an admin
+      And I have stubbed the router
+      And I have stubbed search
+
+  Scenario: Archiving a live artefact
+    Given a live artefact exists
+    And I click the archive tab on the artefact page
+    And I archive the existing artefact
+    Then I should get redirected to the homepage
+
+  Scenario: Archiving an already archived artefact
+    Given an archived artefact exists
+    Then I should not see the archive tab along with the edit and history tabs
+    When I browse to the "/archive" URL for the artefact
+    Then I should get redirected to the homepage

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -22,6 +22,17 @@ Given /^two non-publisher artefacts exist$/ do
   @artefact, @related_artefact = create_two_artefacts("smart-answers")
 end
 
+Given /^a live artefact exists$/ do
+  @artefact = create_artefact("live-artefact")
+end
+
+Given /^an archived artefact exists$/ do
+  @artefact = create_artefact("archived-artefact")
+  Artefact.observers.disable :update_search_observer do
+    @artefact.update_attributes!('state' => 'archived')
+  end
+end
+
 When /^I change the need ID of the first artefact$/ do
   visit edit_artefact_path(@artefact)
   @new_need_id = "100001"
@@ -160,4 +171,29 @@ end
 
 When /^I try to create a new artefact with the same need$/ do
   visit new_artefact_path(:artefact => {:need_id => @artefact.need_ids.first})
+end
+
+When /^I browse to the "(.*)" URL for the artefact$/ do |path|
+  visit archive_artefact_path(@artefact)
+end
+
+And /^I click the archive tab on the artefact page$/ do
+  visit edit_artefact_path(@artefact)
+  click_link "Archive"
+end
+
+And /^I archive the existing artefact$/ do
+  Artefact.observers.disable :update_search_observer do
+    click_button "Archive"
+  end
+end
+
+Then /^I should not see the archive tab along with the edit and history tabs$/ do
+  visit edit_artefact_path(@artefact)
+  assert page.has_no_css?("ul.artefact-actions li", :count => 3)
+  assert page.has_css?("ul.artefact-actions li", :count => 2)
+end
+
+Then /^I should get redirected to the homepage$/ do
+  URI.parse(current_url).path == root_path
 end


### PR DESCRIPTION
- Given you can't unarchive an artefact, being able to see the
  'Archive' tab or page for an archived artefact seems unintuitive.
- Test this behaviour with Cucumber features.

(It's been a while since I've written any Cucumber...)
