### PR TITLE
Add migration to fix duplicate artefacts

### DIFF
--- a/db/migrate/20150813073829_remove_duplicate_detailed_guide_artefacts.rb
+++ b/db/migrate/20150813073829_remove_duplicate_detailed_guide_artefacts.rb
@@ -1,0 +1,29 @@
+class RemoveDuplicateDetailedGuideArtefacts < Mongoid::Migration
+  IGNORED_DIFF_ATTRIBUTES = %w[_id actions updated_at created_at slug business_proposition paths tags]
+
+  def self.up
+    Artefact.where(kind: "detailed_guide", slug: %r{^(?!guidance/)}).each do |unmigrated|
+      duplicate = Artefact.where(kind: "detailed_guide", slug: "guidance/#{unmigrated.slug}").first
+      if duplicate
+        diff = duplicate.attributes.except(*IGNORED_DIFF_ATTRIBUTES).diff(
+          unmigrated.attributes.except(*IGNORED_DIFF_ATTRIBUTES))
+
+        if diff.any?
+          puts "Merging #{unmigrated.slug}:"
+          p diff
+
+          unmigrated.attributes = diff
+          unmigrated.save!
+        end
+        unmigrated.actions += duplicate.actions.map { |a| a.action_type = "update"; a }
+
+        duplicate.destroy
+      end
+      unmigrated.set(:slug, "guidance/#{unmigrated.slug}")
+      puts "Moved #{unmigrated.slug}"
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
During the Detailed Guide migration, there was a window where the slug
that Whitehall used to publish artefacts had been updated to be
prefixed with “guidance/“, but Panopticon’s database hadn’t been
migrated to result the artefacts. This meant that when editors
published changes to existing Detailed Guides, Whitehall published a
new artefact with the new slug.

This migration deletes the newer artefact (in order to preserve the
original ID), merges any changes that were made during the publish and
then performs the reslug as required. It also appends the change
history from the duplicated artefact to the original, but changing
“create” actions to “update”

/cc @jamiecobbett @binaryberry 
