### PR TITLE
Copy tags from publishing-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ else
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'
+gem 'govuk_message_queue_consumer', '~> 2.0.0'
 
 gem 'rails', '3.2.22'
 gem 'unicorn', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     airbrake (3.1.15)
       builder
       multi_json
+    amq-protocol (2.0.0)
     ansi (1.4.3)
     arel (3.0.3)
     autoprefixer-rails (6.0.3)
@@ -48,6 +49,8 @@ GEM
     bson_ext (1.7.1)
       bson (~> 1.7.1)
     builder (3.0.4)
+    bunny (2.2.1)
+      amq-protocol (>= 2.0.0)
     capybara (2.1.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -164,6 +167,8 @@ GEM
       mongoid (~> 2.5)
       plek
       state_machine
+    govuk_message_queue_consumer (2.0.0)
+      bunny (~> 2.2.0)
     hashie (3.4.3)
     hike (1.2.3)
     htmlentities (4.3.4)
@@ -383,6 +388,7 @@ DEPENDENCIES
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
   govuk_content_models (= 31.4.0)
+  govuk_message_queue_consumer (~> 2.0.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy

--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ is no need to have an up-to-date Whitehall database.
 Panopticon includes observers which will index, update or delete records in the
 search index when an artefact is updated. It expects an instance of
 [Rummager](https://github.com/alphagov/rummager) to be present.
+
+## Running the message queue
+
+This application uses the GOV.UK message queue to update artefacts when they are
+tagged via the publishing-api.
+
+To run the message queue:
+
+```
+govuk_setenv panopticon bundle exec rake message_queue:consumer
+```

--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -1,0 +1,6 @@
+class TaggingUpdater
+  def process(message)
+    # This is a no-op for now. Implementation to follow.
+    message.ack
+  end
+end

--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -1,6 +1,44 @@
+# TaggingUpdater
+#
+# To allow us to migrate to the new tagging infrastructure, we need to have
+# taggings be synced between panopticon and publishing-api. This class makes
+# sure that if an app sends `links` to the publishing-api, panopticon/contentapi
+# is also updated.
 class TaggingUpdater
   def process(message)
-    # This is a no-op for now. Implementation to follow.
+    content_item = message.payload
+
+    return message.ack unless content_item['publishing_app'].in?(Settings.apps_with_migrated_tagging)
+    return message.ack unless content_item['links']
+
+    slug = content_item.fetch('base_path').sub(/\A\//, '')
+    artefact = Artefact.find_by_slug(slug)
+
+    if artefact
+      update_artefact_with_content_item(content_item, artefact)
+    end
+
     message.ack
+  end
+
+private
+
+  # Panopticon still uses deprecated names for the tags.
+  TAG_MAPPING = {
+    "mainstream_browse_pages" => "section",
+    "organisations" => "organisation",
+    "topics" => "specialist_sector",
+  }
+
+  def update_artefact_with_content_item(content_item, artefact)
+    TAG_MAPPING.each do |publishing_api_tag_name, panopticon_tag_name|
+      next unless content_item['links'][publishing_api_tag_name]
+
+      new_tags = Tag.where(:content_id.in => content_item['links'][publishing_api_tag_name])
+
+      artefact.set_tags_of_type(panopticon_tag_name, new_tags.map(&:tag_id))
+    end
+
+    artefact.save!
   end
 end

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,4 @@ apps_with_migrated_tagging:
   - publisher
   - smartanswers
   - testapp
+  - an-app-from-the-migrated-apps-config

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -1,0 +1,10 @@
+namespace :message_queue do
+  desc "Run worker to consume messages from RabbitMQ"
+  task consumer: :environment do
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: "panopticon",
+      exchange: "published_documents",
+      processor: TaggingUpdater.new
+    ).run
+  end
+end

--- a/test/unit/queue_consumers/tagging_updater_test.rb
+++ b/test/unit/queue_consumers/tagging_updater_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+require 'govuk_message_queue_consumer/test_helpers'
+
+class TaggingUpdaterTest < ActiveSupport::TestCase
+  def test_message_is_acked
+    message = GovukMessageQueueConsumer::MockMessage.new
+
+    TaggingUpdater.new.process(message)
+
+    assert message.acked?
+  end
+end

--- a/test/unit/queue_consumers/tagging_updater_test.rb
+++ b/test/unit/queue_consumers/tagging_updater_test.rb
@@ -2,8 +2,63 @@ require 'test_helper'
 require 'govuk_message_queue_consumer/test_helpers'
 
 class TaggingUpdaterTest < ActiveSupport::TestCase
-  def test_message_is_acked
-    message = GovukMessageQueueConsumer::MockMessage.new
+  def test_artefact_is_updated_with_tags
+    create(:live_tag, tag_id: 'my-tag', tag_type: 'section', content_id: 'MY-CONTENT-ID')
+    create(:live_tag, tag_id: 'existing-tag', tag_type: 'section', content_id: 'A-CONTENT-ID')
+    artefact = create(:artefact,
+      slug: 'a-tagged-item',
+      sections: ["existing-tag"],
+    )
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "publishing_app" => "smartanswers",
+      "base_path" => "/a-tagged-item",
+      "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
+    })
+
+    TaggingUpdater.new.process(message)
+
+    artefact.reload
+    assert_equal ["my-tag"], artefact.tags.map(&:tag_id)
+    assert message.acked?
+  end
+
+  def test_only_migrated_applications
+    create(:live_tag, tag_id: 'existing-tag', tag_type: 'section', content_id: 'A-CONTENT-ID')
+    artefact = create(:artefact,
+      slug: 'a-tagged-item',
+      sections: ["existing-tag"],
+    )
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "publishing_app" => "not-smartanswers",
+      "base_path" => "/a-tagged-item",
+      "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
+    })
+
+    TaggingUpdater.new.process(message)
+
+    artefact.reload
+    assert_equal ["existing-tag"], artefact.tags.map(&:tag_id)
+    assert message.acked?
+  end
+
+  def test_when_no_artefact_found
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "publishing_app" => "smartanswers",
+      "base_path" => "/some-item-that-does-not-exist",
+      "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
+    })
+
+    TaggingUpdater.new.process(message)
+
+    assert message.acked?
+  end
+
+  def test_when_links_are_missing
+    artefact = create(:artefact, slug: 'an-item')
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "publishing_app" => "smartanswers",
+      "base_path" => "/an-item",
+    })
 
     TaggingUpdater.new.process(message)
 

--- a/test/unit/queue_consumers/tagging_updater_test.rb
+++ b/test/unit/queue_consumers/tagging_updater_test.rb
@@ -10,7 +10,7 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
       sections: ["existing-tag"],
     )
     message = GovukMessageQueueConsumer::MockMessage.new({
-      "publishing_app" => "smartanswers",
+      "publishing_app" => "an-app-from-the-migrated-apps-config",
       "base_path" => "/a-tagged-item",
       "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
     })
@@ -29,7 +29,7 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
       sections: ["existing-tag"],
     )
     message = GovukMessageQueueConsumer::MockMessage.new({
-      "publishing_app" => "not-smartanswers",
+      "publishing_app" => "not-an-app-from-the-migrated-apps-config",
       "base_path" => "/a-tagged-item",
       "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
     })
@@ -43,7 +43,7 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
 
   def test_when_no_artefact_found
     message = GovukMessageQueueConsumer::MockMessage.new({
-      "publishing_app" => "smartanswers",
+      "publishing_app" => "an-app-from-the-migrated-apps-config",
       "base_path" => "/some-item-that-does-not-exist",
       "links" => { "mainstream_browse_pages" => ["MY-CONTENT-ID"] }
     })
@@ -56,7 +56,7 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
   def test_when_links_are_missing
     artefact = create(:artefact, slug: 'an-item')
     message = GovukMessageQueueConsumer::MockMessage.new({
-      "publishing_app" => "smartanswers",
+      "publishing_app" => "an-app-from-the-migrated-apps-config",
       "base_path" => "/an-item",
     })
 


### PR DESCRIPTION
This PR makes panopticon listen to changes from publishing-api, to keep the tags in sync while we migrate to the new tagging infrastructure (Trello: https://trello.com/c/z8b6VmCU).
