### PR TITLE
Disable tagging for Specialist Publisher

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -6,7 +6,6 @@ class Artefact
 
   NON_MIGRATED_APPS = %w(
     publisher
-    specialist-publisher
     whitehall
     non-migrated-app
   ).freeze

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -11,11 +11,11 @@ Given /^the first artefact is live$/ do
 end
 
 Given /^an artefact from a non migrated app exists$/ do
-  @artefact = create_artefact("specialist-publisher")
+  @artefact = create_artefact("non-migrated-app")
 end
 
 Given /^two artefacts from a non migrated app exist$/ do
-  @artefact, @related_artefact = create_two_artefacts("specialist-publisher")
+  @artefact, @related_artefact = create_two_artefacts("non-migrated-app")
 end
 
 When /^I change the need ID of the first artefact$/ do

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -14,7 +14,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
 
       @artefact = FactoryGirl.create(:artefact,
                                      name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
-                                     owning_app: "specialist-publisher", language: "en",
+                                     owning_app: "non-migrated-app", language: "en",
                                      section_ids: ["business/employing-people"])
     end
 
@@ -34,7 +34,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       end
 
       within ".owning-app" do
-        assert page.has_content? "This content is managed in Specialist-publisher"
+        assert page.has_content? "This content is managed in Non-migrated-app"
       end
 
       within ".section-tags" do


### PR DESCRIPTION
Part of: https://trello.com/c/YoeWtswr/609-totally-migrate-specialist-publisher-v1-tagging
