### PR TITLE
Allow PUT of a tag to create instead of 404.

### DIFF
--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -162,12 +162,6 @@ class TagsControllerTest < ActionController::TestCase
       put :update, id: @tag.id, tag: @stub_atts.merge('parent_id' => @tag.parent_id)
     end
 
-    should "return a not found error if a tag doesn't exist" do
-      put :update, id: "foo", tag: @stub_atts
-
-      assert response.not_found?
-    end
-
     should "redirect to the tags list on a successful update" do
       Tag.any_instance.expects(:update_attributes).returns(true)
 

--- a/test/integration/update_tags_test.rb
+++ b/test/integration/update_tags_test.rb
@@ -61,10 +61,52 @@ class UpdateTagsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should 'return an error when the tag does not exist' do
-      put tag_path('section/foo/bar'), { title: 'test', format: 'json' }
+    context "when an existing tag doesn't already exist" do
+      setup do
+        @params = {
+          format: 'json',
+          tag_id: 'driving',
+          tag_type: 'section',
+          title: 'Driving',
+          description: 'All about driving',
+        }
+      end
 
-      assert_equal 404, response.status
+      should 'return a 201 status' do
+        put tag_path("section/driving"), @params
+        assert_equal 201, response.status
+      end
+
+      should 'create a new draft tag with the given parameters' do
+        put tag_path("section/driving"), @params
+
+        tag = Tag.by_tag_id('driving', type: 'section', draft: true)
+        assert tag.present?, "Failed to find driving section tag"
+
+        assert_equal 'Driving', tag.title
+        assert_equal 'All about driving', tag.description
+        assert_equal nil, tag.parent_id
+        assert_equal 'draft', tag.state
+      end
+
+      context "for a non-existent child of an existing parent" do
+        setup do
+          @parent = create(:tag, tag_type: 'section', tag_id: 'driving', title: 'Driving')
+          @params[:tag_id] = 'driving/abroad'
+          @params[:parent_id] = 'driving'
+        end
+
+        should "create a new draft child tag" do
+          put tag_path("section/driving/abroad"), @params
+          puts response.body
+
+          tag = Tag.by_tag_id('driving/abroad', type: 'section', draft: true)
+          assert tag.present?, "Failed to find driving/abroad section tag"
+
+          assert_equal 'driving', tag.parent_id
+          assert_equal 'draft', tag.state
+        end
+      end
     end
   end
 

--- a/test/integration/update_tags_test.rb
+++ b/test/integration/update_tags_test.rb
@@ -1,0 +1,89 @@
+require_relative '../integration_test_helper'
+
+class UpdateTagsTest < ActionDispatch::IntegrationTest
+
+  setup do
+    login_as_user_with_permission('manage_tags')
+  end
+
+  context 'updating a tag' do
+    context "updating an existing tag" do
+      setup do
+        @tag = create(:tag, tag_type: 'section', tag_id: 'tea', title: 'Tea')
+      end
+
+      should 'update an existing tag given valid parameters' do
+        put tag_path(@tag), { title: 'Coffee', format: 'json' }
+
+        assert_equal 200, response.status
+
+        @tag.reload
+        assert_equal 'Coffee', @tag.title
+      end
+
+      should 'return validation errors given invalid parameters' do
+        put tag_path(@tag), { title: '', format: 'json' }
+        body = JSON.parse(response.body)
+
+        assert_equal 422, response.status
+        assert_match /can't be blank/, body['errors']['title'].first
+
+        @tag.reload
+        assert_equal 'Tea', @tag.title
+      end
+
+      context 'fields which cannot be changed' do
+
+        should 'return error when a change is requested to the tag_id' do
+          put tag_path(@tag), { tag_id: 'foo', format: 'json' }
+          body = JSON.parse(response.body)
+
+          assert_equal 422, response.status
+          assert_match "can't be changed", body['errors']['tag_id'].first
+        end
+
+        should 'return error when a change is requested to the parent_id' do
+          put tag_path(@tag), { parent_id: 'foo', format: 'json' }
+          body = JSON.parse(response.body)
+
+          assert_equal 422, response.status
+          assert_match "can't be changed", body['errors']['parent_id'].first
+        end
+
+        should 'return error when a change is requested to the tag_type' do
+          put tag_path(@tag), { tag_type: 'foo', format: 'json' }
+          body = JSON.parse(response.body)
+
+          assert_equal 422, response.status
+          assert_match "can't be changed", body['errors']['tag_type'].first
+        end
+
+      end
+    end
+
+    should 'return an error when the tag does not exist' do
+      put tag_path('section/foo/bar'), { title: 'test', format: 'json' }
+
+      assert_equal 404, response.status
+    end
+  end
+
+  context "publishing a tag" do
+
+    should 'publish a draft tag' do
+      draft_tag = create(:draft_tag)
+      post publish_tag_path(draft_tag), format: 'json'
+
+      assert_equal 200, response.status
+    end
+
+    should 'return an error for requests to publish a live tag' do
+      live_tag = create(:live_tag)
+      post publish_tag_path(live_tag), format: 'json'
+      body = JSON.parse(response.body)
+
+      assert_equal 422, response.status
+      assert_match /already published/, body['error']
+    end
+  end
+end


### PR DESCRIPTION
Collections-publisher is the canonical source of tags. It created them
here via the API when they're created there. It also updates them on any
changes. Currently, if the create_tag call errors for any reason, any
further updates will also fail with a 404, meaning that it's not
possible to get the tag into panopticon without devops intervention.

This updates the tag PUT action to create the tag if it doesn't already
exist, which avoids the problem when creation fails.

Note: controller changes may be easier to see with `?w=1`
