### PR TITLE
Add Procfile to run message queue worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec rake message_queue:consumer


### PR DESCRIPTION
This will be picked up by puppet (PR underway) to run the message queue worker added in https://github.com/alphagov/panopticon/pull/307.

cc @rboulton 
