### PR TITLE
Withdrawn artefacts with prefixes redirect to single url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '24.6.0'
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -372,7 +372,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 24.6.0)
   gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -81,7 +81,7 @@ class RoutableArtefact
     prefixes.each do |path|
       begin
         logger.debug "Redirecting route #{path}"
-        router_api.add_redirect_route(path, "prefix", destination)
+        router_api.add_redirect_route(path, "prefix", destination, "permanent", segments_mode: "ignore")
       rescue GdsApi::HTTPNotFound
       end
     end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -26,7 +26,7 @@ class RoutableArtefactTest < ActiveSupport::TestCase
         @routable.submit
       end
 
-      should "register the route for an achived detailed guide" do
+      should "register the route for an archived detailed guide" do
         @routable.expects(:register)
         @routable.expects(:commit)
 
@@ -249,9 +249,9 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
     should "redirect all defined prefix routes" do
       requests = [
-        stub_redirect_registration("/foo", "prefix", "/new", "permanent"),
-        stub_redirect_registration("/bar", "prefix", "/new", "permanent"),
-        stub_redirect_registration("/baz", "prefix", "/new", "permanent")
+        stub_redirect_registration("/foo", "prefix", "/new", "permanent", "ignore"),
+        stub_redirect_registration("/bar", "prefix", "/new", "permanent", "ignore"),
+        stub_redirect_registration("/baz", "prefix", "/new", "permanent", "ignore")
       ]
 
       @artefact.prefixes = ["/foo", "/bar", "/baz"]
@@ -287,7 +287,7 @@ class RoutableArtefactTest < ActiveSupport::TestCase
     context "when router-api returns 404 for a delete request" do
       should "not blow up" do
         gone_request, _commit_request = stub_redirect_registration(
-          "/foo", "prefix", "/new", "permanent")
+          "/foo", "prefix", "/new", "permanent", "ignore")
 
         gone_request.to_return(status: 404)
 
@@ -299,11 +299,11 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
       should "continue to redirect other routes" do
         missing_redirect_request, _commit_request = stub_redirect_registration(
-          "/foo", "prefix", "/new", "permanent")
+          "/foo", "prefix", "/new", "permanent", "ignore")
         missing_redirect_request.to_return(status: 404)
 
         redirect_request, _commit_request = stub_redirect_registration(
-          "/bar", "prefix", "/new", "permanent")
+          "/bar", "prefix", "/new", "permanent", "ignore")
 
         @artefact.prefixes = ["/foo", "/bar"]
         @routable.redirect("/new")


### PR DESCRIPTION
https://trello.com/c/BYS3dxxV/118-panopticon-unpublishings-should-redirect-without-keeping-subpath-medium

When redirecting artefacts with prefix routes, set them to ignore the
segments after the prefix when redirecting. This is used for multi part
manuals and artefacts like them, where withdrawing and redirecting the
manual is required to redirect all parts to a single URL.
- [x] Requires https://github.com/alphagov/router-api/pull/79 to be deployed first.
