### PR TITLE
Remove worldwide priorities from the database

### DIFF
--- a/db/migrate/20160503103455_remove_worldwide_priorities.rb
+++ b/db/migrate/20160503103455_remove_worldwide_priorities.rb
@@ -1,0 +1,10 @@
+class RemoveWorldwidePriorities < Mongoid::Migration
+  def self.up
+    Artefact.where(:kind => 'worldwide_priority').each do |artefact|
+      artefact.destroy
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
The worldwide priority format is being deleted, therefore its artefacts must be removed from the DB.

Here's the PR that deletes worldwide priorities from Whitehall:
https://github.com/alphagov/whitehall/pull/2246

[Trello](https://trello.com/c/AtYGioxe/321-worldwide-priorities-deleting-the-format-medium)
