### PR TITLE
Fix bug in sending content to rummager

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -6,7 +6,7 @@ class ArtefactsController < ApplicationController
   before_filter :register_url_with_publishing_api, :only => [:create, :update]
   before_filter :tag_collection, :except => [:show]
   helper_method :sort_column, :sort_direction
-  wrap_parameters include: Artefact.attribute_names + [:specialist_sectors, :sections, :primary_section]
+  wrap_parameters include: Artefact.attribute_names + [:specialist_sectors, :indexable_content, :sections, :primary_section]
 
   respond_to :html, :json
 


### PR DESCRIPTION
This is a hotfix for a bug that appears in panopticon when it gets called from panopticon.

Panopticon is sending a `indexable_content` parameter, which propagates through the controller to something that decides whether to send the document to rummager as a update or create:

https://github.com/alphagov/panopticon/blame/adc087a30a2e4f5013b32c0cb3f2569a9d7b3696/app/models/rummageable_artefact.rb#L56

Because `indexable_content` is not wrapped, it will be nil and triggers the `should_amend` code path. This will fail in rummager because the document doesn’t exist.

A follow up to this will fix the root causes of this problem.
