### PR TITLE
Restore routes for archived whitehall artefacts.

### DIFF
--- a/db/migrate/20150720142931_reregister_archived_whitehall_artefact_routes.rb
+++ b/db/migrate/20150720142931_reregister_archived_whitehall_artefact_routes.rb
@@ -1,0 +1,12 @@
+class ReregisterArchivedWhitehallArtefactRoutes < Mongoid::Migration
+  def self.up
+    Artefact.where(:state => 'archived', :owning_app => 'whitehall').each do |artefact|
+      # register the routes with the router.
+      RoutableArtefact.new(artefact).register
+    end
+    RoutableArtefact.new(nil).commit
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
When artefacts are archived, panopticon normally registers gone routes
for them.  Whitehall-owned artefacts are an exception to this; these
ones are skipped ([1] and previously [2]).

There are currently a number of these whitehall-owned artefacts with
gone routes in the router. This means that the unpublishing redirects
(which are normally served by whitehall itself) are not working.

Additionally, there are a small number of gone routes for live content.
This is probably leftover from the mystery unpublishing bug that's now
been fixed[3].

This adds a migration to restore the routes for all whitehall-owned
artefacts to the state they were before they were archived.

[1]https://github.com/alphagov/panopticon/blob/master/app/models/routable_artefact.rb#L30
[2]https://github.com/alphagov/panopticon/blob/release_703/app/observers/update_router_observer.rb#L7
[3]https://github.com/alphagov/whitehall/pull/1974
