### PR TITLE
Reserve URLs using Publishing API...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '24.6.0'
+  gem 'gds-api-adapters', '24.8.0'
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       nokogiri (>= 1.5.0)
     database_cleaner (0.8.0)
     diff-lcs (1.1.3)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -119,7 +119,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (24.6.0)
+    gds-api-adapters (24.8.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -255,7 +255,7 @@ GEM
     rack (1.4.7)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
@@ -372,7 +372,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 24.6.0)
+  gds-api-adapters (= 24.8.0)
   gds-sso (= 10.0.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require "sass"
 require "sprockets/railtie"
 require 'kaminari' # has to be loaded before the models, otherwise the methods aren't added
 require "govuk_content_models"
+require "gds_api/publishing_api"
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -14,8 +15,6 @@ if defined?(Bundler)
   # If you want your assets lazily compiled in production, use this line
   # Bundler.require(:default, :assets, Rails.env)
 end
-
-require 'govuk/client/url_arbiter'
 
 module Panopticon
   mattr_accessor :need_api
@@ -73,8 +72,8 @@ module Panopticon
     # When saving an artefact we want to update search.
     config.mongoid.observers << :update_search_observer
 
-    def url_arbiter_api
-      @url_arbiter_api ||= GOVUK::Client::URLArbiter.new
+    def publishing_api
+      @publishing_api ||= GdsApi::PublishingApi.new(Plek.current.find('publishing-api'))
     end
   end
 end

--- a/features/creating.feature
+++ b/features/creating.feature
@@ -4,7 +4,7 @@ Feature: Creating artefacts
 
   Background:
     Given I am an admin
-    And I have stubbed url-arbiter
+    And I have stubbed publishing-api
 
   Scenario: Creating artefacts directly in panopticon
     When I visit the homepage

--- a/features/registering_resources.feature
+++ b/features/registering_resources.feature
@@ -6,7 +6,7 @@ Feature: Registering resources
   Background:
     # Router registration is tested in test/integration/artefact_router_registration_test.rb
     Given I have stubbed the router
-    And I have stubbed url-arbiter
+    And I have stubbed publishing-api
 
   Scenario: Creating a smart answer
     When I put a new smart answer's details into panopticon

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -6,8 +6,8 @@ Given /^I have stubbed search$/ do
   stub_search
 end
 
-Given /^I have stubbed url-arbiter$/ do
-  stub_url_arbiter
+Given /^I have stubbed publishing-api$/ do
+  stub_publishing_api
 end
 
 When /^I put a new smart answer's details into panopticon$/ do

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -1,7 +1,7 @@
-require 'govuk/client/test_helpers/url_arbiter'
+require 'gds_api/test_helpers/publishing_api'
 
 module RegistrationInfo
-  include GOVUK::Client::TestHelpers::URLArbiter
+  include GdsApi::TestHelpers::PublishingApi
 
   SEARCH_ROOT = "http://search.dev.gov.uk/mainstream"
 
@@ -75,11 +75,11 @@ module RegistrationInfo
     Artefact.observers.disable :update_search_observer do
       @artefact = Artefact.create!(example_smart_answer)
     end
-    url_arbiter_has_registration_for("/#{@artefact.slug}", @artefact.owning_app)
+    publishing_api_has_path_reservation_for("/#{@artefact.slug}", @artefact.owning_app)
   end
 
-  def stub_url_arbiter
-    stub_default_url_arbiter_responses
+  def stub_publishing_api
+    stub_default_publishing_api_path_reservation
   end
 end
 

--- a/lib/tasks/detailed_guides.rake
+++ b/lib/tasks/detailed_guides.rake
@@ -10,21 +10,21 @@ namespace :detailed_guide do
         new_slug = "guidance/#{old_slug}"
 
         begin
-          path = Rails.application.url_arbiter_api.reserve_path("/#{new_slug}",
+          path = Rails.application.publishing_api.put_path("/#{new_slug}",
             "publishing_app" => "whitehall")
           detailed_guide.set(:slug, new_slug)
           puts "Renamed #{old_slug} to #{new_slug} (#{i+1}/#{count})"
-        rescue GOVUK::Client::Errors::Conflict => e
+        rescue GdsApi::HTTPClientError => e
           puts "Couldn't rename #{old_slug} to #{new_slug} (#{i+1}/#{count})"
           message = ""
-          if e.response["errors"]
-            e.response["errors"].each do |field, errors|
+          if e.error_details["errors"]
+            e.error_details["errors"].each do |field, errors|
               errors.each do |error|
                 message << "#{field.humanize} #{error}\n"
               end
             end
           else
-            message = e.response.raw_body
+            message = e.message
           end
           puts message
         end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'gds_api/test_helpers/publishing_api'
 require 'gds_api/test_helpers/router'
 
 class ArtefactsControllerTest < ActionController::TestCase
@@ -161,8 +162,8 @@ class ArtefactsControllerTest < ActionController::TestCase
         end
 
         should "not blow up if not given a slug" do
-          # simulate the error that url-arbiter would return if it was called
-          url_arbiter_returns_validation_error_for("/", "path" => ["can't be blank"])
+          # simulate the error that publishing-api would return if it was called
+          publishing_api_returns_path_reservation_validation_error_for("/", "path" => ["can't be blank"])
 
           post :create, :artefact => {
             :owning_app => 'smart-answers',
@@ -486,7 +487,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           name: "Whatever",
           need_ids: ['100001']
         )
-        url_arbiter_has_registration_for("/whatever", "publisher")
+        publishing_api_has_path_reservation_for("/whatever", "publisher")
 
         put :update, id: artefact.id, "CONTENT_TYPE" => "application/json", owning_app: 'smart-answers'
         assert_equal 409, response.status

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -118,8 +118,8 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         assert artefact
       end
 
-      should "return an error if url-arbiter rejects the registration" do
-        url_arbiter_has_registration_for("/wibble", "a-different-backend")
+      should "return an error if publishing-api rejects the registration" do
+        publishing_api_has_path_reservation_for("/wibble", "a-different-backend")
 
         artefact_data = {
           'slug' => 'wibble',
@@ -141,8 +141,8 @@ class ArtefactsAPITest < ActiveSupport::TestCase
       end
 
       should "not blow up if not given an owning-app" do
-        # simulate the error that url-arbiter would return if it was called
-        url_arbiter_returns_validation_error_for("/wibble", "publishing_app" => ["can't be blank"])
+        # simulate the error that publishing-api would return if it was called
+        publishing_api_returns_path_reservation_validation_error_for("/wibble", "publishing_app" => ["can't be blank"])
 
         artefact_data = {
           'slug' => 'wibble',
@@ -251,8 +251,8 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         assert_equal "Wibble", @artefact.name
       end
 
-      should "return an error if url-arbiter rejects the registration" do
-        url_arbiter_has_registration_for("/wibble", "a-different-backend")
+      should "return an error if publishing-api rejects the registration" do
+        publishing_api_has_path_reservation_for("/wibble", "a-different-backend")
 
         artefact_data = {
           'slug' => 'wibble',
@@ -275,8 +275,8 @@ class ArtefactsAPITest < ActiveSupport::TestCase
       end
 
       should "not blow up if not given an owning-app" do
-        # simulate the error that url-arbiter would return if it was called
-        url_arbiter_returns_validation_error_for("/wibble", "publishing_app" => ["can't be blank"])
+        # simulate the error that publishing-api would return if it was called
+        publishing_api_returns_path_reservation_validation_error_for("/wibble", "publishing_app" => ["can't be blank"])
 
         artefact_data = {
           'slug' => 'wibble',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,8 +17,7 @@ require 'webmock/minitest'
 # this is to allow Poltergeist JS tests to talk to the local server
 WebMock.disable_net_connect!(:allow_localhost => true)
 require 'govuk_content_models/test_helpers/factories'
-
-require 'govuk/client/test_helpers/url_arbiter'
+require 'gds_api/test_helpers/publishing_api'
 
 DatabaseCleaner.strategy = :truncation
 # initial clean
@@ -27,14 +26,14 @@ DatabaseCleaner.clean
 class ActiveSupport::TestCase
   include Rack::Test::Methods
   include FactoryGirl::Syntax::Methods
-  include GOVUK::Client::TestHelpers::URLArbiter
+  include GdsApi::TestHelpers::PublishingApi
 
   def clean_db
     DatabaseCleaner.clean
   end
   set_callback :teardown, :before, :clean_db
 
-  set_callback :setup, :before, :stub_default_url_arbiter_responses
+  set_callback :setup, :before, :stub_default_publishing_api_path_reservation
 
   def app
     Panopticon::Application


### PR DESCRIPTION
Another part of this story https://trello.com/c/bf4nuPIc/340-move-url-arbitration-to-publishing-api
Path reservation is no longer the responsibility of URL Arbiter,
this change makes Panopticon reserve paths using the Publishing API endpoint.
