### PR TITLE
Remove whitehall organisation tagging

### DIFF
--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -40,14 +40,16 @@
           </div>
         <% end %>
 
-        <div class="organisation-tags fieldset-section">
-          <label for="artefact_organisation_ids" class="section-label">Organisations</label>
+        <% unless f.object.owning_app == "whitehall" %>
+          <div class="organisation-tags fieldset-section">
+            <label for="artefact_organisation_ids" class="section-label">Organisations</label>
 
-          <%= f.input :organisation_ids,
-                      :label => false,
-                      :collection => options_for_tags_of_type('organisation'),
-                      :input_html => { :multiple => true, :class => "chosen-select" } %>
-        </div>
+            <%= f.input :organisation_ids,
+                        :label => false,
+                        :collection => options_for_tags_of_type('organisation'),
+                        :input_html => { :multiple => true, :class => "chosen-select" } %>
+          </div>
+        <% end %>
       <% end %>
     </div>
   <%- end %>


### PR DESCRIPTION
Panopticon currently allows tagging to organisations for Whitehall content.

But whenever the user changes the organisation in Whitehall the new values get sent to panopticon. This means any changes in this application will eventually be overwritten because there's no data flow back.

It's really odd that this app had a feature that would never actually work, but I can't rule it out. 
