### PR TITLE
Remove faking of section in travel-advice search results

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -110,12 +110,7 @@ class RummageableArtefact
         hash[rummageable_key] = value
       end
     end
-    # travel advice fakes belonging to a section in frontend
-    # this code continues the fakery so it'll display in search results
-    # as belonging to the correct section
-    if @artefact.kind == "travel-advice"
-      result['section'] = 'foreign-travel-advice'
-    end
+
     result
   end
 

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -168,26 +168,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
-  test "should fake section information for travel advice format" do
-    artefact = Artefact.new do |artefact|
-      artefact.name = "My artefact"
-      artefact.slug = "my-artefact"
-      artefact.kind = "travel-advice"
-      artefact.indexable_content = "Blah blah blah index this"
-    end
-    expected = {
-      "link" => "/my-artefact",
-      "title" => "My artefact",
-      "format" => "travel-advice",
-      "section" => "foreign-travel-advice",
-      "subsection" => nil,
-      "indexable_content" => "Blah blah blah index this",
-      "organisations" => [],
-      "specialist_sectors" => [],
-    }
-    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
-  end
-
   test "should include organisations" do
     artefact = Artefact.new do |artefact|
       artefact.name = "My artefact"


### PR DESCRIPTION
We are sending a "fake" mainstream browse section to rummager in this application.

This was added to display the correct breadcrumb in the search result metadata. We no longer display the that information in the metadata (removed in https://github.com/alphagov/frontend/pull/806), so we don't need this anymore.

Because rummager copies the section information to the `mainstream_browse_pages` field, this will remove the `mainstream_browse_pages` tag `foreign-travel-advice` from the rummager
documents.

This is okay because the `foreign-travel-advice` section is not an existing mainstream browse page:

  https://www.gov.uk/browse/foreign-travel-advice

However, filtering by `mainstream_browse_pages` will no longer be possible. But there's no evidence that this is ever used.

  https://www.gov.uk/api/search.json?filter_mainstream_browse_pages[]=foreign-travel-advice

Part of Part of https://trello.com/c/N0dU4k3G 
