### PR TITLE
Migration to remove finder artefacts

### DIFF
--- a/db/migrate/20150730155503_remove_finder_artefacts.rb
+++ b/db/migrate/20150730155503_remove_finder_artefacts.rb
@@ -1,0 +1,10 @@
+class RemoveFinderArtefacts < Mongoid::Migration
+  def self.up
+    Artefact.where(:kind => 'finder').each do |artefact|
+      artefact.destroy
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
These are left behind from when finder-api was in use. Finders are now
managed by specialist-publisher which doesn't send them to
panopticon/contentapi (they go to content-store instead). Having these
artefacts here will lead to confusion when editors try to populate
specialise_sectors etc for them becuase those changes won't have any
affect.

Note: this **must not be merged** until https://github.com/alphagov/collections/pull/146 has been deployed to production.  That PR in turn depends on https://github.com/alphagov/specialist-publisher/pull/529
