### PR TITLE
Remove the 'Add Whitehall artefact' function.

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -1,7 +1,7 @@
 class ArtefactsController < ApplicationController
   before_filter :find_artefact, :only => [:show, :edit, :history, :withdraw]
   before_filter :convert_comma_separated_string_to_array_attribute, :only => [:create, :update], :if => -> { request.format.html? }
-  before_filter :build_artefact, :only => [:new, :create]
+  before_filter :build_artefact, :only => [:create]
   before_filter :find_or_build_artefact, :only => [:update]
   before_filter :register_with_url_arbiter, :only => [:create, :update]
   before_filter :tag_collection, :except => [:show]
@@ -48,6 +48,7 @@ class ArtefactsController < ApplicationController
   end
 
   def new
+    @artefact = Artefact.new
     redirect_to_show_if_need_met
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,15 +1,11 @@
 module ApplicationHelper
   # Set class on active navigation items
   def nav_link(text, link)
-    determinant_params = ["owning_app"]
-    link_query = Rack::Utils.parse_nested_query(URI.parse(link).query)
-    query_matches = determinant_params.all? { |p| params[p] == link_query[p] }
-
     recognized = Rails.application.routes.recognize_path(link)
     controller_matches = recognized[:controller] == params[:controller]
     action_matches = recognized[:action] == params[:action]
 
-    if (controller_matches && action_matches && query_matches)
+    if (controller_matches && action_matches)
       content_tag(:li, :class => "active") do
         link_to( text, link)
       end

--- a/app/views/artefacts/_whitehall_form.html.erb
+++ b/app/views/artefacts/_whitehall_form.html.erb
@@ -22,10 +22,6 @@
       <%= f.input :name, :input_html => { :class => "input-md-6" } %>
       <%= f.input :description, :input_html => { :class => "input-md-6", :rows => 6 }, :as => :text %>
       <%= f.input :slug, :input_html => { :class => "input-md-6" }, :hint => "Inside government slugs are: <code>government/the-slug</code>. Detailed guides are simply: <code>the-slug</code>".html_safe %>
-
-      <% if artefact.new_record? %>
-        <%= f.input :kind, :collection => Artefact::FORMATS_BY_DEFAULT_OWNING_APP["whitehall"].map { |s| [s.humanize, s]}, :as => :select, :input_html => {:class => "input-md-3"}, :prompt => "Select a kind" %>
-      <% end %>
     </div>
 
     <%= render partial: "artefacts/form/tags", locals: { f: f, tag_collection: tag_collection } %>

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -1,9 +1,6 @@
-<%= content_for :page_title, "New #{@artefact.owning_app.nil? ? "" : @artefact.owning_app.capitalize} artefact" %>
+<%= content_for :page_title, "New artefact" %>
 <div class="page-header">
   <h1><%= yield :page_title %></h1>
 </div>
-<% if "whitehall" == @artefact.owning_app %>
-  <%= render 'whitehall_form', artefact: @artefact, tag_collection: @tag_collection %>
-<% else %>
-  <%= render 'form', artefact: @artefact, tag_collection: @tag_collection %>
-<% end %>
+
+<%= render 'form', artefact: @artefact, tag_collection: @tag_collection %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,6 @@
       <%= nav_link 'Tags', tags_path %>
     <% end %>
     <%= nav_link 'Add artefact', new_artefact_path %>
-    <%= nav_link 'Add Whitehall artefact', new_artefact_path(owning_app: "whitehall") %>
   <% end %>
 
   <% content_for :navbar_right do %>

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -171,23 +171,9 @@ class ArtefactsControllerTest < ActionController::TestCase
 
     context "GET new" do
 
-      should "render only the non-whitehall link as active" do
+      should "render the 'Add artefact' link as active" do
         get :new
         assert_select "li[class~=active] a[href=/artefacts/new]"
-        assert_select "li[class~=active] a[href=/artefacts/new?owning_app=whitehall]", false
-      end
-
-      context "whitehall is the owning_app" do
-        should "render the whitehall variant of the form" do
-          get :new, owning_app: "whitehall"
-          assert_template :whitehall_form
-        end
-
-        should "display only the whitehall link as active" do
-          get :new, owning_app: "whitehall"
-          assert_select "li[class~=active] a[href=/artefacts/new]", false
-          assert_select "li[class~=active] a[href=/artefacts/new?owning_app=whitehall]"
-        end
       end
     end
 

--- a/test/integration/artefact_create_test.rb
+++ b/test/integration/artefact_create_test.rb
@@ -7,46 +7,6 @@ class ArtefactCreateTest < ActionDispatch::IntegrationTest
     stub_all_router_api_requests
   end
 
-  should "allow the use of deep slugs when creating a whitehall artefact" do
-    visit "/artefacts"
-    click_on "Add Whitehall artefact"
-
-    within("form#edit_artefact") do
-      fill_in "Name", :with => "British Embassy Legoland"
-      fill_in "Description", :with => "Some information on the British Embassy in Legoland"
-      fill_in "Slug", :with => "government/world/organisations/british-embassy-legoland"
-      select "Worldwide priority", :from => "Kind"
-      click_on "Save and continue editing"
-
-      artefact = Artefact.where(:slug => 'government/world/organisations/british-embassy-legoland').last
-
-      assert_equal "/artefacts/#{artefact.to_param}/edit", current_path
-    end
-
-    assert page.has_link?("/government/world/organisations/british-embassy-legoland")
-    assert page.has_no_css?(".alert.alert-danger"), "No form errors were expected"
-  end
-
-  should "not allow the use of invalid slugs when creating a whitehall artefact" do
-    visit "/artefacts"
-    click_on "Add Whitehall artefact"
-
-    within("form#edit_artefact") do
-      fill_in "Name", :with => "British Embassy Legoland"
-      fill_in "Description", :with => "Some information on the British Embassy in Legoland"
-      fill_in "Slug", :with => "government/world/.organi$ation$/briti$h~embassy~legoland"
-      select "Worldwide priority", :from => "Kind"
-      click_on "Save and continue editing"
-    end
-
-    assert_equal "/artefacts", current_path
-
-    within(".alert-danger") do
-      assert page.has_content?("Slug must be usable in a URL")
-    end
-
-  end
-
   should "allow creation of help_page artefacts" do
     visit "/artefacts"
     click_on "Add artefact"


### PR DESCRIPTION
This predates Whitehall sending all its content to Panopticon. Now that
it does, there's no need to manually add Whitehall artefacts.
Additionally, doing so is bad because there will be no corresponding
item in Whitehall, which will lead to confusion.

Trello: https://trello.com/c/8O2KhFiA
