### PR TITLE
Use govuk_content_models save_as_task instead of save!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 .sass-cache/
 .DS_Store
 /script/*_dump/
+public/assets/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,10 @@ gem "bson", "~> 1.12.3"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '~> 32.3'
+  gem 'govuk_content_models', '~> 33.0.0'
 end
+
+gem 'rake', '10.5.0'
 
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     database_cleaner (0.8.0)
     deep_merge (1.0.1)
     diff-lcs (1.1.3)
-    domain_name (0.5.20160216)
+    domain_name (0.5.20160309)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -161,7 +161,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (32.3.0)
+    govuk_content_models (33.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -396,7 +396,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (~> 32.3)
+  govuk_content_models (~> 33.0.0)
   govuk_message_queue_consumer (~> 2.0.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
@@ -416,6 +416,7 @@ DEPENDENCIES
   pry (~> 0.10.3)
   quiet_assets
   rails (= 3.2.22.2)
+  rake (= 10.5.0)
   rummageable (= 1.0.1)
   sass-rails (= 3.2.6)
   select2-rails (= 3.5.9.1)

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -30,21 +30,30 @@ module ArtefactsHelper
 
     phrase = case action.action_type
     when 'create', 'update'
-      "has #{action.action_type}d this artefact"
+      "has #{action.action_type}d this artefact."
     else
-      "did a #{action.action_type} action"
+      "did a #{action.action_type} action."
     end
 
-    action_performed_by(action) << phrase
+    action_performed_by(action, phrase)
   end
 
-  def action_performed_by(action)
-    if action.task_performed_by
-      "Automatic task: '#{action.task_performed_by}' "
-    elsif action.user
+  def action_performed_by(action, phrase)
+    return performed_by_message(action.task_performed_by) if action.task_performed_by
+
+    if action.user
       "#{action.user} <#{action.user.email}> "
     else
       "An unknown user or task "
+    end << phrase
+  end
+
+  def performed_by_message(performed_by)
+    case performed_by
+    when 'TaggingUpdater'
+      "An external application has updated the tags for this artefact."
+    else
+      "A developer has manually updated this artefact."
     end
   end
 end

--- a/app/helpers/artefacts_helper.rb
+++ b/app/helpers/artefacts_helper.rb
@@ -24,4 +24,27 @@ module ArtefactsHelper
     # select2 needs a JSON object with id and text attributes
     related_artefacts.map {|a| { id: a.slug, text: a.name_with_owner_prefix } }.to_json
   end
+
+  def action_information_phrase(action)
+    return "Automatic snapshot" if !action.user && action.action_type == "snapshot"
+
+    phrase = case action.action_type
+    when 'create', 'update'
+      "has #{action.action_type}d this artefact"
+    else
+      "did a #{action.action_type} action"
+    end
+
+    action_performed_by(action) << phrase
+  end
+
+  def action_performed_by(action)
+    if action.task_performed_by
+      "Automatic task: '#{action.task_performed_by}' "
+    elsif action.user
+      "#{action.user} <#{action.user.email}> "
+    else
+      "An unknown user or task "
+    end
+  end
 end

--- a/app/models/diff_enabled_action.rb
+++ b/app/models/diff_enabled_action.rb
@@ -4,7 +4,7 @@ class DiffEnabledAction
 
   extend Forwardable
 
-  def_delegators :@action, :action_type, :snapshot, :created_at, :user
+  def_delegators :@action, :action_type, :snapshot, :created_at, :user, :task_performed_by
 
   def initialize(action, previous = nil)
     @action, @previous = action, previous

--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -51,6 +51,6 @@ private
       artefact.set_primary_tag_of_type('section', parent.first.tag_id)
     end
 
-    artefact.save_as_task('TaggingUpdater')
+    artefact.save_as_task!('TaggingUpdater')
   end
 end

--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -51,6 +51,6 @@ private
       artefact.set_primary_tag_of_type('section', parent.first.tag_id)
     end
 
-    artefact.save!
+    artefact.save_as_task('TaggingUpdater')
   end
 end

--- a/app/views/artefacts/history.html.erb
+++ b/app/views/artefacts/history.html.erb
@@ -9,19 +9,7 @@
     <dt><%= human_timestamp(action.created_at) %></dt>
     <dd>
       <p>
-      <% if ! action.user and action.action_type == "snapshot" %>
-        Automatic snapshot
-      <% else %>
-        <%= action.user || "An unknown user" %>
-        <% case action.action_type %>
-        <% when "create" %>
-          created this artefact
-        <% when "update" %>
-          updated this artefact
-        <% else %>
-          did a "<%= action.action_type %>" action
-        <% end %>
-      <% end %>
+        <%= action_information_phrase(action) %>
       </p>
       <% unless action.initial? %>
         <% if action.changes.empty? %>

--- a/lib/organisation_slug_changer.rb
+++ b/lib/organisation_slug_changer.rb
@@ -50,7 +50,7 @@ private
 
   def update_artefact(artefact)
     artefact.organisation_ids = (artefact.organisation_ids - [old_slug] + [new_slug])
-    artefact.save_as_task('OrganisationSlugChanger')
+    artefact.save_as_task!('OrganisationSlugChanger')
     logger.info "   -> Updated tags for artefact '#{artefact.slug}'"
   end
 

--- a/lib/organisation_slug_changer.rb
+++ b/lib/organisation_slug_changer.rb
@@ -50,7 +50,7 @@ private
 
   def update_artefact(artefact)
     artefact.organisation_ids = (artefact.organisation_ids - [old_slug] + [new_slug])
-    artefact.save!
+    artefact.save_as_task('OrganisationSlugChanger')
     logger.info "   -> Updated tags for artefact '#{artefact.slug}'"
   end
 

--- a/lib/tasks/move_content_to_new_topic.rake
+++ b/lib/tasks/move_content_to_new_topic.rake
@@ -37,7 +37,7 @@ task :move_content_to_new_topic => :environment do
       topic.tag_id
     }
     artefact.specialist_sectors = new_topics
-    artefact.save!
+    artefact.save_as_task('move_content_to_new_topic')
 
     rummageable_artefact = RummageableArtefact.new(artefact)
     if rummageable_artefact.should_be_indexed?

--- a/lib/tasks/move_content_to_new_topic.rake
+++ b/lib/tasks/move_content_to_new_topic.rake
@@ -37,7 +37,7 @@ task :move_content_to_new_topic => :environment do
       topic.tag_id
     }
     artefact.specialist_sectors = new_topics
-    artefact.save_as_task('move_content_to_new_topic')
+    artefact.save_as_task!('move_content_to_new_topic')
 
     rummageable_artefact = RummageableArtefact.new(artefact)
     if rummageable_artefact.should_be_indexed?

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -24,23 +24,36 @@ class ArtefactsHelperTest < ActiveSupport::TestCase
         user = FactoryGirl.create(:user)
         @artefact.actions.build(user: user, action_type: 'update')
 
-        expected = "#{user} <#{user.email}> has updated this artefact"
+        expected = "#{user} <#{user.email}> has updated this artefact."
         assert_equal expected, action_information_phrase(@artefact.actions.last)
       end
     end
 
     context "when action is performed by task" do
-      should "return task name" do
-        @artefact.actions.build(task_performed_by: 'TaggingUpdater', action_type: 'update')
+      context 'when performed by TaggingUpdater' do
+        should "show updated tags phrase" do
+          @artefact.actions.build(task_performed_by: 'TaggingUpdater', action_type: 'update')
 
-        expected = "Automatic task: 'TaggingUpdater' has updated this artefact"
-        assert_equal expected, action_information_phrase(@artefact.actions.last)
+          expected = "An external application has updated the tags for this artefact."
+          assert_equal expected, action_information_phrase(@artefact.actions.last)
+        end
+      end
+
+      %w(OrganisationSlugChanger move_content_to_new_topic).each do |task_name|
+        context "when performed by #{task_name}" do
+          should "show updated by a developer phrase" do
+            @artefact.actions.build(task_performed_by: task_name, action_type: 'update')
+
+            expected = "A developer has manually updated this artefact."
+            assert_equal expected, action_information_phrase(@artefact.actions.last)
+          end
+        end
       end
     end
 
     context "when action is performed by unknown" do
       should "return unknown user or task" do
-        expected = "An unknown user or task has created this artefact"
+        expected = "An unknown user or task has created this artefact."
         assert_equal expected, action_information_phrase(@artefact.actions.last)
       end
     end
@@ -50,7 +63,7 @@ class ArtefactsHelperTest < ActiveSupport::TestCase
         action = @artefact.actions.build(task_performed_by: 'TaggingUpdater', action_type: 'update')
         diff_enabled_action = DiffEnabledAction.new(action, nil)
 
-        expected = "Automatic task: 'TaggingUpdater' has updated this artefact"
+        expected = "An external application has updated the tags for this artefact."
         assert_equal expected, action_information_phrase(diff_enabled_action)
       end
     end

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -13,4 +13,36 @@ class ArtefactsHelperTest < ActiveSupport::TestCase
       assert manageable_formats.exclude?('specialist_sector')
     end
   end
+
+  context "#action_information_phrase" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact)
+    end
+
+    context "when action is performed by user" do
+      should "return user name and email" do
+        user = FactoryGirl.create(:user)
+        @artefact.actions.build(user: user, action_type: 'update')
+
+        expected = "#{user} <#{user.email}> has updated this artefact"
+        assert_equal expected, action_information_phrase(@artefact.actions.last)
+      end
+    end
+
+    context "when action is performed by task" do
+      should "return task name" do
+        @artefact.actions.build(task_performed_by: 'TaggingUpdater', action_type: 'update')
+
+        expected = "Automatic task: 'TaggingUpdater' has updated this artefact"
+        assert_equal expected, action_information_phrase(@artefact.actions.last)
+      end
+    end
+
+    context "when action is performed by unknown" do
+      should "return unknown user or task" do
+        expected = "An unknown user or task has created this artefact"
+        assert_equal expected, action_information_phrase(@artefact.actions.last)
+      end
+    end
+  end
 end

--- a/test/unit/helpers/artefacts_helper_test.rb
+++ b/test/unit/helpers/artefacts_helper_test.rb
@@ -44,5 +44,15 @@ class ArtefactsHelperTest < ActiveSupport::TestCase
         assert_equal expected, action_information_phrase(@artefact.actions.last)
       end
     end
+
+    context "when action is a DiffEnabledAction" do
+      should "work as normal action" do
+        action = @artefact.actions.build(task_performed_by: 'TaggingUpdater', action_type: 'update')
+        diff_enabled_action = DiffEnabledAction.new(action, nil)
+
+        expected = "Automatic task: 'TaggingUpdater' has updated this artefact"
+        assert_equal expected, action_information_phrase(diff_enabled_action)
+      end
+    end
   end
 end


### PR DESCRIPTION
Uses `save_as_task` added on https://github.com/alphagov/govuk_content_models/pull/360

Given that during the incident in 2016-02-14 it was not clear what meant
"An unknown user".

When an artefact action has no user it means it was updated by one of
the tasks, in panopticon it would be one of these three:
- TaggingUpdater
- OrganisationSlugChanger
- rake task "Move content to new topics"

In order to know which one, we have agreed to add a new field in
ArtefactAction called "task_performed_by" that receives a string with
the name of the automatic task.

This will facilitate future debugging and more visibility to developers
if future incidents happen.

**First**
<img width="1146" alt="screen shot 2016-03-14 at 12 49 17" src="https://cloud.githubusercontent.com/assets/136777/13745019/a0dce0f6-e9e3-11e5-8ec2-e3a7e951352c.png">

**Second**
<img width="1136" alt="screen shot 2016-03-14 at 14 42 09" src="https://cloud.githubusercontent.com/assets/136777/13748038/052ef5da-e9f3-11e5-9fe5-113e28cb6fd8.png">
