### PR TITLE
Register archived routes for detailed guides

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -28,7 +28,11 @@ class RoutableArtefact
     if artefact.live?
       register
     elsif artefact.owning_app == "whitehall"
-      return
+      if artefact.kind == "detailed_guide" && artefact.archived?
+        register
+      else
+        return
+      end
     elsif artefact.archived? && artefact.redirect_url.present?
       redirect(artefact.redirect_url)
     elsif artefact.archived?

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -26,6 +26,16 @@ class RoutableArtefactTest < ActiveSupport::TestCase
         @routable.submit
       end
 
+      should "register the route for an achived detailed guide" do
+        @routable.expects(:register)
+        @routable.expects(:commit)
+
+        @artefact.kind = "detailed_guide"
+        @artefact.state = "archived"
+
+        @routable.submit
+      end
+
       should "not set an archived route as Gone" do
         @routable.expects(:delete).never
         @routable.expects(:commit).never


### PR DESCRIPTION
Routes for Detailed Guides are exact, so if a Detailed Guide artefact
is marked as “archived”, panopticon should still publish the routes for
it, as Whitehall still needs to respond with a Withdrawal Notice, Gone
response or Redirect.

/cc @jamiecobbett 
