### PR TITLE
Updates several vulnerable gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,9 @@ gem 'logstasher', '0.4.8'
 # TODO: Investigate whether there is a requirement to pin these
 # gems here, when they are dependencies of govuk_content_models
 gem "mongoid", "~> 2.5"
-gem "mongo", "1.7.1"
-gem "bson_ext", "1.7.1"
-gem "bson", "1.7.1"
+gem "mongo", "~> 1.12.3"
+gem "bson_ext", "~> 1.12.3"
+gem "bson", "~> 1.12.3"
 
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
@@ -62,7 +62,7 @@ gem 'config', '~>1.0'
 group :assets do
   gem "therubyracer", "0.12.0"
   gem 'sass-rails', '3.2.6'
-  gem 'uglifier'
+  gem 'uglifier', '>= 2.7.2'
 end
 
 group :development do
@@ -92,5 +92,5 @@ group :test do
 end
 
 group :import do
-  gem 'nokogiri'
+  gem 'nokogiri', '>= 1.6.7.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,9 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
-    bson (1.7.1)
-    bson_ext (1.7.1)
-      bson (~> 1.7.1)
+    bson (1.12.5)
+    bson_ext (1.12.5)
+      bson (~> 1.12.5)
     builder (3.0.4)
     bunny (2.2.1)
       amq-protocol (>= 2.0.0)
@@ -98,7 +98,8 @@ GEM
     config (1.0.0)
       activesupport (>= 3.0)
       deep_merge (~> 1.0.0)
-    crack (0.3.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     cucumber (1.2.1)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -213,12 +214,12 @@ GEM
     metaclass (0.0.1)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
-    mongo (1.7.1)
-      bson (~> 1.7.1)
+    mongo (1.12.5)
+      bson (= 1.12.5)
     mongoid (2.6.0)
       activemodel (~> 3.1)
       mongo (~> 1.7)
@@ -235,8 +236,8 @@ GEM
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     netrc (0.11.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     ntlm-http (0.1.1)
     null_logger (0.0.1)
     oauth2 (1.0.0)
@@ -307,6 +308,7 @@ GEM
       multi_json
       null_logger
       rest-client
+    safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
     sass (3.4.18)
@@ -341,9 +343,9 @@ GEM
     turn (0.9.6)
       ansi
     tzinfo (0.3.46)
-    uglifier (1.2.7)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
-      multi_json (~> 1.3)
+      json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -375,8 +377,8 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   ansi
   bootstrap-kaminari-views (= 0.0.3)
-  bson (= 1.7.1)
-  bson_ext (= 1.7.1)
+  bson (~> 1.12.3)
+  bson_ext (~> 1.12.3)
   capybara (~> 2.1.0)
   capybara-mechanize (~> 1.1.0)
   chosen-rails (= 1.4.2)
@@ -403,11 +405,11 @@ DEPENDENCIES
   mechanize (~> 2.7.2)
   minitest
   mocha (= 0.13.3)
-  mongo (= 1.7.1)
+  mongo (~> 1.12.3)
   mongoid (~> 2.5)
   mongoid_rails_migrations (= 1.0.0)
   nested_form (= 0.3.2)
-  nokogiri
+  nokogiri (>= 1.6.7.2)
   null_logger
   plek (~> 1.8)
   poltergeist (~> 1.6.0)
@@ -422,7 +424,7 @@ DEPENDENCIES
   simplecov-rcov
   therubyracer (= 0.12.0)
   turn
-  uglifier
+  uglifier (>= 2.7.2)
   unicorn (= 4.3.1)
   webmock
   whenever (= 0.9.2)


### PR DESCRIPTION
Related with: https://trello.com/c/J8jN7OFV/502-ensure-all-apps-have-up-to-date-dependencies
Gems updated:
- mongo    to '1.12.3'
- bson     to '1.12.3'
- bson_ext to '1.12.3'
- uglifier to '2.7.2'
- nokogiri to '1.6.7.2'
- crack    to '0.4.3'

Although we can't update `mail` gem because `actionmailer` depends on `~> 2.5.4`
the only way to support `2.6.0` is to upgrade to rails 4, which will break a lot of the dependencies.

Edit: Seems there's a pull request in place to fix this security issue, hopefully it will be merged in a near future, https://github.com/mikel/mail/issues/944

It's also safe to ignore it as this app does not make use of `actionmailer`

```
------ Auditing panopticon -------
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Current branch master is up to date.
ruby-advisory-db: 262 advisories
Name: bson
Version: 1.7.1
Advisory: CVE-2015-4412
Criticality: Unknown
URL: http://sakurity.com/blog/2015/06/04/mongo_ruby_regexp.html
Title: Data Injection Vulnerability in bson Rubygem
Solution: upgrade to ~> 1.12.3, >= 3.0.4

Name: crack
Version: 0.3.1
Advisory: CVE-2013-1800
Criticality: High
URL: http://osvdb.org/show/osvdb/90742
Title: crack Gem for Ruby Type Casting Parameter Parsing Remote Code Execution
Solution: upgrade to >= 0.3.2

Name: mail
Version: 2.5.4
Advisory: 131677
Criticality: Unknown
URL: http://www.mbsd.jp/Whitepaper/smtpi.pdf
Title: Mail Gem for Ruby vulnerable to SMTP Injection via recipient email addresses
Solution: upgrade to >= 2.6.0

Name: nokogiri
Version: 1.6.6.2
Advisory: CVE-2015-1819
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1374
Title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
Solution: upgrade to ~> 1.6.6.4, >= 1.6.7.rc4

Name: nokogiri
Version: 1.6.6.2
Advisory: CVE-2015-5312
Criticality: High
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
Title: Nokogiri gem contains several vulnerabilities in libxml2
Solution: upgrade to >= 1.6.7.1

Name: nokogiri
Version: 1.6.6.2
Advisory: CVE-2015-7499
Criticality: Medium
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/Dy7YiKb_pMM
Title: Nokogiri gem contains a heap-based buffer overflow vulnerability in libxml2
Solution: upgrade to >= 1.6.7.2
```
#### After

```
Name: mail
Version: 2.5.4
Advisory: 131677
Criticality: Unknown
URL: http://www.mbsd.jp/Whitepaper/smtpi.pdf
Title: Mail Gem for Ruby vulnerable to SMTP Injection via recipient email addresses
Solution: upgrade to >= 2.6.0

Vulnerabilities found!
```

cc @tijmenb @rboulton 
