### PR TITLE
Send documents' mainstream browse pages to rummager

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -79,7 +79,7 @@ class RummageableArtefact
     # When we want to include additional links, this will become an issue
     rummageable_keys = %w{title description format section subsection
       indexable_content boost_phrases organisations additional_links
-      specialist_sectors public_timestamp latest_change_note}
+      specialist_sectors public_timestamp latest_change_note mainstream_browse_pages}
 
     # If a key is in this list, and the corresponding value in the artefact is
     # nil, then it will be omitted from the hash returned from this method
@@ -147,6 +147,10 @@ class RummageableArtefact
 
   def artefact_specialist_sectors
     @artefact.specialist_sectors.map(&:tag_id)
+  end
+
+  def artefact_mainstream_browse_pages
+    @artefact.sections.map(&:tag_id)
   end
 
   def artefact_public_timestamp

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -89,7 +89,8 @@ Then /^rummager should be told to do a partial update$/ do
     title: "Child Benefit rates",
     format: "answer",
     section: @section.tag_id,
-    subsection: ""
+    subsection: "",
+    "mainstream_browse_pages[]" => "crime",
   }
   assert_requested :post, artefact_search_url(@artefact), body: amendments
 end

--- a/test/integration/artefact_search_indexing_test.rb
+++ b/test/integration/artefact_search_indexing_test.rb
@@ -75,6 +75,7 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
       "subsection" => "subsection",
       "organisations" => ["cabinet-office"],
       "specialist_sectors" => ["working-sea/health-safety"],
+      "mainstream_browse_pages" => ["a-section/subsection"],
     }
 
     mock_search_index = mock()

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -242,6 +242,33 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
+  test "should include live mainstream browse pages" do
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "a-browse-page-tag")
+
+    artefact = Artefact.new do |artefact|
+      artefact.sections = [
+        'a-browse-page-tag',
+      ]
+    end
+
+    expected = { "mainstream_browse_pages" => ['a-browse-page-tag'] }
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
+  end
+
+  test "should include live second-level mainstream browse pages" do
+    parent_section = FactoryGirl.create(:live_tag, tag_id: "parent-browse-page", tag_type: "section")
+    FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "parent-browse-page/a-browse-page-tag", parent_id: parent_section.tag_id)
+
+    artefact = Artefact.new do |artefact|
+      artefact.sections = [
+        'parent-browse-page/a-browse-page-tag',
+      ]
+    end
+
+    expected = { "mainstream_browse_pages" => ['parent-browse-page/a-browse-page-tag'] }
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
+  end
+
   test "should consider live items should be indexed" do
     artefact = Artefact.new do |artefact|
       artefact.state = "live"

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -20,6 +20,12 @@ class RummageableArtefactTest < ActiveSupport::TestCase
                        parent_id: "working-sea")
   end
 
+  def assert_hash_including(expected_hash, actual_hash)
+    expected_hash.each do |expected_key, expected_value|
+      assert_equal expected_value, actual_hash[expected_key]
+    end
+  end
+
   test "should extract artefact attributes" do
     artefact = Artefact.new do |artefact|
       artefact.name = "My artefact"
@@ -35,7 +41,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash.merge(bla: 'akjd')
   end
 
   test "should include description" do
@@ -55,7 +61,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include indexable content if present" do
@@ -76,7 +82,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include latest_change_note and public_timestamp if present" do
@@ -98,7 +104,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "public_timestamp" => "2014-01-01T12:00:00+00:00",
       "latest_change_note" => "Something has changed",
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should work with no primary section" do
@@ -138,7 +144,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include subsection information" do
@@ -159,7 +165,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should fake section information for travel advice format" do
@@ -179,7 +185,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "organisations" => [],
       "specialist_sectors" => [],
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include organisations" do
@@ -203,7 +209,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "specialist_sectors" => [],
       "indexable_content" => "Blah blah blah index this"
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include live specialist sectors" do
@@ -233,7 +239,7 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       ],
       "indexable_content" => "Blah blah blah index this"
     }
-    assert_equal expected, RummageableArtefact.new(artefact).artefact_hash
+    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should consider live items should be indexed" do


### PR DESCRIPTION
This commit adds "mainstream_browse_pages" to the content sent to rummager. It is an array of tag_ids, in the same way topics are currently sent.

This is needed to collections render the list of items on a mainstream browse page. Currently that's being done via the content-api.

Trello: https://trello.com/c/6vXKBd5d
## Result

![screen shot 2015-07-24 at 15 16 15](https://cloud.githubusercontent.com/assets/233676/8876347/fa17aa1e-3216-11e5-86d2-ae3ca3e758a8.png)

`mainstream_browse_pages` now occur in the rummager document.  
