### PR TITLE
Refactor the `ParameterExtractor`

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -1,12 +1,11 @@
 class ArtefactsController < ApplicationController
   before_filter :find_artefact, :only => [:show, :edit, :history, :withdraw]
-  before_filter :convert_comma_separated_string_to_array_attribute, :only => [:create, :update], :if => -> { request.format.html? }
   before_filter :build_artefact, :only => [:create]
   before_filter :find_or_build_artefact, :only => [:update]
   before_filter :register_url_with_publishing_api, :only => [:create, :update]
   before_filter :tag_collection, :except => [:show]
   helper_method :sort_column, :sort_direction
-  wrap_parameters include: Artefact.attribute_names + [:specialist_sectors, :indexable_content, :sections, :primary_section]
+  wrap_parameters include: ParameterExtractor::ALLOWED_FIELD_NAMES
 
   respond_to :html, :json
 
@@ -199,15 +198,6 @@ class ArtefactsController < ApplicationController
 
     def sort_direction
       %w[asc desc].include?(params[:direction]) ? params[:direction] : :asc
-    end
-
-    def convert_comma_separated_string_to_array_attribute
-      return if (artefact_params = params[:artefact]).blank?
-
-      [:need_ids, :related_artefact_slugs].each do |attribute|
-        next if artefact_params[attribute].nil?
-        artefact_params[attribute] = artefact_params[attribute].split(",").map(&:strip).reject(&:blank?)
-      end
     end
 
     def register_url_with_publishing_api

--- a/test/unit/parameter_extractor_test.rb
+++ b/test/unit/parameter_extractor_test.rb
@@ -1,0 +1,127 @@
+require 'test_helper'
+
+class ParameterExtractorTest < ActiveSupport::TestCase
+  test 'a create with params from the UI' do
+    params = ActionController::Parameters.new(
+      "utf8" => "✓",
+      "authenticity_token" => "some-token",
+      "artefact" => {
+        "kind" => "answer",
+        "language" => "en",
+        "live" => "1",
+        "name" => "This is a test",
+        "need_extended_font" => "0",
+        "need_ids" => "123123,321321",
+        "organisation_ids" => ["", "accelerated-access-review"],
+        "owning_app" => "publisher",
+        "related_artefact_slugs" => "",
+        "sections" => ["visas-immigration/arriving-in-the-uk", "working/armed-forces"],
+        "slug" => "my-super-test",
+        "specialist_sector_ids" => ["", "animal-welfare/pets"],
+      },
+      "commit" => "Save and continue editing" )
+
+    result = ParameterExtractor.new(params).extract
+
+    expected = {
+      "kind" => "answer",
+      "language" => "en",
+      "name" => "This is a test",
+      "need_extended_font" => "0",
+      "need_ids" => ["123123", "321321"],
+      "organisation_ids" => ["accelerated-access-review"],
+      "owning_app" => "publisher",
+      "related_artefact_slugs" => [],
+      "sections" => ["visas-immigration/arriving-in-the-uk", "working/armed-forces"],
+      "slug" => "my-super-test",
+      "specialist_sector_ids" => ["animal-welfare/pets"],
+      "state" => "live",
+    }
+    assert_equal expected, result
+  end
+
+  test 'an update with params from the UI' do
+    params = ActionController::Parameters.new({
+      "utf8" => "✓",
+      "authenticity_token" => "some-token",
+      "artefact" => {
+        "slug" => "my-super-test",
+        "related_artefact_slugs" => "",
+        "organisation_ids" => ["", "accelerated-access-review"],
+        "need_ids" => "121231,123123",
+        "language" => "en",
+        "need_extended_font" => "0"
+      },
+      "commit" => "Save and continue editing",
+      "id" => "572c9c95759b746c23203cef"
+    })
+
+    result = ParameterExtractor.new(params).extract
+
+    expected = {
+      "related_artefact_slugs" => [],
+      "slug" => "my-super-test",
+      "need_ids" => ["121231", "123123"],
+      "language" => "en",
+      "need_extended_font" => "0",
+      "organisation_ids"=>["accelerated-access-review"]
+    }
+    assert_equal expected, result
+  end
+
+  test 'where the params are already arrays' do
+    params = ActionController::Parameters.new({
+      "artefact" => {
+        "need_ids" => ["121231", "123123"],
+      },
+    })
+
+    result = ParameterExtractor.new(params).extract
+
+    expected = {
+      "need_ids" => ["121231", "123123"],
+    }
+    assert_equal expected, result
+  end
+
+  test 'update with params from the API' do
+    params = ActionController::Parameters.new({
+     "artefact" => {
+       "description" =>  "Foo bar.",
+       "indexable_content" => "Foo",
+       "kind" => "guide",
+       "latest_change_note" => nil,
+       "name" => "Get a copy of military service records",
+       "owning_app" => "publisher",
+       "paths" => ["/get-copy-military-service-records.json"],
+       "prefixes" => ["/get-copy-military-service-records"],
+       "public_timestamp" => "2015-09-24T11:14:16.000+01:00",
+       "rendering_app" => "frontend",
+       "sections" => ["births-deaths-marriages/register-offices", "working/armed-forces"],
+       "slug" => "get-copy-military-service-records",
+       "specialist_sectors" => nil,
+       "state" => "live",
+      }
+    })
+
+    result = ParameterExtractor.new(params).extract
+
+    expected = {
+      "description" => "Foo bar.",
+      "indexable_content" => "Foo",
+      "kind" => "guide",
+      "latest_change_note" => nil,
+      "name" => "Get a copy of military service records",
+      "owning_app" => "publisher",
+      "paths" => ["/get-copy-military-service-records.json"],
+      "prefixes" => ["/get-copy-military-service-records"],
+      "public_timestamp" => "2015-09-24T11:14:16.000+01:00",
+      "rendering_app" => "frontend",
+      "sections" => ["births-deaths-marriages/register-offices", "working/armed-forces"],
+      "slug" => "get-copy-military-service-records",
+      "specialist_sectors" => [],
+      "state" => "live",
+    }
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
This commit refactors the “parameter extraction”.
- Instead of a dynamically generated list of allowed parameters we use a static array. This makes it a lot easier to read and makes all the attributes that we allow very explicit.
- Use this list of parameters as the input for the wrap_parameters. This prevents this list to get out of sync.
- Refactor the preparation of the parameters so that it is easier to read.

https://trello.com/c/9my1VG7z/625-clean-up-panopticon-to-fix-bugs-and-aid-migration
