### PR TITLE
Fix sign in issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", '31.2.2'
+  gem "govuk_content_models", '31.4.0'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "bson", "1.7.1"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem "govuk_content_models", "31.4.0"
+  gem "govuk_content_models", '31.2.2'
 end
 
 if ENV['BUNDLE_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     factory_girl_rails (3.3.0)
       factory_girl (~> 3.3.0)
       railties (>= 3.0.0)
-    faraday (0.9.2)
+    faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.8)
     formtastic (2.3.0.rc4)
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.4.0)
+    govuk_content_models (31.2.2)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -160,7 +160,7 @@ GEM
       mongoid (~> 2.5)
       plek
       state_machine
-    hashie (3.4.3)
+    hashie (3.4.2)
     hike (1.2.3)
     htmlentities (4.3.4)
     http-cookie (1.0.2)
@@ -173,7 +173,7 @@ GEM
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
     json (1.8.3)
-    jwt (1.5.2)
+    jwt (1.5.1)
     kaminari (0.14.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -240,7 +240,7 @@ GEM
     omniauth-gds (3.2.0)
       multi_json (~> 1.10)
       omniauth-oauth2 (~> 1.0)
-    omniauth-oauth2 (1.4.0)
+    omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     plek (1.11.0)
@@ -324,7 +324,7 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    tzinfo (0.3.45)
+    tzinfo (0.3.44)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (= 31.4.0)
+  govuk_content_models (= 31.2.2)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.2.2)
+    govuk_content_models (31.4.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -377,7 +377,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (= 31.2.2)
+  govuk_content_models (= 31.4.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy


### PR DESCRIPTION
This PR is a fix of #309. That PR inadvertently updated some sso-related gems, which caused errors during sign in with panopticon.

---

URLs with fragments should be allowed, and is safe. It's also allowed by router-api.

Original PR: alphagov/govuk_content_models#348
