### PR TITLE
Add a TagMigrator to migrate tags for an app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'airbrake', '3.1.15'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '24.8.0'
+  gem 'gds-api-adapters', '25.1.0'
 end
 
 gem 'govuk-client-url_arbiter', '0.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (24.8.0)
+    gds-api-adapters (25.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -223,7 +223,7 @@ GEM
     nested_form (0.3.2)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     ntlm-http (0.1.1)
@@ -372,7 +372,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 24.8.0)
+  gds-api-adapters (= 25.1.0)
   gds-sso (= 11.1.0)
   gelf
   govuk-client-url_arbiter (= 0.0.2)

--- a/lib/tagging_migrator.rb
+++ b/lib/tagging_migrator.rb
@@ -1,0 +1,58 @@
+# TaggingMigrator
+#
+# We are migrating the taggings from panopticon/content-api to publishing-api.
+# This class takes the taggings for a certain app and sends it to the
+# publishing-api so that it contains the current taggings. This functionality
+# will be removed after the migration.
+
+require 'gds_api/publishing_api_v2'
+
+class TaggingMigrator
+  def initialize(app_name)
+    @app_name = app_name
+  end
+
+  def migrate!
+    artefacts_owned_by_app.each do |artefact|
+      next unless artefact.content_id
+      migrate_tags_for_artefact(artefact)
+    end
+  end
+
+private
+
+  def migrate_tags_for_artefact(artefact)
+    link_payload = {
+      mainstream_browse_pages: [],
+      topics: [],
+      organisations: [],
+    }
+
+    artefact.tags.each do |tag|
+      if tag.tag_type == 'section'
+        link_payload[:mainstream_browse_pages] << tag.content_id
+      end
+
+      if tag.tag_type == 'specialist_sector'
+        link_payload[:topics] << tag.content_id
+      end
+
+      if tag.tag_type == 'organisation'
+        link_payload[:organisations] << tag.content_id
+      end
+    end
+
+    publishing_api.put_links(
+      artefact.content_id,
+      links: link_payload
+    )
+  end
+
+  def artefacts_owned_by_app
+    Artefact.where(owning_app: @app_name)
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(Plek.new.find('publishing-api'))
+  end
+end

--- a/lib/tasks/migrate_taggings.rake
+++ b/lib/tasks/migrate_taggings.rake
@@ -1,0 +1,4 @@
+desc "Migrate taggings for an app (rake migrate_taggings OWNING_APP=smartanswers)"
+task migrate_taggings: [:environment] do
+  TaggingMigrator.new(ENV.fetch('OWNING_APP')).migrate!
+end

--- a/test/unit/tagging_migrator_test.rb
+++ b/test/unit/tagging_migrator_test.rb
@@ -1,0 +1,46 @@
+require_relative "../test_helper"
+
+class TaggingMigratorTest < ActiveSupport::TestCase
+  test "sends current migrations to publishing-api" do
+    create(:live_tag, tag_id: "a-topic", tag_type: "specialist_sector", content_id: "A-TOPIC")
+    create(:live_tag, tag_id: "a-browse-page", tag_type: "section", content_id: "A-BROWSE-PAGE")
+    create(:live_tag, tag_id: "an-organisation", tag_type: "organisation", content_id: "AN-ORGANISATION")
+
+    create(:artefact,
+      content_id: "A",
+      slug: "item-a",
+      owning_app: "smartanswers",
+      sections: ["a-browse-page"],
+      specialist_sectors: ["a-topic"],
+    )
+    create(:artefact,
+      content_id: "B",
+      slug: "item-b",
+      owning_app: "smartanswers",
+      sections: ["a-browse-page"],
+      organisations: ["an-organisation"],
+    )
+    create(:artefact,
+      content_id: "C",
+      slug: "item-c",
+      owning_app: "smartanswers",
+    )
+    create(:artefact,
+      content_id: "D",
+      slug: "item-d",
+      owning_app: "whitehall",
+    )
+
+    stub_request(:put, %r[#{Plek.find('publishing-api')}/v2/links/*]).
+      to_return(body: {}.to_json)
+
+    TaggingMigrator.new("smartanswers").migrate!
+
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":["A-TOPIC"],"organisations":[]}}'
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/B",
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":["AN-ORGANISATION"]}}'
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/C",
+      body: '{"links":{"mainstream_browse_pages":[],"topics":[],"organisations":[]}}'
+  end
+end


### PR DESCRIPTION
We are migrating the taggings from panopticon/content-api to publishing-api. The TagMigrator takes the taggings for a certain app and sends it to the publishing-api so that it contains the current tags.

It will be used for the first time when we migrate smart-answers.

Trello: https://trello.com/c/irVr1PU6
Needed for: https://trello.com/c/4doiGxWW/417-migrate-smartanswers-to-new-tagging-infrastructure
