### PR TITLE
Migration to fix the parent_ids for renamed topics

### DIFF
--- a/db/migrate/20150604115012_fix_population_screening_tag_parents.rb
+++ b/db/migrate/20150604115012_fix_population_screening_tag_parents.rb
@@ -1,0 +1,12 @@
+class FixPopulationScreeningTagParents < Mongoid::Migration
+  OLD_PARENT = 'nhs-population-screening-programmes'
+
+  def self.up
+    Tag.where(:tag_type => "specialist_sector", :parent_id => OLD_PARENT).each do |tag|
+      new_parent_id = tag.parent_id.sub(/\Anhs-/, '')
+      puts "Updating #{tag.tag_id} parent #{tag.parent_id} -> #{new_parent_id}"
+      tag.parent_id = new_parent_id
+      tag.save!
+    end
+  end
+end


### PR DESCRIPTION
The previous migration (#253) changed the slug of these tags, but
failed to make the corresponding change to the parent_ids.  This
rectifies that.
