### PR TITLE
Don't run edition validations when archiving an artefact

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '31.2.0'
+  gem "govuk_content_models", '31.2.1'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       json
     gherkin (2.11.1)
       json (>= 1.4.6)
-    govspeak (3.4.0)
+    govspeak (3.5.0)
       htmlentities (~> 4)
       kramdown (~> 1.5.0)
       nokogiri (~> 1.5)
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.2.0)
+    govuk_content_models (31.2.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (= 31.2.0)
+  govuk_content_models (= 31.2.1)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
The bump in the gem gets this fix.

Before this change, attempting to archive an artefact with invalid editions
would successfully mark the artefact as archived, but the editions would be
left in their state.

We have published editions which are invalid because validation rules have been
introduced since they were last worked on/saved.

Ideally, the state machine transition for archiving would skip validations, but
state_machine doesn't seem to support this.

Successfully tested with known-problem examples in development.
