### PR TITLE
Only update editions when the artefact slug changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '29.0.0'
+  gem "govuk_content_models", '29.0.1'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (29.0.0)
+    govuk_content_models (29.0.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 2.3.1)
-  govuk_content_models (= 29.0.0)
+  govuk_content_models (= 29.0.1)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
Copied from the govuk_content_models change:

Before this change, any time an Artefact was updated in Panopticon, the edition
would have `save!` called on it, which would update the `updated_at` field on
all the non-archived editions. For example, this included hundreds of items
where the content was re-tagged to live in the new Topics.

This was a problem because the updated_at field is used to see what editions
have been worked on recently - it is really important in the content designers'
workflow.

Given that the intent was only to update the slug on the editions if it had
changed on the artefact then let's only call the method when the slug has
changed.

The alternative would be to update the slug on the editions without triggering
callbacks, but that seems potentially risky and expectation-subverting.
