### PR TITLE
Update MessageQueueConsumer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ else
   gem 'gds-api-adapters', '25.1.0'
 end
 
-gem 'govuk_message_queue_consumer', '~> 2.1.0'
+gem "govuk_message_queue_consumer", "~> 3.0.1"
 
 gem 'rails', '4.2.5.2'
 gem 'unicorn', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_message_queue_consumer (2.1.0)
+    govuk_message_queue_consumer (3.0.1)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
     hashie (3.4.3)
@@ -443,7 +443,7 @@ DEPENDENCIES
   gelf
   govuk_admin_template (= 3.0.0)
   govuk_content_models!
-  govuk_message_queue_consumer (~> 2.1.0)
+  govuk_message_queue_consumer (~> 3.0.1)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)
   launchy

--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -3,7 +3,6 @@ namespace :message_queue do
   task consumer: :environment do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "panopticon",
-      exchange_name: "published_documents",
       processor: TaggingUpdater.new
     ).run
   end

--- a/test/lib/tasks/message_queue_test.rb
+++ b/test/lib/tasks/message_queue_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class MessageQueueConsumerRakeTest < ActiveSupport::TestCase
+  # minitest doesn't provide this by default
+  def refute_raises(exception)
+    yield
+  rescue Exception => err
+    flunk "Expected no failures but #{mu_pp(err).chomp} was raised."
+  end
+
+  context "when consuming messages from RabbitMQ" do
+    setup do
+      # The consumer needs this values when initialized
+      ENV["RABBITMQ_HOSTS"] = "server-one,server-two"
+      ENV["RABBITMQ_VHOST"] = "/"
+      ENV["RABBITMQ_USER"] = "my_user"
+      ENV["RABBITMQ_PASSWORD"] = "my_pass"
+
+      @consumer = GovukMessageQueueConsumer::Consumer
+    end
+
+    should "use GovukMessageQueueConsumer::Consumer API correctly" do
+      assert_raises(ArgumentError) { @consumer.new }
+      assert_raises(ArgumentError) { @consumer.new(queue_name: "panopticon") }
+      assert_raises(ArgumentError) { @consumer.new(bad_name: "panopticon") }
+
+      refute_raises(ArgumentError) do
+        @consumer.new(
+          queue_name: "panopticon",
+          processor: Object.new,
+        )
+      end
+    end
+
+    should "call GovukMessageQueueConsumer::Consumer" do
+      tagging_updater = mock('TaggingUpdater')
+      TaggingUpdater.expects(:new).returns(tagging_updater)
+
+      @consumer.expects(:run).returns(true)
+
+      GovukMessageQueueConsumer::Consumer.expects(:new)
+        .with(
+          queue_name: "panopticon",
+          processor: tagging_updater,
+        ).returns(@consumer)
+
+      Rake::Task["message_queue:consumer"].invoke
+    end
+  end
+end
+


### PR DESCRIPTION
- Adds test case for message queue consumer rake task

Part of: https://trello.com/c/eP2CdnrC/590-fix-rabbitmq-queue-binding
