### PR TITLE
Remove root detailed guide paths

### DIFF
--- a/lib/tasks/detailed_guides.rake
+++ b/lib/tasks/detailed_guides.rake
@@ -31,4 +31,30 @@ namespace :detailed_guide do
       end
     end
   end
+
+  desc "Remove root detailed guide paths"
+  task update_slugs: :environment do
+    scope = Artefact.where(kind: 'detailed_guide')
+    count = scope.count
+
+    scope.each_with_index do |detailed_guide, i|
+      begin
+        detailed_guide.set(:paths, ["/#{detailed_guide.slug}"])
+        puts "updated path to /#{detailed_guide.slug} (#{i+1}/#{count})"
+      rescue GOVUK::Client::Errors::Conflict => e
+        puts "couldn't delete /#{detailed_guide.slug} path (#{i+1}/#{count})"
+        message = ""
+        if e.response["errors"]
+          e.response["errors"].each do |field, errors|
+            errors.each do |error|
+              message << "#{field.humanize} #{error}\n"
+            end
+          end
+        else
+          message = e.response.raw_body
+        end
+        puts message
+      end
+    end
+  end
 end

--- a/lib/tasks/detailed_guides.rake
+++ b/lib/tasks/detailed_guides.rake
@@ -4,7 +4,7 @@ namespace :detailed_guide do
     scope = Artefact.where(kind: 'detailed_guide')
     count = scope.count
 
-    scope.each_with_index do |detailed_guide, i|
+    scope.each.each_with_index do |detailed_guide, i|
       unless detailed_guide.slug.start_with?('guidance/')
         old_slug = detailed_guide.slug
         new_slug = "guidance/#{old_slug}"
@@ -37,7 +37,7 @@ namespace :detailed_guide do
     scope = Artefact.where(kind: 'detailed_guide')
     count = scope.count
 
-    scope.each_with_index do |detailed_guide, i|
+    scope.each.each_with_index do |detailed_guide, i|
       begin
         detailed_guide.set(:paths, ["/#{detailed_guide.slug}"])
         puts "updated path to /#{detailed_guide.slug} (#{i+1}/#{count})"


### PR DESCRIPTION
Detailed guides are now available under guidance/ and moving
away from root paths.

This is part of our multi-step [plan](https://docs.google.com/a/digital.cabinet-office.gov.uk/spreadsheets/d/1xMgOH3ha7dzoPaHJw9VAu9hlCvAm3ifwbBABbuFNMDQ/edit?usp=sharing) to achieve this.
