### PR TITLE
Remove ansi and gelf gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,6 @@ gem 'plek', '~> 1.8'
 
 gem 'nested_form', '0.3.2'
 
-gem 'ansi'
-gem 'gelf'
-
 gem 'airbrake', '3.1.15'
 gem 'statsd-ruby', '~> 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,8 +159,6 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    gelf (2.0.0)
-      json
     gherkin (3.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -420,7 +418,6 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 3.1.15)
-  ansi
   bootstrap-kaminari-views (= 0.0.3)
   capybara (~> 2.1.0)
   capybara-mechanize (~> 1.1.0)
@@ -435,7 +432,6 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 25.1.0)
   gds-sso (~> 11.2.1)
-  gelf
   govuk_admin_template (= 3.0.0)
   govuk_content_models (= 35.0.0)
   govuk_message_queue_consumer (~> 3.0.1)


### PR DESCRIPTION
Added here https://github.com/alphagov/panopticon/commit/d7808eee6ec2ade95e0ed9ada58f338f14edac27 and here https://github.com/alphagov/panopticon/commit/75652cf09c1cb5813c3cd006ed8a898b22b211e1.
Both of them are not used anymore."
