### PR TITLE
Avoid mongo cursor timeout in query

### DIFF
--- a/script/correct_routes_for_detailed_guides.rb
+++ b/script/correct_routes_for_detailed_guides.rb
@@ -11,7 +11,7 @@ router_api = GdsApi::Router.new(Plek.find("router-api"))
 
 scope = Artefact.where(kind: "detailed_guide")
 count = scope.count
-scope.each_with_index do |guide, i|
+scope.to_a.each_with_index do |guide, i|
   puts "Processing #{guide.slug} (#{i + 1}/#{count})"
   guide.slug.sub!(%r{^(guidance/)?(deleted-)?}, 'guidance/')
 


### PR DESCRIPTION
Mongo fetches records for this query in batches of 1000. The script
takes over 10 minutes to publish each batch on preview, which means the
cursor has timed out by the time it goes to fetch the next batch. To
work around this, we fetch them all in advance and iterate over the
array. This fits in under 400MB of RAM and avoids the timeout issue

/cc @jamiecobbett 
