### PR TITLE
Save organisation content_id in Tag sync

### DIFF
--- a/lib/organisation_importer.rb
+++ b/lib/organisation_importer.rb
@@ -24,13 +24,16 @@ class OrganisationImporter
     if existing_tag.present?
       logger.info "Found existing tag: #{tag_id}"
 
-      if existing_tag.title != organisation.title
-        if existing_tag.update_attributes(title: organisation.title)
-          logger.info "Updated title to '#{existing_tag.title}'"
-        else
-          log_error_and_notify_airbrake(organisation,
-                                        "Could not update title: #{existing_tag.errors.full_messages}")
+      existing_tag.title = organisation.title
+      existing_tag.content_id = organisation.details.content_id
+
+      if existing_tag.save
+        if existing_tag.changes.any?
+          logger.info "Updated tag with changes: #{existing_tag.changes}"
         end
+      else
+        log_error_and_notify_airbrake(organisation,
+                                      "Could not update title: #{existing_tag.errors.full_messages}")
       end
 
       if existing_tag.draft?
@@ -44,7 +47,8 @@ class OrganisationImporter
     else
       new_tag = Tag.new(tag_type: TAG_TYPE,
                         tag_id: tag_id,
-                        title: organisation.title)
+                        title: organisation.title,
+                        content_id: organisation.details.content_id)
 
       logger.info "Creating organisation tag: #{tag_id}"
 

--- a/test/unit/organisation_importer_test.rb
+++ b/test/unit/organisation_importer_test.rb
@@ -61,16 +61,6 @@ class OrganisationImporterTest < ActiveSupport::TestCase
     assert_equal "Cabinet Office", organisation_tag.title
   end
 
-  should "not update the title of an existing organisation if it hasn't changed" do
-    create(:live_tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Cabinet Office")
-
-    # assert that no tags are updated during the import run
-    Tag.any_instance.expects(:update_attributes).never
-
-    organisations_api_has_organisations(["cabinet-office"])
-    OrganisationImporter.new.run
-  end
-
   should "notify Airbrake if creating an organisation fails" do
     organisations_api_has_organisations(["cabinet-office"])
 
@@ -89,7 +79,7 @@ class OrganisationImporterTest < ActiveSupport::TestCase
     create(:live_tag, tag_type: "organisation", tag_id: "cabinet-office", title: "Something else")
     organisations_api_has_organisations(["cabinet-office"])
 
-    Tag.any_instance.expects(:update_attributes).returns(false)
+    Tag.any_instance.expects(:save).returns(false)
 
     Airbrake.expects(:notify_or_ignore).with {|exception, options|
       options.has_key?(:parameters) &&


### PR DESCRIPTION
Every night at 3AM, panopticon downloads the organisations from the whitehall `/api/organisations`. Currently, the importer doesn't persist the `content_id` of the organisation. This PR will make it do that. 

We need the `content_id` to start migrating to the publishing-api.

I've done some refactoring on this class to make it more flexible.

https://trello.com/c/1JkpLaTD/421-add-content-id-to-organisation-tags-in-panopticon
