### PR TITLE
Add exceptional slugs for search

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -20,6 +20,7 @@ class RummageableArtefact
     new-enterprise-allowance
     helping-your-business-grow-internationally
     unimoney
+    horizon-2020
   )
 
   def initialize(artefact)

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -21,6 +21,7 @@ class RummageableArtefact
     helping-your-business-grow-internationally
     unimoney
     horizon-2020
+    civil-service-apprenticeships
   )
 
   def initialize(artefact)


### PR DESCRIPTION
Add the Horizon 2020 business support page and the Civil Service Apprenticeship Schemes campaign to search, as these content types are excluded by default.

https://trello.com/c/cCs1ySza/361-add-horizon-2020-business-support-page-to-search
and
https://trello.com/c/CAIF8viE/362-cs-apprenticeship-schemes-not-in-search-results
