### PR TITLE
Set a `content_id` for publisher artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -57,6 +57,10 @@ class ArtefactsController < ApplicationController
   end
 
   def create
+    if @artefact.owning_app == "publisher"
+      @artefact.content_id = SecureRandom.uuid
+    end
+
     @artefact.save_as current_user
     continue_editing = (params[:commit] == 'Save and continue editing')
     if continue_editing || @artefact.owning_app != "publisher"

--- a/db/migrate/20150916095528_add_content_id_to_publisher_documents.rb
+++ b/db/migrate/20150916095528_add_content_id_to_publisher_documents.rb
@@ -1,0 +1,10 @@
+class AddContentIdToPublisherDocuments < Mongoid::Migration
+  def self.up
+    Artefact.where(owning_app: 'publisher', content_id: nil).each do |artefact|
+      artefact.set(:content_id, SecureRandom.uuid)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/features/creating.feature
+++ b/features/creating.feature
@@ -17,6 +17,7 @@ Feature: Creating artefacts
      And I save, indicating that I want to go to the item
 
     Then I should be redirected to Publisher
+     And an artefact should have be created with content_id
 
   Scenario: Trying to create an artefact for a need that is already met
     Given an artefact exists

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -71,6 +71,10 @@ Then /^I should be redirected to (.*)$/ do |app|
   check_redirect app, (@artefact || Artefact.last)
 end
 
+Then /^an artefact should have be created with content_id$/ do
+  assert Artefact.last.content_id
+end
+
 Given /^the artefacts are related$/ do
   add_related_artefact @artefact, @related_artefact
 end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,10 +1,22 @@
 namespace :data_hygiene do
+  desc "Verify that artefacts have the correct `owning_app`"
   task :verify_formats => [:environment] do
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP.detect do |app_name, formats|
       mislabeled = Artefact.where(owning_app: app_name, :kind.nin => formats)
 
       puts "\n#{app_name}:"
       puts "#{mislabeled.size} docs with foreign formats: #{mislabeled.map(&:kind).uniq.inspect}"
+    end
+  end
+
+  desc "See which artefacts don't have content IDs"
+  task :inspect_content_ids => [:environment] do
+    owning_apps = Artefact.all.distinct("owning_app")
+    owning_apps.each do |owning_app|
+      without_content_id = Artefact.where(content_id: nil, owning_app: owning_app).count
+      with_content_id = Artefact.where(owning_app: owning_app).count - without_content_id
+
+      puts "#{owning_app}: #{without_content_id} without, #{with_content_id} with"
     end
   end
 end


### PR DESCRIPTION
Artefacts managed by the publisher application should have a `content_id`.

This PR adds a migration to add a `content_id` to artefacts that don't have one, and makes sure newly created artefacts have a `content_id` set.

``` shell
vagrant@development:~/govuk/panopticon (master)$ be rake data_hygiene:inspect_content_ids
publisher: 4262 without, 0 with
smartanswers: 68 without, 1 with
calendars: 3 without, 0 with
(...)

vagrant@development:~/govuk/panopticon (master)$ be rake db:migrate
==  AddContentIdToPublisherDocuments: migrating ===============================
==  AddContentIdToPublisherDocuments: migrated (5.3316s) ======================

vagrant@development:~/govuk/panopticon (master)$ be rake data_hygiene:inspect_content_ids
publisher: 0 without, 4263 with
smartanswers: 68 without, 1 with
(...)
```

Trello: https://trello.com/c/rmBoBPm9
