### PR TITLE
Migrate primary browse page to parent

### DIFF
--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -46,6 +46,11 @@ private
       artefact.set_tags_of_type(panopticon_tag_name, new_tags.map(&:tag_id))
     end
 
+    if content_item['links']['parent']
+      parent = Tag.where(:content_id.in => content_item['links']['parent'])
+      artefact.set_primary_tag_of_type('section', parent.first.tag_id)
+    end
+
     artefact.save!
   end
 end

--- a/lib/tagging_migrator.rb
+++ b/lib/tagging_migrator.rb
@@ -28,6 +28,10 @@ private
       organisations: [],
     }
 
+    if artefact.primary_section
+      link_payload[:parent] = [artefact.primary_section.content_id]
+    end
+
     artefact.tags.each do |tag|
       if tag.tag_type == 'section'
         link_payload[:mainstream_browse_pages] << tag.content_id

--- a/test/unit/tagging_migrator_test.rb
+++ b/test/unit/tagging_migrator_test.rb
@@ -37,9 +37,9 @@ class TaggingMigratorTest < ActiveSupport::TestCase
     TaggingMigrator.new("smartanswers").migrate!
 
     assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
-      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":["A-TOPIC"],"organisations":[]}}'
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":["A-TOPIC"],"organisations":[],"parent":["A-BROWSE-PAGE"]}}'
     assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/B",
-      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":["AN-ORGANISATION"]}}'
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":["AN-ORGANISATION"],"parent":["A-BROWSE-PAGE"]}}'
     assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/C",
       body: '{"links":{"mainstream_browse_pages":[],"topics":[],"organisations":[]}}'
   end


### PR DESCRIPTION
We are splitting up the mainstream_browse_page into `parent` (used for breadcrumb) and the main tags.

This PR:
- copies the primary mainstream browse page to the `parent` 
- makes sure that if we send a `parent` link, we copy that tag to the front of the section tags. This will ensure that the same browse page will be displayed in the breadcrumb on mainstream browse pages.

Related: 
- https://github.com/alphagov/govuk-content-schemas/pull/154 adds `parent` to the content schema.
- [RFC 36](https://gov-uk.atlassian.net/wiki/display/FS/RFC+36%3A+Stop+preserving+order+for+links) describes the rationale behind the change.
- Part of https://trello.com/c/A4P3V9gK
