### PR TITLE
Delete unused mainstream browse pages

### DIFF
--- a/db/migrate/20150716132102_remove_unused_child_browse_tags.rb
+++ b/db/migrate/20150716132102_remove_unused_child_browse_tags.rb
@@ -1,0 +1,21 @@
+class RemoveUnusedChildBrowseTags < Mongoid::Migration
+
+  TAG_IDS = %w(
+    childcare-parenting/time-off-new-child
+    childcare-parenting/child-into-care
+  )
+
+  def self.up
+    TAG_IDS.each { |tag_id|
+    tag = Tag.where(tag_id: tag_id).first
+     if tag
+        tag.destroy
+        puts "Tag with id #{tag_id} destroyed"
+     end
+    }
+  end
+
+  def self.down
+    # Nothing to do here
+  end
+end


### PR DESCRIPTION
Two childcare mainstream browse pages were created,
but then the content was updated and they're no longer needed.
They were never published, and never should be,
but need deleting to tidy things up.

Ticket:
https://trello.com/c/drh7LqiI/249-delete-two-unused-childcare-mainstream-browse-page-tags
