### PR TITLE
Refactor and cleanup: extract some methods into classes

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -24,9 +24,7 @@ class ArtefactsController < ApplicationController
   end
 
   def search_relatable_items
-    artefacts = Artefact.relatable_items_like(params[:title_substring]).page(params[:page]).per(15)
-    artefacts_map = { artefacts: artefacts.map {|a| { id: a.slug, text: a.name_with_owner_prefix } } }
-    respond_with artefacts_map.merge(total: artefacts.total_count).to_json
+    respond_with RelatableItems.new(params).relatable_items.to_json
   end
 
   def show

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -175,39 +175,7 @@ class ArtefactsController < ApplicationController
     end
 
     def extract_parameters(params)
-      fields_to_update = [
-        "primary_section",
-        "indexable_content",
-        "sections" => [],
-        "specialist_sectors" => [],
-        "related_artefact_slugs" => [],
-        "external_links_attributes" => [:title, :url, :id, :_destroy],
-      ] + Artefact.fields.map {|k,v| v.type == Array ? { k => [] } : k }
-
-      parameters_to_use = params[:artefact]
-
-      # Partly for legacy reasons, the API can receive live=true
-      if live_param = parameters_to_use[:live]
-        if ["true", true, "1"].include?(live_param)
-          parameters_to_use[:state] = "live"
-        end
-      end
-
-      # Convert nil tag fields to empty arrays if they're present
-      Artefact.tag_types.each do |tag_type|
-        if parameters_to_use.has_key?(tag_type)
-          parameters_to_use[tag_type] ||= []
-        end
-        fields_to_update << { tag_type => [] }
-      end
-
-      # Strip out the empty submit option for sections
-      ['sections', 'specialist_sector_ids', 'organisation_ids'].each do |param|
-        param_value = parameters_to_use[param]
-        param_value.reject!(&:blank?) if param_value
-        fields_to_update << { param => [] }
-      end
-      parameters_to_use.permit(fields_to_update)
+      ParameterExtractor.new(params).extract
     end
 
     def build_actions
@@ -260,5 +228,4 @@ class ArtefactsController < ApplicationController
 
       render text: message, status: 409
     end
-
 end

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -61,11 +61,13 @@ class ArtefactsController < ApplicationController
 
     @artefact.save_as current_user
     continue_editing = (params[:commit] == 'Save and continue editing')
+
     if continue_editing || @artefact.owning_app != "publisher"
       location = edit_artefact_path(@artefact.id)
     else
       location = admin_url_for_edition(@artefact, params.slice(:return_to))
     end
+
     respond_with @artefact, location: location
   end
 
@@ -85,9 +87,11 @@ class ArtefactsController < ApplicationController
     end
 
     @actions = build_actions
+
     respond_with @artefact, status: status_to_use do |format|
       format.html do
         continue_editing = (params[:commit] == 'Save and continue editing')
+
         if saved && (continue_editing || (@artefact.owning_app != "publisher"))
           redirect_to edit_artefact_path(@artefact)
         else
@@ -95,11 +99,12 @@ class ArtefactsController < ApplicationController
           respond_with @artefact, status: status_to_use
         end
       end
+
       format.json do
         if saved
           render json: @artefact.to_json, status: status_to_use
         else
-          render json: {"errors" => @artefact.errors.full_messages}, status: 422
+          render json: { "errors" => @artefact.errors.full_messages }, status: 422
         end
       end
     end
@@ -109,6 +114,7 @@ class ArtefactsController < ApplicationController
     @artefact = Artefact.from_param(params[:id])
     redirect_url = params[:artefact] && params[:artefact][:redirect_url]
     redirect_url.sub!(%r{^https?://(www\.)?gov\.uk/}, "/") if redirect_url
+
     if @artefact.update_attributes_as(
       current_user,
       state: "archived",

--- a/app/services/filtered_scope.rb
+++ b/app/services/filtered_scope.rb
@@ -1,0 +1,42 @@
+class FilteredScope
+  def initialize(initial_scope, filters)
+    @initial_scope = initial_scope
+    @filters = filters
+  end
+
+  def scope
+    scope = initial_scope
+
+    [:section, :specialist_sector].each do |tag_type|
+      if filters[tag_type].present?
+        scope = scope.with_parent_tag(tag_type, filters[tag_type])
+      end
+    end
+
+    if filters[:state].present? && Artefact::STATES.include?(filters[:state])
+      scope = scope.in_state(filters[:state])
+    end
+
+    if filters[:kind].present? && Artefact::FORMATS.include?(filters[:kind])
+      scope = scope.of_kind(filters[:kind])
+    end
+
+    if filters[:search].present?
+      scope = scope.matching_query(filters[:search])
+    end
+
+    if filters[:owned_by].present?
+      scope = scope.owned_by(filters[:owned_by])
+    else
+      # Exclude all panopticon-owned artefacts from the index
+      # because they have their own specialised interfaces.
+      scope = scope.not_owned_by('panopticon')
+    end
+
+    scope
+  end
+
+private
+
+  attr_reader :initial_scope, :filters
+end

--- a/app/services/parameter_extractor.rb
+++ b/app/services/parameter_extractor.rb
@@ -1,0 +1,44 @@
+class ParameterExtractor
+  def initialize(params)
+    @params = params
+  end
+
+  def extract
+    params = @params
+
+    fields_to_update = [
+      "primary_section",
+      "indexable_content",
+      "sections" => [],
+      "specialist_sectors" => [],
+      "related_artefact_slugs" => [],
+      "external_links_attributes" => [:title, :url, :id, :_destroy],
+    ] + Artefact.fields.map {|k,v| v.type == Array ? { k => [] } : k }
+
+    parameters_to_use = params[:artefact]
+
+    # Partly for legacy reasons, the API can receive live=true
+    if live_param = parameters_to_use[:live]
+      if ["true", true, "1"].include?(live_param)
+        parameters_to_use[:state] = "live"
+      end
+    end
+
+    # Convert nil tag fields to empty arrays if they're present
+    Artefact.tag_types.each do |tag_type|
+      if parameters_to_use.has_key?(tag_type)
+        parameters_to_use[tag_type] ||= []
+      end
+      fields_to_update << { tag_type => [] }
+    end
+
+    # Strip out the empty submit option for sections
+    ['sections', 'specialist_sector_ids', 'organisation_ids'].each do |param|
+      param_value = parameters_to_use[param]
+      param_value.reject!(&:blank?) if param_value
+      fields_to_update << { param => [] }
+    end
+
+    parameters_to_use.permit(fields_to_update)
+  end
+end

--- a/app/services/relatable_items.rb
+++ b/app/services/relatable_items.rb
@@ -1,0 +1,15 @@
+class RelatableItems
+  def initialize(params)
+    @params = params
+  end
+
+  def relatable_items
+    artefacts = Artefact.relatable_items_like(params[:title_substring]).page(params[:page]).per(15)
+    artefacts_map = { artefacts: artefacts.map {|a| { id: a.slug, text: a.name_with_owner_prefix } } }
+    artefacts_map.merge(total: artefacts.total_count)
+  end
+
+private
+
+  attr_reader :params
+end


### PR DESCRIPTION
After the Rails 4 upgrade (https://github.com/alphagov/panopticon/pull/341) there have been a number of bugs that are related to the poor readability/quality of the codebase:
- https://github.com/alphagov/panopticon/pull/363
- https://github.com/alphagov/panopticon/pull/361
- https://github.com/alphagov/panopticon/pull/356
- https://github.com/alphagov/panopticon/pull/352

This PR is the first in a series to improve the code a little. The goals are to prevent immediate bugs, to improve readability and make debugging easier, and to feel more confident about removing parts of panopticon.

Best reviewed per-commit.

https://trello.com/c/9my1VG7z/625-clean-up-panopticon-to-fix-bugs-and-aid-migration
