### PR TITLE
Allow tagging for service-manual-publisher

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -6,7 +6,6 @@ class Artefact
 
   NON_MIGRATED_APPS = %w(
     publisher
-    service-manual-publisher
     specialist-publisher
     whitehall
     non-migrated-app


### PR DESCRIPTION
Service manual publisher has been migrated to the new tagging mechanism.

See https://trello.com/c/FSo3C9Qf/591-allow-tagging-for-service-manual-publisher

Other blacklists:
https://github.com/alphagov/content-tagger/pull/57
https://github.com/alphagov/rummager/pull/621
