### PR TITLE
Add travel-advice-publisher to migrated apps list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,3 +6,4 @@ apps_with_migrated_tagging:
  - smartanswers
  - policy-publisher
  - hmrc-manuals-api
+ - travel-advice-publisher


### PR DESCRIPTION
This should now have its links sent to the publishing API.

Part of: https://trello.com/c/Unia7Z0B
