### PR TITLE
Don't sync & migrate the `parent` tag for TAP

### DIFF
--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -46,9 +46,11 @@ private
       artefact.set_tags_of_type(panopticon_tag_name, new_tags.map(&:tag_id))
     end
 
-    if content_item['links']['parent']
-      parent = Tag.where(:content_id.in => content_item['links']['parent'])
-      artefact.set_primary_tag_of_type('section', parent.first.tag_id)
+    unless content_item.fetch('publishing_app') == 'travel-advice-publisher'
+      if content_item['links']['parent']
+        parent = Tag.where(:content_id.in => content_item['links']['parent'])
+        artefact.set_primary_tag_of_type('section', parent.first.tag_id)
+      end
     end
 
     artefact.save!

--- a/lib/tagging_migrator.rb
+++ b/lib/tagging_migrator.rb
@@ -28,8 +28,10 @@ private
       organisations: [],
     }
 
-    if artefact.primary_section
-      link_payload[:parent] = [artefact.primary_section.content_id]
+    unless @app_name == 'travel-advice-publisher'
+      if artefact.primary_section
+        link_payload[:parent] = [artefact.primary_section.content_id]
+      end
     end
 
     artefact.tags.each do |tag|


### PR DESCRIPTION
Travel advice publisher pages don't have the usual `content_id` for `parent` in the links hash, but an expanded hash. This means that we don't want to overwrite this when syncing travel advice pages. This is okay because we are disabling `parent` for tap-pages in content-tagger.

Part of: https://trello.com/c/Unia7Z0B
