### PR TITLE
Guarantee artefacts exist for manuals

### DIFF
--- a/lib/manual_artefact_guarantor.rb
+++ b/lib/manual_artefact_guarantor.rb
@@ -9,6 +9,8 @@ class ManualArtefactGuarantor
   def guarantee
     if !content_item_exists?
       Guarantee.failure(manual_slug, :does_not_exist)
+    elsif !content_item_is_a_manual?
+      Guarantee.failure(manual_slug, :is_not_a_manual)
     end
   end
 
@@ -21,6 +23,10 @@ class ManualArtefactGuarantor
   end
 
   private
+
+  def content_item_is_a_manual?
+    content_item.format == 'manual'
+  end
 
   def content_item_exists?
     content_item.present?

--- a/lib/manual_artefact_guarantor.rb
+++ b/lib/manual_artefact_guarantor.rb
@@ -1,0 +1,61 @@
+require 'gds_api/content_store'
+
+class ManualArtefactGuarantor
+  attr_reader :manual_slug
+  def initialize(manual_slug)
+    @manual_slug = manual_slug
+  end
+
+  def guarantee
+    if !content_item_exists?
+      Guarantee.failure(manual_slug, :does_not_exist)
+    end
+  end
+
+  def content_item
+    # Do this to allow memoizing the nils we get from a 404
+    unless defined? @content_item
+      @content_item = fetch_content_item
+    end
+    @content_item
+  end
+
+  private
+
+  def content_item_exists?
+    content_item.present?
+  end
+
+  def base_path
+    "/#{manual_slug}"
+  end
+
+  def fetch_content_item
+    content_store.content_item(base_path)
+  end
+
+  def content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find('content-store'))
+  end
+
+  class Guarantee
+    attr_reader :slug, :reason
+    def initialize(success, slug, reason)
+      @success = !!success
+      @slug = slug
+      @reason = reason
+    end
+
+    def success?
+      @success
+    end
+
+    def message
+      "#{slug} #{reason.to_s.humanize.downcase}"
+    end
+
+    def self.failure(slug, reason)
+      new(false, slug, nil, reason)
+    end
+  end
+end

--- a/lib/manual_artefact_guarantor.rb
+++ b/lib/manual_artefact_guarantor.rb
@@ -1,6 +1,10 @@
 require 'gds_api/content_store'
 
 class ManualArtefactGuarantor
+  def self.guarantee(manual_slug)
+    new(manual_slug).guarantee
+  end
+
   attr_reader :manual_slug
   def initialize(manual_slug)
     @manual_slug = manual_slug
@@ -119,6 +123,10 @@ class ManualArtefactGuarantor
 
     def message
       "#{slug}#{content_id.present? ? "(#{content_id})" : ''} #{reason.to_s.humanize.downcase}"
+    end
+
+    def to_s
+      "#{success? ? "OK" : "ERROR"}: #{message}"
     end
 
     def self.failure(slug, content_id: nil, reason:)

--- a/lib/manual_artefact_guarantor.rb
+++ b/lib/manual_artefact_guarantor.rb
@@ -37,7 +37,7 @@ class ManualArtefactGuarantor
     @artefact
   end
 
-  private
+private
 
   def handle_existing_artefact
     if artefact_matches?

--- a/lib/tasks/manuals.rake
+++ b/lib/tasks/manuals.rake
@@ -1,0 +1,16 @@
+require 'manual_artefact_guarantor'
+
+namespace :manuals do
+  desc "Guarantee that a manual has an artefact"
+  task :guarantee_artefact, [] => :environment do |_task, args|
+    manual_slugs = args.extras
+    if manual_slugs.empty?
+      puts "Usage: rake manuals:guarantee_artefact[manual-slug-to-check-1,manual-slug-to-check-2,...,manual-slug-to-check-n]"
+    else
+      manual_slugs.each do |manual_slug|
+        print "Guaranteeing Artefact exists for manual '#{manual_slug}': "
+        puts ManualArtefactGuarantor.guarantee(manual_slug)
+      end
+    end
+  end
+end

--- a/test/unit/manual_artefact_guarantor_test.rb
+++ b/test/unit/manual_artefact_guarantor_test.rb
@@ -13,6 +13,10 @@ class ManualArtefactGuarantorTest < ActiveSupport::TestCase
     content_item_for_base_path("/guidance/#{slug}").merge({ 'format' => 'manual', 'content_id' => generate_content_id })
   end
 
+  setup do
+    RoutableArtefact.any_instance.stubs(:submit)
+  end
+
   should "return an unsuccessful result if the slug does not exist in the content store" do
     content_store_does_not_have_item('/guidance/missing-item')
 
@@ -76,6 +80,30 @@ class ManualArtefactGuarantorTest < ActiveSupport::TestCase
       response = mag.guarantee
       assert_equal false, response.success?
       assert_match /artefact details do not match/, response.message
+      assert_match /#{Regexp.escape(@manual_item['content_id'])}/, response.message
+    end
+  end
+
+  context 'when there is no artefact for the slug' do
+    setup do
+      @manual_item = manual_item('a-manual-with-artefact')
+      content_store_has_item('/guidance/a-manual-with-artefact', @manual_item)
+    end
+
+    should "return a successful result after creating one without error" do
+      mag = ManualArtefactGuarantor.new('a-manual-with-artefact')
+      response = mag.guarantee
+      assert_equal true, response.success?
+      assert_match /artefact created/, response.message
+      assert_match /#{Regexp.escape(@manual_item['content_id'])}/, response.message
+    end
+
+    should "return an unsuccessful result if creating one fails" do
+      Artefact.any_instance.stubs(:save).returns(false)
+      mag = ManualArtefactGuarantor.new('a-manual-with-artefact')
+      response = mag.guarantee
+      assert_equal false, response.success?
+      assert_match /artefact creation failed/, response.message
       assert_match /#{Regexp.escape(@manual_item['content_id'])}/, response.message
     end
   end

--- a/test/unit/manual_artefact_guarantor_test.rb
+++ b/test/unit/manual_artefact_guarantor_test.rb
@@ -40,4 +40,21 @@ class ManualArtefactGuarantorTest < ActiveSupport::TestCase
     assert_equal false, response.success?
     assert_match /is not a manual/, response.message
   end
+
+  should "return a successful result if the content_item is a manual and an artefact already exists for it" do
+    manual_item = manual_item('a-manual-with-artefact')
+    content_store_has_item('/guidance/a-manual-with-artefact', manual_item)
+    artefact = FactoryGirl.create(:artefact,
+      slug: 'guidance/a-manual-with-artefact',
+      owning_app: 'specialist-publisher',
+      kind: 'manual',
+      content_id: manual_item['content_id']
+    )
+
+    mag = ManualArtefactGuarantor.new('a-manual-with-artefact')
+    response = mag.guarantee
+    assert_equal true, response.success?
+    assert_match /artefact already exists/, response.message
+    assert_match /#{Regexp.escape(manual_item['content_id'])}/, response.message
+  end
 end

--- a/test/unit/manual_artefact_guarantor_test.rb
+++ b/test/unit/manual_artefact_guarantor_test.rb
@@ -21,4 +21,23 @@ class ManualArtefactGuarantorTest < ActiveSupport::TestCase
     assert_equal false, response.success?
     assert_match /does not exist/, response.message
   end
+
+  should "fetch the content_item for the specified manual slug from the content store" do
+    manual_item = manual_item('a-manual')
+    content_store_has_item('/guidance/a-manual', manual_item)
+
+    mag = ManualArtefactGuarantor.new('a-manual')
+
+    assert_equal manual_item['content_id'], mag.content_item.content_id
+  end
+
+  should "return an unsuccessful result if the content_item is not a manual" do
+    not_a_manual = content_item_for_base_path('/guidance/not-a-manual').merge({ 'format' => 'license', 'content_id' => generate_content_id })
+    content_store_has_item('/guidance/not-a-manual', not_a_manual)
+
+    mag = ManualArtefactGuarantor.new('not-a-manual')
+    response = mag.guarantee
+    assert_equal false, response.success?
+    assert_match /is not a manual/, response.message
+  end
 end

--- a/test/unit/manual_artefact_guarantor_test.rb
+++ b/test/unit/manual_artefact_guarantor_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'gds_api/test_helpers/content_store'
+require 'manual_artefact_guarantor'
+
+class ManualArtefactGuarantorTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  def generate_content_id
+    SecureRandom.uuid
+  end
+
+  def manual_item(slug)
+    content_item_for_base_path("/guidance/#{slug}").merge({ 'format' => 'manual', 'content_id' => generate_content_id })
+  end
+
+  should "return an unsuccessful result if the slug does not exist in the content store" do
+    content_store_does_not_have_item('/guidance/missing-item')
+
+    mag = ManualArtefactGuarantor.new('missing-item')
+    response = mag.guarantee
+    assert_equal false, response.success?
+    assert_match /does not exist/, response.message
+  end
+end


### PR DESCRIPTION
Since https://github.com/alphagov/specialist-publisher/pull/533 manuals published by specialist-publisher no longer store an `Artefact` instance and this means they cannot be loaded in panopticon for tagging purposes.  This PR provides a rake task that given the slug of a manual will make sure that it has an `Artefact` instance.

For: https://trello.com/c/CgxBYZoV/241-artefacts-are-not-being-created-in-panopticon-for-newly-published-manuals-any-more
