### PR TITLE
Do not allow organisation tagging for specialist-content

### DIFF
--- a/app/views/artefacts/form/_tags.html.erb
+++ b/app/views/artefacts/form/_tags.html.erb
@@ -40,7 +40,7 @@
           </div>
         <% end %>
 
-        <% unless f.object.owning_app == "whitehall" %>
+        <% unless f.object.owning_app.in?(["whitehall", "specialist-publisher"])  %>
           <div class="organisation-tags fieldset-section">
             <label for="artefact_organisation_ids" class="section-label">Organisations</label>
 


### PR DESCRIPTION
It is currently possible to add organisation tags to specialist-publisher owned content. This is a mistake, because specialist-publisher also sends organisations.

If you would tag a document to an organisation here, it would eventually end up in rummager (because rummager reads tags from the content-api). For clarity, organisations should only be set by specialist-publisher.

We will do a follow up to fix any inconsistencies.

Trello: https://trello.com/c/YoeWtswr
