### PR TITLE
Upgrade gov_content_models gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '29.1.2'
+  gem "govuk_content_models", '30.0.0'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (29.1.2)
+    govuk_content_models (30.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 2.3.1)
-  govuk_content_models (= 29.1.2)
+  govuk_content_models (= 30.0.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
We want to use content IDs instead of slugs to represent items in curated lists, so that things like slug changes don't break the linkage. In order to do this, we need to ensure that all content in publisher has a content-id, and these content-ids are published to the publishing API.

Part of: https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id
