### PR TITLE
Ensure correct paths are set for Detailed Guide artefacts

### DIFF
--- a/db/migrate/20150817143541_correct_routes_for_detailed_guides.rb
+++ b/db/migrate/20150817143541_correct_routes_for_detailed_guides.rb
@@ -1,0 +1,28 @@
+require "gds_api/router"
+
+class CorrectRoutesForDetailedGuides < Mongoid::Migration
+  def self.up
+    router_api = GdsApi::Router.new(Plek.find("router-api"))
+
+    scope = Artefact.where(kind: "detailed_guide")
+    count = scope.count
+    scope.each_with_index do |guide, i|
+      puts "Processing #{guide.slug} (#{i + 1}/#{count})"
+      guide.slug.sub!(%r{^(guidance/)?(deleted-)?}, 'guidance/')
+
+      # Check the root route is owned by Whitehall
+      route = router_api.get_route("/#{guide.slug.sub(%r{^guidance/}, '')}")
+      if route && route["handler"] == "backend" && route["backend_id"] == "whitehall-frontend"
+        guide.paths = guide.paths.map { |pa| pa.sub(%r{^/(guidance/)?(deleted-)?}, '/guidance/') }.uniq
+        puts "Paths set to #{guide.paths.inspect}"
+      else
+        puts "Skipping, not owned by whitehall"
+      end
+
+      guide.save
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This loops through all Detailed Guide artefacts and:
- Ensures the slug begins with `guidance/`, and isn’t prefixed with
  `deleted-`
- Ensures the paths are correct, including translations. This will
  publish the correct routes to the Router API. We don’t need the
  `/:slug` form any more, and Panopticon won’t delete routes from the
  router as a result of removing a path from the paths array. We need to
  do this to ensure the root redirect isn’t overwritten when published.
  We check first that the root form is owned by Whitehall in order to
  prevent publishing `/guidance/:slug` when `/:slug` is already a
  redirect away to another content type.

/cc @jamiecobbett @benilovj 
