### PR TITLE
Add policy-publisher to list of migrated apps

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,3 +4,4 @@ apps_with_migrated_tagging:
  - calendars
  - licencefinder
  - smartanswers
+ - policy-publisher


### PR DESCRIPTION
We're migrating policy-publisher to use the publishing api so that we have a single source of truth for tags.

This is related to https://trello.com/c/87jz9T24/465-migrate-policy-publisher-to-new-tagging-infrastructure
and depends on alphagov/policy-publisher#121
