### PR TITLE
[See other PRs] Migrate tagging to publishing api.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,7 @@ apps_with_migrated_tagging:
  - policy-publisher
  - hmrc-manuals-api
  - travel-advice-publisher
+ - tariff
 
 apps_without_tagging:
   - finder-api


### PR DESCRIPTION
Tagging is now handled by content tagger and the publishing api.

Part of: https://trello.com/c/Aqvwgl1G/558-migrate-the-trade-tariff-page-to-new-tagging-infrastructure

Should be deployed with
- https://github.com/alphagov/content-tagger/pull/50
- https://github.com/alphagov/rummager/pull/594
- https://github.com/alphagov/tagging-migration-verifier/pull/14
