### PR TITLE
Don't return an error for republishing published tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -84,15 +84,8 @@ class TagsController < ApplicationController
 
   def publish
     respond_to do |format|
-      if @tag.draft?
-        @tag.publish!
-        format.json { head :ok }
-      else
-        format.json {
-          render json: { error: 'Tag is already published' },
-                 status: :unprocessable_entity
-        }
-      end
+      @tag.publish! if @tag.draft?
+      format.json { head :ok }
     end
   end
 

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -182,14 +182,12 @@ class TagsControllerTest < ActionController::TestCase
       assert response.ok?
     end
 
-    should 'not process and return an error for a live tag' do
+    should 'be cool with published tags' do
       tag = create(:live_tag)
-      error_response = {"error" => "Tag is already published"}
 
       put :publish, id: tag.id, format: :json
 
-      assert_equal 422, response.status
-      assert_equal error_response, JSON.parse(response.body)
+      assert response.ok?
     end
   end
 

--- a/test/integration/update_tags_test.rb
+++ b/test/integration/update_tags_test.rb
@@ -122,10 +122,8 @@ class UpdateTagsTest < ActionDispatch::IntegrationTest
     should 'return an error for requests to publish a live tag' do
       live_tag = create(:live_tag)
       post publish_tag_path(live_tag), format: 'json'
-      body = JSON.parse(response.body)
 
-      assert_equal 422, response.status
-      assert_match /already published/, body['error']
+      assert_equal 200, response.status
     end
   end
 end


### PR DESCRIPTION
Sometimes collections-publisher doesn't know that a tag has already been published, because an error occurred after publishing and the local state was wiped because it runs in a transaction.

We should allow clients to send the publish request to panopticon without it erroring.

@alext 
