### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '16.5.0'
+  gem 'gds-api-adapters', '20.1.1'
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,13 +126,13 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (16.5.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.6.3)
+      rest-client (~> 1.8.0)
     gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -230,6 +230,7 @@ GEM
     nested_form (0.3.2)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     ntlm-http (0.1.1)
@@ -258,7 +259,7 @@ GEM
     polyglot (0.3.5)
     quiet_assets (1.0.1)
       railties (~> 3.1)
-    rack (1.4.6)
+    rack (1.4.7)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-cache (1.2)
@@ -290,9 +291,10 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     ref (1.0.5)
-    rest-client (1.6.8)
-      mime-types (~> 1.16)
-      rdoc (>= 2.4.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rummageable (1.0.1)
       multi_json
       null_logger
@@ -378,7 +380,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 16.5.0)
+  gds-api-adapters (= 20.1.1)
   gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -26,11 +26,11 @@ class RoutableArtefact
     ensure_backend_exists
     prefixes.each do |path|
       logger.debug("Registering route #{path} (prefix) => #{rendering_app}")
-      router_api.add_route(path, "prefix", rendering_app, :skip_commit => true)
+      router_api.add_route(path, "prefix", rendering_app)
     end
     paths.each do |path|
       logger.debug("Registering route #{path} (exact) => #{rendering_app}")
-      router_api.add_route(path, "exact", rendering_app, :skip_commit => true)
+      router_api.add_route(path, "exact", rendering_app)
     end
     commit unless options[:skip_commit]
   end
@@ -38,15 +38,15 @@ class RoutableArtefact
   def delete(options = {})
     prefixes.each do |path|
       begin
-        logger.debug "Removing route #{path} (prefix)"
-        router_api.delete_route(path, "prefix", :skip_commit => true)
+        logger.debug "Removing route #{path}"
+        router_api.delete_route(path)
       rescue GdsApi::HTTPNotFound
       end
     end
     paths.each do |path|
       begin
-        logger.debug "Removing route #{path} (exact)"
-        router_api.delete_route(path, "exact", :skip_commit => true)
+        logger.debug "Removing route #{path}"
+        router_api.delete_route(path)
       rescue GdsApi::HTTPNotFound
       end
     end

--- a/test/integration/artefact_router_registration_test.rb
+++ b/test/integration/artefact_router_registration_test.rb
@@ -88,7 +88,7 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
 
     should "delete routes in the router then the updated artefact is archived" do
       delete_request = WebMock.stub_request(:delete, "#{@router_api_base}/routes").
-        with(:query => {"incoming_path" => "/foo", "route_type" => "prefix"}).
+        with(:query => {"incoming_path" => "/foo"}).
         to_return(:status => 200)
 
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "archived")
@@ -101,7 +101,7 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
 
     should "not blow up when deleting routes if the routes dont exist" do
       delete_request = WebMock.stub_request(:delete, "#{@router_api_base}/routes").
-        with(:query => {"incoming_path" => "/foo", "route_type" => "prefix"}).
+        with(:query => {"incoming_path" => "/foo"}).
         to_return(:status => 404)
 
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "archived")

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -37,17 +37,17 @@ class RoutableArtefactTest < ActiveSupport::TestCase
     end
 
     should "add all defined prefix routes" do
-      GdsApi::Router.any_instance.expects(:add_route).with("/foo", "prefix", "bee", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:add_route).with("/bar", "prefix", "bee", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:add_route).with("/baz", "prefix", "bee", :skip_commit => true)
+      GdsApi::Router.any_instance.expects(:add_route).with("/foo", "prefix", "bee")
+      GdsApi::Router.any_instance.expects(:add_route).with("/bar", "prefix", "bee")
+      GdsApi::Router.any_instance.expects(:add_route).with("/baz", "prefix", "bee")
 
       @artefact.prefixes = ["/foo", "/bar", "/baz"]
       @routable.submit
     end
 
     should "add all defined exact routes" do
-      GdsApi::Router.any_instance.expects(:add_route).with("/foo.json", "exact", "bee", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:add_route).with("/bar", "exact", "bee", :skip_commit => true)
+      GdsApi::Router.any_instance.expects(:add_route).with("/foo.json", "exact", "bee")
+      GdsApi::Router.any_instance.expects(:add_route).with("/bar", "exact", "bee")
 
       @artefact.paths = ["/foo.json", "/bar"]
       @routable.submit
@@ -85,17 +85,17 @@ class RoutableArtefactTest < ActiveSupport::TestCase
     end
 
     should "delete all defined prefix routes" do
-      GdsApi::Router.any_instance.expects(:delete_route).with("/foo", "prefix", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:delete_route).with("/bar", "prefix", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:delete_route).with("/baz", "prefix", :skip_commit => true)
+      GdsApi::Router.any_instance.expects(:delete_route).with("/foo")
+      GdsApi::Router.any_instance.expects(:delete_route).with("/bar")
+      GdsApi::Router.any_instance.expects(:delete_route).with("/baz")
 
       @artefact.prefixes = ["/foo", "/bar", "/baz"]
       @routable.delete
     end
 
     should "delete all defined exact routes" do
-      GdsApi::Router.any_instance.expects(:delete_route).with("/foo.json", "exact", :skip_commit => true)
-      GdsApi::Router.any_instance.expects(:delete_route).with("/bar", "exact", :skip_commit => true)
+      GdsApi::Router.any_instance.expects(:delete_route).with("/foo.json")
+      GdsApi::Router.any_instance.expects(:delete_route).with("/bar")
 
       @artefact.paths = ["/foo.json", "/bar"]
       @routable.delete
@@ -137,8 +137,8 @@ class RoutableArtefactTest < ActiveSupport::TestCase
       end
 
       should "continue to delete other routes" do
-        GdsApi::Router.any_instance.stubs(:delete_route).with("/foo", "prefix", :skip_commit => true).raises(GdsApi::HTTPNotFound.new(404))
-        GdsApi::Router.any_instance.expects(:delete_route).with("/bar", "prefix", :skip_commit => true)
+        GdsApi::Router.any_instance.stubs(:delete_route).with("/foo").raises(GdsApi::HTTPNotFound.new(404))
+        GdsApi::Router.any_instance.expects(:delete_route).with("/bar")
 
         @artefact.prefixes = ["/foo", "/bar"]
         @routable.delete


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

Includes updates for the changes to the Router api.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information
