### PR TITLE
Don't send section & subsection to rummager

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -75,7 +75,7 @@ class RummageableArtefact
   def artefact_hash
     # This won't cope with nested values, but we don't have any of those yet
     # When we want to include additional links, this will become an issue
-    rummageable_keys = %w{title description format section subsection
+    rummageable_keys = %w{title description format
       indexable_content boost_phrases organisations additional_links
       specialist_sectors public_timestamp latest_change_note mainstream_browse_pages}
 
@@ -112,14 +112,6 @@ class RummageableArtefact
     end
 
     result
-  end
-
-  def artefact_section
-    section_parts[0]
-  end
-
-  def artefact_subsection
-    section_parts[1]
   end
 
   def artefact_format

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -88,8 +88,6 @@ Then /^rummager should be told to do a partial update$/ do
   amendments = {
     title: "Child Benefit rates",
     format: "answer",
-    section: @section.tag_id,
-    subsection: "",
     "mainstream_browse_pages[]" => "crime",
   }
   assert_requested :post, artefact_search_url(@artefact), body: amendments

--- a/test/integration/artefact_search_indexing_test.rb
+++ b/test/integration/artefact_search_indexing_test.rb
@@ -71,8 +71,6 @@ class ArtefactSearchIndexingTest < ActiveSupport::TestCase
     expected_hash_of_attributes_to_index = {
       "title" => "My artefact",
       "format" => "guide",
-      "section" => "a-section",
-      "subsection" => "subsection",
       "organisations" => ["cabinet-office"],
       "specialist_sectors" => ["working-sea/health-safety"],
       "mainstream_browse_pages" => ["a-section/subsection"],

--- a/test/unit/rummageable_artefact_test.rb
+++ b/test/unit/rummageable_artefact_test.rb
@@ -36,8 +36,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     expected = {
       "title" => "My artefact",
       "format" => "guide",
-      "section" => nil,
-      "subsection" => nil,
       "organisations" => [],
       "specialist_sectors" => [],
     }
@@ -56,8 +54,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "title" => "My artefact",
       "format" => "guide",
       "description" => "Describe describey McDescribe",
-      "section" => nil,
-      "subsection" => nil,
       "organisations" => [],
       "specialist_sectors" => [],
     }
@@ -76,8 +72,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "link" => "/my-artefact",
       "title" => "My artefact",
       "format" => "guide",
-      "section" => nil,
-      "subsection" => nil,
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
       "specialist_sectors" => [],
@@ -97,8 +91,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
     expected = {
       "title" => "My artefact",
       "format" => "guide",
-      "section" => nil,
-      "subsection" => nil,
       "organisations" => [],
       "specialist_sectors" => [],
       "public_timestamp" => "2014-01-01T12:00:00+00:00",
@@ -119,53 +111,9 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "link" => "/my-artefact",
       "title" => "My artefact",
       "format" => "guide",
-      "section" => nil,
-      "subsection" => nil,
       "indexable_content" => "Blah blah blah index this",
       "organisations" => [],
     }
-  end
-
-  test "should include section information" do
-    artefact = Artefact.new do |artefact|
-      artefact.name = "My artefact"
-      artefact.slug = "my-artefact"
-      artefact.kind = "guide"
-      artefact.indexable_content = "Blah blah blah index this"
-      artefact.sections = ["crime"]
-    end
-    expected = {
-      "link" => "/my-artefact",
-      "title" => "My artefact",
-      "format" => "guide",
-      "section" => "crime",
-      "subsection" => nil,
-      "indexable_content" => "Blah blah blah index this",
-      "organisations" => [],
-      "specialist_sectors" => [],
-    }
-    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
-  end
-
-  test "should include subsection information" do
-    artefact = Artefact.new do |artefact|
-      artefact.name = "My artefact"
-      artefact.slug = "my-artefact"
-      artefact.kind = "guide"
-      artefact.indexable_content = "Blah blah blah index this"
-      artefact.sections = ["crime/batman"]
-    end
-    expected = {
-      "link" => "/my-artefact",
-      "title" => "My artefact",
-      "format" => "guide",
-      "section" => "crime",
-      "subsection" => "batman",
-      "indexable_content" => "Blah blah blah index this",
-      "organisations" => [],
-      "specialist_sectors" => [],
-    }
-    assert_hash_including expected, RummageableArtefact.new(artefact).artefact_hash
   end
 
   test "should include organisations" do
@@ -180,8 +128,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "link" => "/my-artefact",
       "title" => "My artefact",
       "format" => "guide",
-      "subsection" => nil,
-      "section" => nil,
       "organisations" => [
         "cabinet-office",
         "department-for-transport"
@@ -209,8 +155,6 @@ class RummageableArtefactTest < ActiveSupport::TestCase
       "link" => "/my-artefact",
       "title" => "My artefact",
       "format" => "guide",
-      "subsection" => nil,
-      "section" => nil,
       "organisations" => [],
       "specialist_sectors" => [
         'oil-and-gas/licensing',


### PR DESCRIPTION
This information is identical to what's in mainstream_browse_pages and isn't needed by anything else.

Part of: https://trello.com/c/N0dU4k3G
