### PR TITLE
Switch back to released version of content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ else
 end
 
 gem 'rake', '10.5.0'
+gem 'therubyracer', '0.12.0'
+gem 'sass-rails', '5.0.4'
+gem 'uglifier', '>= 2.7.2'
 
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
@@ -54,11 +57,6 @@ gem 'responders', '~> 2.0'
 
 gem 'whenever', '0.9.2', require: false
 
-group :assets do
-  gem 'therubyracer', '0.12.0'
-  gem 'sass-rails', '5.0.4'
-  gem 'uglifier', '>= 2.7.2'
-end
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'logstasher', '0.4.8'
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', path: '../govuk_content_models'
 else
-  gem 'govuk_content_models', :github => 'alphagov/govuk_content_models', :branch => 'rails-mongoid-upgrade'
+  gem 'govuk_content_models', '35.0.0'
 end
 
 gem 'rake', '10.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/govuk_content_models.git
-  revision: abc8edec36967cc3cd52a6196c2d54afda3d8777
-  branch: rails-mongoid-upgrade
-  specs:
-    govuk_content_models (33.0.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (~> 11.2)
-      govspeak (~> 3.1)
-      mongoid (~> 5.1)
-      plek
-      state_machines (~> 0.4)
-      state_machines-mongoid (~> 0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -67,7 +52,7 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    bson (4.0.4)
+    bson (4.1.0)
     bson_ext (1.5.1)
     builder (3.2.2)
     bunny (2.2.2)
@@ -189,6 +174,15 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    govuk_content_models (35.0.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (~> 11.2)
+      govspeak (~> 3.1)
+      mongoid (~> 5.1)
+      plek
+      state_machines (~> 0.4)
+      state_machines-mongoid (~> 0.1)
     govuk_message_queue_consumer (3.0.1)
       bunny (~> 2.2.0)
     hashdiff (0.3.0)
@@ -245,7 +239,7 @@ GEM
       metaclass (~> 0.0.1)
     mongo (2.2.4)
       bson (~> 4.0)
-    mongoid (5.1.1)
+    mongoid (5.1.2)
       activemodel (~> 4.0)
       mongo (~> 2.1)
       origin (~> 2.2)
@@ -443,7 +437,7 @@ DEPENDENCIES
   gds-sso (~> 11.2.1)
   gelf
   govuk_admin_template (= 3.0.0)
-  govuk_content_models!
+  govuk_content_models (= 35.0.0)
   govuk_message_queue_consumer (~> 3.0.1)
   jquery-ui-rails (= 5.0.0)
   kaminari (= 0.14.1)

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,6 @@ ENV["COVERAGE"] = "true"
 ENV["GOVUK_WEBSITE_ROOT"] = ENV.fetch("GOVUK_WEBSITE_ROOT", "http://www.dev.gov.uk")
 require File.expand_path('../config/application', __FILE__)
 
-Panopticon::Application.load_tasks
+Rails.application.load_tasks
 
 task :default => [:test, :check_for_bad_time_handling]

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run Panopticon::Application
+run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,12 +8,9 @@ require 'kaminari' # has to be loaded before the models, otherwise the methods a
 require "govuk_content_models"
 require "gds_api/publishing_api"
 
-if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  Bundler.require *Rails.groups(:assets => %w(development test))
-  # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
-end
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
 
 module Panopticon
   mattr_accessor :need_api
@@ -33,13 +30,6 @@ module Panopticon
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)
 
-    # Only load the plugins named here, in the order given (default is alphabetical).
-    # :all can be used as a placeholder for all plugins not explicitly named.
-    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
-
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
-
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = 'London'
@@ -50,9 +40,6 @@ module Panopticon
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
-
-    # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
 
     # Disable Rack::Cache.
     config.action_dispatch.rack_cache = nil

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application
-Panopticon::Application.initialize!
+Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-Panopticon::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
   # In the development environment your application's code is reloaded on
@@ -19,13 +19,17 @@ Panopticon::Application.configure do
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log
 
-  # Only use best-standards-support built into browsers
-  config.action_dispatch.best_standards_support = :builtin
-
-  # Do not compress assets
-  config.assets.compress = false
-
-  # Expands the lines which load the assets
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
   config.assets.debug = true
 
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-Panopticon::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
   # Code is not reloaded between requests

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-Panopticon::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
   # The test environment is used exclusively to run your application's
@@ -27,7 +27,7 @@ Panopticon::Application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  config.action_controller.allow_forgery_protection = false
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
@@ -40,5 +40,6 @@ Panopticon::Application.configure do
   # Allow pass debug_assets=true as a query parameter to load pages with unpackaged assets
   config.assets.allow_debugging = true
 
+  # Randomize the order test cases are executed
   config.active_support.test_order = :random
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Configure sensitive parameters which will be filtered from the log file.
+Rails.application.config.filter_parameters += [:password]


### PR DESCRIPTION
The rails-upgrade branch has been merged back to master and released, so switching back to that.

Also bring Rails ancillary files up to date after upgrade.
