### PR TITLE
Add rake task to reindex artefacts in search

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,4 +1,24 @@
 namespace :rummager do
+
+  desc "Reindex (with an amend) live artefacts in rummager"
+  task :reindex_live_artefacts => :environment do
+    artefact_scope = Artefact.where(:state => 'live', :owning_app.ne => 'whitehall')
+    total = artefact_scope.count
+    puts "Re-indexing (amending) live artefacts"
+    artefact_scope.each_with_index do |artefact, i|
+      i += 1 # Humans prefer 1-indexed counters
+      begin
+        RummageableArtefact.new(artefact).submit
+      rescue RestClient::ResourceNotFound => e
+        puts "artefact #{artefact.slug} not in search index, so can't amend.  skipping."
+      rescue
+        puts "error registering #{artefact.slug}"
+        raise
+      end
+      puts "done #{i}/#{total}" if i % 100 == 0
+    end
+  end
+
   desc "Reindex specialist sectors"
   task :specialist_sector_reindex => :environment do
     sector_tags = Tag.where(tag_type: 'specialist_sector')


### PR DESCRIPTION
This does will do an amend on the documents in search because panopticon
doesn't persist the full details needed to insert a fresh copy of the
document. An amend is sufficient for use-cases like adding new taggings
etc.
