### PR TITLE
Remove `legacy_source` from panopticon

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -223,7 +223,7 @@ class ArtefactsController < ApplicationController
       end
 
       # Strip out the empty submit option for sections
-      ['sections', 'legacy_source_ids', 'specialist_sector_ids', 'organisation_ids'].each do |param|
+      ['sections', 'specialist_sector_ids', 'organisation_ids'].each do |param|
         param_value = parameters_to_use[param]
         param_value.reject!(&:blank?) if param_value
       end

--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -31,15 +31,6 @@
         </p>
       <% end %>
 
-      <div class="legacy-source-tags fieldset-section">
-        <label for="artefact_legacy_source_ids" class="section-label">Legacy sources</label>
-
-        <%= f.input :legacy_source_ids,
-                    :label => false,
-                    :collection => options_for_tags_of_type('legacy_source'),
-                    :input_html => { :multiple => true, :class => "chosen-select" } %>
-      </div>
-
       <% if f.object.allow_specialist_sector_tag_changes? %>
         <div class="specialist-sector-tags fieldset-section">
           <label for="artefact_specialist_sector_ids" class="section-label">Specialist sectors</label>

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -246,14 +246,13 @@ class ArtefactsControllerTest < ActionController::TestCase
           artefact = FactoryGirl.create(:artefact, owning_app: "whitehall")
           get :edit, id: artefact.id
           assert_template :whitehall_form
-        end      
+        end
       end
 
       should "assign list of sections" do
         FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'kablooey', :title => 'Kablooey')
         FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'fooey', :title => 'Fooey')
         FactoryGirl.create(:live_tag, :tag_type => 'section', :tag_id => 'gooey', :title => 'Gooey')
-        FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
 
         artefact = FactoryGirl.create(:artefact)
 
@@ -268,14 +267,14 @@ class ArtefactsControllerTest < ActionController::TestCase
           artefact = FactoryGirl.create(:artefact, owning_app: 'smartanswers')
           get :edit, id: artefact.id, format: :html
           assert_select "button#add-section", true, "Expecting to find a button to add tags when tagging for the owning app has not been migrated"
-        end 
+        end
 
         should "not show the tags partial when owning app is in the list of apps with migrated tagging" do
           Settings.expects(:apps_with_migrated_tagging).returns(%w{ publisher smartanswers testapp }).at_least(1)
           artefact = FactoryGirl.create(:artefact, owning_app: 'smartanswers')
           get :edit, id: artefact.id, format: :html
           assert_select "button#add-section", false, "Not expecting to find a button to add tags when tagging for the owning app has been migrated"
-        end 
+        end
       end
     end
 
@@ -428,15 +427,13 @@ class ArtefactsControllerTest < ActionController::TestCase
 
       should "Include tag_ids" do
         FactoryGirl.create(:live_tag, :tag_id => 'crime', :tag_type => 'section', :title => 'Crime')
-        FactoryGirl.create(:live_tag, :tag_id => 'businesslink', :tag_type => 'legacy_source', :title => 'Business Link')
         artefact = Artefact.create! :slug => 'whatever', :kind => 'guide', :owning_app => 'publisher', :name => 'Whatever', :need_ids => ['100001']
         artefact.sections = ['crime']
-        artefact.legacy_sources = ['businesslink']
         artefact.save!
         get :show, id: artefact.id, format: :json
         parsed = JSON.parse(response.body)
 
-        assert_equal %w(businesslink crime), parsed['tag_ids'].sort
+        assert_equal %w(crime), parsed['tag_ids'].sort
       end
 
       should "return 404 if the artefact's not found" do

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -11,12 +11,11 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     setup do
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
-      FactoryGirl.create(:live_tag, tag_type: "legacy_source", tag_id: "businesslink", parent_id: nil, title: "Business Link")
 
       @artefact = FactoryGirl.create(:artefact,
                                      name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
                                      owning_app: "smart-answers", language: "en",
-                                     section_ids: ["business/employing-people"], legacy_source_ids: ["businesslink"])
+                                     section_ids: ["business/employing-people"])
     end
 
     should "display the artefact form" do
@@ -142,42 +141,6 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
       artefact.reload
       assert_equal ["100012"], artefact.need_ids
-    end
-  end
-
-  context "editing legacy_sources" do
-    setup do
-      @bl   = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'businesslink', :title => 'Business Link')
-      @dg   = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'directgov', :title => 'Directgov')
-      @dvla = FactoryGirl.create(:live_tag, :tag_type => 'legacy_source', :tag_id => 'dvla', :title => 'DVLA')
-      @a = FactoryGirl.create(:artefact, :name => "VAT")
-      Settings.expects(:apps_with_migrated_tagging).returns(%w{ smartanswers testapp }).at_least(1)
-    end
-
-    should "allow adding legacy sources to artefacts" do
-      visit "/artefacts"
-      click_on "VAT"
-
-      select "Business Link", :from => "artefact[legacy_source_ids][]"
-      select "DVLA", :from => "artefact[legacy_source_ids][]"
-      click_on "Save and continue editing"
-
-      @a.reload
-      assert_equal [@bl, @dvla], @a.legacy_sources
-    end
-
-    should "allow removing legacy sources from artefacts" do
-      @a.legacy_source_ids = ['businesslink', 'directgov']
-      @a.save!
-
-      visit "/artefacts"
-      click_on "VAT"
-
-      unselect "Directgov", :from => "artefact[legacy_source_ids][]"
-      click_on "Save and continue editing"
-
-      @a.reload
-      assert_equal [@bl], @a.legacy_sources
     end
   end
 

--- a/test/unit/helpers/tags_helper_test.rb
+++ b/test/unit/helpers/tags_helper_test.rb
@@ -9,8 +9,6 @@ class TagsHelperTest < ActiveSupport::TestCase
       create(:live_tag, tag_type: "section", tag_id: "driving", title: "Driving")
       create(:live_tag, tag_type: "section", tag_id: "driving/car-tax", title: "Car tax", parent_id: "driving")
       create(:live_tag, tag_type: "section", tag_id: "driving/mot", title: "MOT", parent_id: "driving")
-
-      create(:live_tag, tag_type: "legacy_source", tag_id: "directgov", title: "Directgov")
     end
 
     should "return a hierarchy of parent tags and their children" do
@@ -22,5 +20,4 @@ class TagsHelperTest < ActiveSupport::TestCase
       assert_equal expected, grouped_options_for_tags_of_type("section")
     end
   end
-
 end


### PR DESCRIPTION
`legacy_source` was used in the beginning of GOV.UK to brand certain pages with "Business Link" or "Directgov". The data in the database has not been used since https://github.com/alphagov/slimmer/pull/109.

We will also add a PR to remove it from `govuk_content_models`.

Also see the search results for [legacy_source user:alphagov](https://github.com/search?q=legacy_source+user%3Aalphagov&type=Code&utf8=%E2%9C%93).

https://trello.com/c/ODNdKlkp
