### PR TITLE
Fix incorrect owning_app for some documents

### DIFF
--- a/db/migrate/20150916093231_correct_publishing_app.rb
+++ b/db/migrate/20150916093231_correct_publishing_app.rb
@@ -1,0 +1,9 @@
+class CorrectPublishingApp < Mongoid::Migration
+  def self.up
+    Artefact.where(owning_app: 'publisher', kind: 'smart-answer').update_all(owning_app: 'smartanswers')
+    Artefact.where(owning_app: 'publisher', kind: 'travel-advice').update_all(owning_app: 'travel-advice-publisher')
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
There are currently 15 `smart-answer` documents with owning-app `publisher`, which should be `smartanswers`. Also one `travel-advice` with `publisher` instead of `travel-advice-publisher`. These were put in by mistake (see https://github.com/alphagov/panopticon/pull/296).

We need to fix these to keep the database consistent and set the `content_id` for all documents by publisher.

Trello: https://trello.com/c/rmBoBPm9
