### PR TITLE
Don't load ActionMailer framework

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sass"
 require "sprockets/railtie"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,9 +13,6 @@ Panopticon::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
-
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,9 +45,6 @@ Panopticon::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   # config.assets.precompile += %w( search.js )
 
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable threaded mode
   # config.threadsafe!
 
@@ -57,9 +54,6 @@ Panopticon::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
-
-  config.action_mailer.default_url_options = { :host => Plek.current.find('panopticon') }
-  config.action_mailer.delivery_method = :ses
 
   # Enable JSON-style logging
   config.logstasher.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,11 +24,6 @@ Panopticon::Application.configure do
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types


### PR DESCRIPTION
This application doesn't send emails. It used to send its errors via the `exception_notification` gem (which needs ActionMailer). We've used Airbrake for a while now so we can remove this.

We'll also remove the actionmailer initializer from alphagov-deployment:

https://github.gds/gds/alphagov-deployment/pull/1163
