### PR TITLE
Add hmrc-manuals-api to list of apps migrated to new tagging architecture

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,4 @@ apps_with_migrated_tagging:
  - licencefinder
  - smartanswers
  - policy-publisher
+ - hmrc-manuals-api


### PR DESCRIPTION
Trello: https://trello.com/c/6Owhx9Vn
