### PR TITLE
Add deprecated application list

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -42,4 +42,9 @@ class Artefact
     return true if self.new_record? && self.owning_app.nil? && Settings.apps_with_migrated_tagging.include?('publisher')
     Settings.apps_with_migrated_tagging.include?(self.owning_app)
   end
+
+  def app_without_tagging?
+    return false unless Settings.apps_without_tagging
+    Settings.apps_without_tagging.include?(self.owning_app)
+  end
 end

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -1,4 +1,7 @@
-<%- if f.object.tagging_migrated? %>
+<%- if f.object.app_without_tagging?
+    # show nothing
+%>
+<%- elsif f.object.tagging_migrated? %>
   <%= render 'migrated_app', artefact: f.object %>
 <% else %>
   <div class="well">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,4 @@ apps_with_migrated_tagging:
 
 apps_without_tagging:
   - finder-api
+  - planner

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,4 +10,5 @@ apps_with_migrated_tagging:
 
 apps_without_tagging:
   - finder-api
+  - frontend
   - planner

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,6 @@ apps_with_migrated_tagging:
  - policy-publisher
  - hmrc-manuals-api
  - travel-advice-publisher
+
+apps_without_tagging:
+  - finder-api

--- a/test/unit/artefact/artefact_test.rb
+++ b/test/unit/artefact/artefact_test.rb
@@ -2,6 +2,23 @@ require_relative '../../test_helper'
 
 class Artefact::ArtefactTest < ActiveSupport::TestCase
 
+  context "app_without_tagging?" do
+    context "when artefact is from a deprecated application" do
+
+      should "return true when owning app is in the apps_without_migrated_tagging" do
+        artefact = FactoryGirl.create(:artefact, slug: "low-hanging-fruit", owning_app: 'finder-api')
+
+        assert_equal true, artefact.app_without_tagging?
+      end
+
+      should "return false when owning app is not in the apps_without_migrated_tagging" do
+        artefact = FactoryGirl.create(:artefact, slug: "low-hanging-fruit", owning_app: 'whitehall')
+
+        assert_equal false, artefact.app_without_tagging?
+      end
+    end
+  end
+
   context "tagging_migrated?" do
 
     context 'standard set of untaggable apps (publisher, smartanswers and testapp)' do


### PR DESCRIPTION
Don't show tagging options for artefacts that can't be tagged.

Part of: https://trello.com/c/1JbLazTK/553-finder-api-disable-tagging-for-panopticon-content
- The only page owned by `frontend` (/help) is not in the content-store, so can't be tagged.
- `finder-api` is [deprecated](https://github.com/gds-attic/finder-api)
- `planner` only has `withdrawn` content
