### PR TITLE
Delete all specialist documents.

### DIFF
--- a/db/migrate/20150803103508_delete_specialist_documents.rb
+++ b/db/migrate/20150803103508_delete_specialist_documents.rb
@@ -1,0 +1,17 @@
+class DeleteSpecialistDocuments < Mongoid::Migration
+  def self.up
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["specialist-publisher"].each do |kind|
+      Artefact.where(kind: kind).each do |artefact|
+        puts "Destroying artefact ##{artefact.id}"
+        artefact.destroy
+        Edition.where(panopticon_id: artefact.id).each do |edition|
+          puts "Destroying edition ##{edition.id} for artefact ##{artefact.id}"
+          edition.destroy
+        end
+      end
+    end
+  end
+
+  RenderedManual.all.each(&:destroy)
+  RenderedSpecialistDocument.all.each(&:destroy)
+end


### PR DESCRIPTION
These are no longer being sent via panopticon/contentapi.

https://trello.com/c/XW6wJpbJ/268-stop-publishing-specialist-documents-to-content-api

This could have an impact on the work @KushalP and @tommyp are doing with HMRC manuals.  Could you both chip in here and let me know whether I need to leave some or all of these behind?
- [x] Kush/Tommy signoff
