### PR TITLE
Update integration tests to reflect current reality 

### DIFF
--- a/features/editing.feature
+++ b/features/editing.feature
@@ -28,13 +28,13 @@ Feature: Editing artefacts
     Then I should be redirected to Publisher
 
   Scenario: Add a section
-    Given a non-publisher artefact exists
+    Given an artefact from a non migrated app exists
       And a section exists
     When I add the section to the artefact
     Then the API should say that the artefact has the section
 
   Scenario: Remove a section
-    Given a non-publisher artefact exists
+    Given an artefact from a non migrated app exists
       And two sections exist
       And the artefact has both sections
     When I remove the second section from the artefact
@@ -50,7 +50,7 @@ Feature: Editing artefacts
     Then rummager should not be notified
 
   Scenario: Editing a live item
-    Given a non-publisher artefact exists
+    Given an artefact from a non migrated app exists
       And the first artefact is live
       And a section exists
     When I add the section to the artefact

--- a/features/related_items.feature
+++ b/features/related_items.feature
@@ -7,7 +7,7 @@ Feature: Related items
 
   @javascript
   Scenario: Assign a related item
-    Given two non-publisher artefacts exist
+    Given two artefacts from a non migrated app exist
      When I create a relationship between them
       And I save
      Then the API should say that the artefacts are related

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -14,12 +14,12 @@ Given /^the first artefact is live$/ do
   end
 end
 
-Given /^a non-publisher artefact exists$/ do
-  @artefact = create_artefact("smart-answers")
+Given /^an artefact from a non migrated app exists$/ do
+  @artefact = create_artefact("specialist-publisher")
 end
 
-Given /^two non-publisher artefacts exist$/ do
-  @artefact, @related_artefact = create_two_artefacts("smart-answers")
+Given /^two artefacts from a non migrated app exist$/ do
+  @artefact, @related_artefact = create_two_artefacts("specialist-publisher")
 end
 
 When /^I change the need ID of the first artefact$/ do

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -16,7 +16,7 @@ module RegistrationInfo
       "subsection"        => "tax",
       "link"              => "/calculate-married-couples-allowance",
       "indexable_content" => "You can use this calculator to work out if you qualify for Married Couple's Allowance, and how much you might get. You need to be married or in a civil partnership to claim. Were you or your partner born on or before 6 April 1935? You must be married or in a civil partnership to qualify. Did you marry before 5 December 2005? Before this date the husband's income is used to work out your allowance, after this date it's the income of the highest earner. What's the husband's date of birth? We need your date of birth to work out your personal allowance (how much of your income is tax-free). What's the highest earner's date of birth? We need your date of birth to work out your personal allowance (how much of your income is tax-free). What's the husband's yearly income? Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Employment and Support Allowance. What's the highest earner's yearly income? Add up your taxable income, eg earnings, pensions and any taxable benefits, eg Employment and Support Allowance. Contact HM Revenue & Customs to claim. HM Revenue & Customs Telephone 0845 300 0627 Textphone 0845 302 1408 This result is an estimate based on your answers. Contact HM Revenue & Customs to claim. HM Revenue & Customs Telephone 0845 300 0627 Textphone 0845 302 1408 This result is an estimate based on your answers. Sorry, you don't qualify for Married Couple's Allowance.",
-      "owning_app"        => 'smart-answers',
+      "owning_app"        => 'smartanswers',
       "state"             => "live"
     }
   end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -176,7 +176,7 @@ class ArtefactsControllerTest < ActionController::TestCase
       context "invalid artefact" do
         should "rerender the form" do
           Artefact.any_instance.stubs(:need)
-          post :create, :artefact => { :slug => 'not/valid', :owning_app => 'smart-answers', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
+          post :create, :artefact => { :slug => 'not/valid', :owning_app => 'smartanswers', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
         end
 
         should "not blow up if not given a slug" do
@@ -184,7 +184,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           publishing_api_returns_path_reservation_validation_error_for("/", "path" => ["can't be blank"])
 
           post :create, :artefact => {
-            :owning_app => 'smart-answers',
+            :owning_app => 'smartanswers',
             :slug => '',
             :kind => 'smart-answer',
             :name => 'Whatever',
@@ -197,7 +197,7 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "redirect to GET edit" do
-        post :create, :artefact => { :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
+        post :create, :artefact => { :owning_app => 'smartanswers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
 
         artefact = Artefact.last
         assert_redirected_to "/artefacts/#{artefact.id}/edit"
@@ -310,8 +310,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       end
 
       should "redirect to GET edit" do
-        artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers", kind: "smart-answer")
-        put :update, :id => artefact.id, :artefact => { :owning_app => 'smart-answers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
+        artefact = FactoryGirl.create(:artefact, owning_app: "smartanswers", kind: "smart-answer")
+        put :update, :id => artefact.id, :artefact => { :owning_app => 'smartanswers', :slug => 'whatever', :kind => 'smart-answer', :name => 'Whatever', :need_ids => '100001' }
 
         assert_redirected_to "/artefacts/#{artefact.id}/edit"
       end
@@ -520,7 +520,7 @@ class ArtefactsControllerTest < ActionController::TestCase
         )
         publishing_api_has_path_reservation_for("/whatever", "publisher")
 
-        put :update, id: artefact.id, "CONTENT_TYPE" => "application/json", owning_app: 'smart-answers'
+        put :update, id: artefact.id, "CONTENT_TYPE" => "application/json", owning_app: 'smartanswers'
         assert_equal 409, response.status
         assert response.body.include? "publisher"
       end

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -7,14 +7,14 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     stub_all_rummager_requests
   end
 
-  context "editing a publisher artefact" do
+  context "when editing an artefact from a non migrated publisher app" do
     setup do
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
 
       @artefact = FactoryGirl.create(:artefact,
                                      name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
-                                     owning_app: "smart-answers", language: "en",
+                                     owning_app: "specialist-publisher", language: "en",
                                      section_ids: ["business/employing-people"])
     end
 
@@ -34,7 +34,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       end
 
       within ".owning-app" do
-        assert page.has_content? "This content is managed in Smart-answers"
+        assert page.has_content? "This content is managed in Specialist-publisher"
       end
 
       within ".section-tags" do

--- a/test/unit/enhancements/artefact_test.rb
+++ b/test/unit/enhancements/artefact_test.rb
@@ -59,7 +59,7 @@ class ArtefactTest < ActiveSupport::TestCase
 
   context '#allow_specialist_sector_tag_changes?' do
     should 'be true for a non-whitehall non-publisher artefact' do
-      artefact = FactoryGirl.build(:artefact, owning_app: 'smart-answers')
+      artefact = FactoryGirl.build(:artefact, owning_app: 'smartanswers')
 
       assert artefact.allow_specialist_sector_tag_changes?
     end


### PR DESCRIPTION
At a given time this app was called `smart-answers` but has been renamed
to `smartanswers`.

The aim was to correct the tests to reflect the current reality.

This was done as part of: https://trello.com/c/tZd23gW5/568-allow-tagging-in-content-tagger-for-apps-that-can-t-be-tagged-yet-s
