### PR TITLE
Bump poltergeist and libv8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
   gem 'launchy'
   gem 'mocha', '0.13.3', :require => false
   gem 'webmock', require: false
-  gem 'poltergeist', '~> 1.5.0'
+  gem 'poltergeist', '~> 1.6.0'
 end
 
 gem 'debugger', group: [:test, :development]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     plek (1.10.0)
-    poltergeist (1.5.0)
+    poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -332,7 +332,9 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
     webrobots (0.1.1)
-    websocket-driver (0.3.2)
+    websocket-driver (0.5.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     whenever (0.9.2)
       activesupport (>= 2.3.4)
       chronic (>= 0.6.3)
@@ -380,7 +382,7 @@ DEPENDENCIES
   nokogiri
   null_logger
   plek (~> 1.8)
-  poltergeist (~> 1.5.0)
+  poltergeist (~> 1.6.0)
   quiet_assets
   rails (= 3.2.22)
   rummageable (= 1.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     kramdown (1.4.2)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     link_header (0.0.8)
     logstash-event (1.1.5)
     logstasher (0.4.8)


### PR DESCRIPTION
Supersedes #247 and #248 (they no longer apply cleanly)
