### PR TITLE
Bump govuk_content_models to 32.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '31.2.1'
+  gem "govuk_content_models", '31.2.2'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.2.1)
+    govuk_content_models (31.2.2)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (= 31.2.1)
+  govuk_content_models (= 31.2.2)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
Fixes a bug where Whitehall couldn't push Official Statistics publications to Panopticon.

Related change:  https://github.com/alphagov/govuk_content_models/pull/344
