### PR TITLE
Only allow manual artefact creation for publisher formats

### DIFF
--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -16,7 +16,7 @@ module ArtefactsHelper
   end
 
   def manageable_formats
-    Artefact::FORMATS_BY_DEFAULT_OWNING_APP.except('whitehall', 'panopticon').values.flatten
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP['publisher']
   end
 
   def related_artefacts_json(related_artefacts)

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,0 +1,10 @@
+namespace :data_hygiene do
+  task :verify_formats => [:environment] do
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP.detect do |app_name, formats|
+      mislabeled = Artefact.where(owning_app: app_name, :kind.nin => formats)
+
+      puts "\n#{app_name}:"
+      puts "#{mislabeled.size} docs with foreign formats: #{mislabeled.map(&:kind).uniq.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
Currently it's possible to create artefacts with many formats, even formats that don't belong to the `publisher` application. This is odd because the `owning_app` is set to `publisher` by default for these docs, via a hidden field in the form ([code](https://github.com/alphagov/panopticon/blob/23c3846a731b10e3ba47347e028e401051758ef6/app/views/artefacts/form/_core_attributes.html.erb#L10)).

This behaviour causes non-publisher artefacts created this way to show "This content is managed in Publisher." with a link that will show an error.

We need to be strict about formats and owning apps because we wish to give all documents `content_ids`, and those attributes will tell us who the should generate that content_id.

To verify we're not breaking existing functionality, there is a rake task that prints out per-app the number of documents that don't have the default `owning_app`. This currently shows no relevant mismatching artefacts. I've confirmed with the content team that these documents were put in by mistake.

http://panopticon.dev.gov.uk/artefacts?kind=smart-answer&owned_by=publisher
### Before

![screen shot 2015-09-15 at 14 57 32](https://cloud.githubusercontent.com/assets/233676/9878371/39b7a36e-5bba-11e5-81fd-2842ce7c91ed.png)
### After

![screen shot 2015-09-15 at 14 57 12](https://cloud.githubusercontent.com/assets/233676/9878376/4090c594-5bba-11e5-8fa4-c96f66842e3b.png)

Trello: https://trello.com/c/rmBoBPm9

Thanks @tadast for helping me figuring out the data.
