### PR TITLE
Parse 'sections' param correctly to fix tagging of mainstream browse pages

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -6,7 +6,7 @@ class ArtefactsController < ApplicationController
   before_filter :register_url_with_publishing_api, :only => [:create, :update]
   before_filter :tag_collection, :except => [:show]
   helper_method :sort_column, :sort_direction
-  wrap_parameters include: Artefact.attribute_names + [:specialist_sectors, :primary_section]
+  wrap_parameters include: Artefact.attribute_names + [:specialist_sectors, :sections, :primary_section]
 
   respond_to :html, :json
 

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -218,6 +218,30 @@ class ArtefactsAPITest < ActiveSupport::TestCase
         assert_equal 'draft', @artefact.state
       end
 
+      should "update the artefact with mainstream browse pages" do
+
+        FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
+        FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
+
+        artefact_data = {
+            'slug' => 'wibble',
+            'name' => 'Wibble 2 - the return',
+            'kind' => 'answer',
+            'description' => 'Wibble description',
+            'owning_app' => 'publisher',
+            'rendering_app' => 'frontend',
+            'state' => 'draft',
+            'sections' => ['business/employing-people'],
+        }
+
+        put "/artefacts/wibble.json", artefact_data.to_json
+
+        assert_equal 200, last_response.status
+
+        @artefact.reload
+        assert_equal ['business/employing-people'], @artefact.tags.map(&:tag_id)
+      end
+
       should "add content_id to an artefact that does not have one" do
         artefact_data = { 'content_id' => '105e2299-dcfe-4301-b8e0-56959ce95ec0' }
 


### PR DESCRIPTION
When param handling was converted to use strong parameters there were
a number of oversights. This one broke mainstream browse page tagging
from mainstream publisher.

It's not clear whether the strong parameters feature is at fault -
introducing it seems to have caused several bugs, but testing in this area was
rather patchy.

@benhyland and @tijmenb
