### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ else
   gem 'gds-sso', '10.0.0'
 end
 
-gem 'govuk_admin_template', '2.3.1'
+gem 'govuk_admin_template', '3.0.0'
 gem 'formtastic', '2.3.0.rc4'
 gem 'formtastic-bootstrap', '3.0.0'
 gem 'jquery-ui-rails', '5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,15 +35,15 @@ GEM
       multi_json
     ansi (1.4.3)
     arel (3.0.3)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     bootstrap-kaminari-views (0.0.3)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     bson (1.7.1)
     bson_ext (1.7.1)
       bson (~> 1.7.1)
@@ -106,7 +106,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    execjs (2.5.2)
+    execjs (2.6.0)
     factory_girl (3.3.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (3.3.0)
@@ -148,7 +148,7 @@ GEM
       multi_json (~> 1.0)
       plek (~> 1.8)
       rest-client (~> 1.6)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -167,7 +167,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     journey (1.0.4)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.0)
@@ -294,7 +294,7 @@ GEM
       rest-client
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.4.14)
+    sass (3.4.18)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
@@ -376,7 +376,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)
-  govuk_admin_template (= 2.3.1)
+  govuk_admin_template (= 3.0.0)
   govuk_content_models (= 31.2.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
@@ -407,3 +407,6 @@ DEPENDENCIES
   unicorn (= 4.3.1)
   webmock
   whenever (= 0.9.2)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools
