### PR TITLE
Remove topic (aka specialist_sector) route registration

### DIFF
--- a/app/forms/specialist_sector_tag_form.rb
+++ b/app/forms/specialist_sector_tag_form.rb
@@ -36,8 +36,6 @@ private
     {
       name: tag.title,
       slug: slug,
-      paths: paths,
-      prefixes: prefixes,
       kind: "specialist_sector",
       owning_app: "panopticon",
       rendering_app: "collections",
@@ -47,17 +45,5 @@ private
 
   def slug
     tag.tag_id
-  end
-
-  def paths
-    child? ? [] : ["/#{slug}"]
-  end
-
-  def prefixes
-    child? ? ["/#{slug}"] : []
-  end
-
-  def child?
-    slug.include?('/')
   end
 end

--- a/db/migrate/20150626111312_remove_specialist_sector_routes.rb
+++ b/db/migrate/20150626111312_remove_specialist_sector_routes.rb
@@ -1,0 +1,11 @@
+class RemoveSpecialistSectorRoutes < Mongoid::Migration
+  def self.up
+    Artefact.where(:kind => "specialist_sector").each do |artefact|
+      artefact.set(:paths, [])
+      artefact.set(:prefixes, [])
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/unit/forms/specialist_sector_tag_form_test.rb
+++ b/test/unit/forms/specialist_sector_tag_form_test.rb
@@ -60,7 +60,7 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       assert_equal 'live', artefact.state
     end
 
-    should 'set paths for a parent tag' do
+    should 'not set any paths or prefixes' do
       subject = SpecialistSectorTagForm.new(
         title: 'Oil and gas',
         tag_type: 'specialist_sector',
@@ -73,28 +73,8 @@ class SpecialistSectorTagFormTest < ActiveSupport::TestCase
       end
 
       artefact = Artefact.last
-      assert_equal ['/oil-and-gas'], artefact.paths
-      assert_equal [], artefact.prefixes
-    end
-
-    should 'set prefixes for a child tag' do
-      parent_tag = FactoryGirl.create(:tag, tag_type: 'specialist_sector', tag_id: 'oil-and-gas')
-
-      subject = SpecialistSectorTagForm.new(
-        title: 'Licensing',
-        tag_type: 'specialist_sector',
-        tag_id: 'oil-and-gas/licensing',
-        parent_id: parent_tag.tag_id
-      )
-      subject.state = 'live'
-
-      assert_difference 'Artefact.count', 1 do
-        subject.save
-      end
-
-      artefact = Artefact.last
       assert_equal [], artefact.paths
-      assert_equal ['/oil-and-gas/licensing'], artefact.prefixes
+      assert_equal [], artefact.prefixes
     end
 
     should 'create a draft artefact for a draft tag' do


### PR DESCRIPTION
This is now handled by collections-publisher via the publishing-api.
Additionally, this was registering the wrong routes (missing the /topic
prefix).

This includes a migration to remove the routes from all existing topics in the db to prevent anything being erroneously registered in future.
