### PR TITLE
Bump govuk_content_models gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '30.0.0'
+  gem "govuk_content_models", '31.2.0'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       nokogiri (>= 1.5.0)
     database_cleaner (0.8.0)
     diff-lcs (1.1.3)
-    domain_name (0.5.18)
+    domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (30.0.0)
+    govuk_content_models (31.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -160,7 +160,7 @@ GEM
       mongoid (~> 2.5)
       plek
       state_machine
-    hashie (3.4.1)
+    hashie (3.4.2)
     hike (1.2.3)
     htmlentities (4.3.4)
     http-cookie (1.0.2)
@@ -173,7 +173,7 @@ GEM
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
     json (1.8.3)
-    jwt (1.4.1)
+    jwt (1.5.1)
     kaminari (0.14.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -217,7 +217,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.2.0)
       railties (>= 3.2.0)
-    multi_json (1.11.1)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nested_form (0.3.2)
@@ -240,10 +240,10 @@ GEM
     omniauth-gds (3.2.0)
       multi_json (~> 1.10)
       omniauth-oauth2 (~> 1.0)
-    omniauth-oauth2 (1.3.0)
+    omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    plek (1.10.0)
+    plek (1.11.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -330,7 +330,7 @@ GEM
       multi_json (~> 1.3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
     unicorn (4.3.1)
       kgio (~> 2.6)
       rack
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 2.3.1)
-  govuk_content_models (= 30.0.0)
+  govuk_content_models (= 31.2.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
This adds `content_id` to tags (https://github.com/alphagov/govuk_content_models/pull/340).

https://trello.com/c/IgYwT6yM

Related to: https://github.com/alphagov/collections-publisher/pull/143
