### PR TITLE
Update govuk_content_models to 34.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "bson", "~> 1.12.3"
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', '~> 33.0.0'
+  gem 'govuk_content_models', '~> 34.0.0'
 end
 
 gem 'rake', '10.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     database_cleaner (0.8.0)
     deep_merge (1.0.1)
     diff-lcs (1.1.3)
-    domain_name (0.5.20160309)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -161,7 +161,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (33.0.0)
+    govuk_content_models (34.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -342,7 +342,7 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.9.6)
       ansi
-    tzinfo (0.3.46)
+    tzinfo (0.3.48)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -396,7 +396,7 @@ DEPENDENCIES
   gelf
   govuk-client-url_arbiter (= 0.0.2)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (~> 33.0.0)
+  govuk_content_models (~> 34.0.0)
   govuk_message_queue_consumer (~> 2.0.0)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)


### PR DESCRIPTION
Part of: https://trello.com/c/ODNdKlkp/564-remove-legacy-source-from-panopticon

Also updates the following:
- tzinfo
- domain_name
