### PR TITLE
Fix related external link bug

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -210,7 +210,7 @@ class ArtefactsController < ApplicationController
         "sections" => [],
         "specialist_sectors" => [],
         "related_artefact_slugs" => [],
-        "external_links_attributes" => [:title, :url, :_id, :_destroy],
+        "external_links_attributes" => [:title, :url, :id, :_destroy],
       ] + Artefact.fields.map {|k,v| v.type == Array ? { k => [] } : k }
 
       parameters_to_use = params[:artefact]


### PR DESCRIPTION
When updating an artefact related external links were being 're-saved' with each update effectively doubling them each time. Destroying them was also broken. This PR fixes the bug and adds some tests.

[Zendesk Ticket](https://govuk.zendesk.com/agent/tickets/1316142)
