### PR TITLE
Add rake task to migrate mainstream browse page taggings to publishing API

### DIFF
--- a/lib/mainstream_browse_migrator.rb
+++ b/lib/mainstream_browse_migrator.rb
@@ -1,0 +1,46 @@
+# MainstreamBrowseMigrator
+#
+# We are migrating the taggings from panopticon/content-api to publishing-api.
+# This class takes the mainstream browse taggings for a certain app and sends
+# it to the publishing-api so that it contains the current taggings. This
+# functionality will be removed after the migration.
+
+require 'gds_api/publishing_api_v2'
+
+class MainstreamBrowseMigrator
+  def initialize(app_name)
+    @app_name = app_name
+  end
+
+  def migrate!
+    artefacts_owned_by_app.each do |artefact|
+      next unless artefact.content_id
+      migrate_tags_for_artefact(artefact)
+    end
+  end
+
+private
+
+  def migrate_tags_for_artefact(artefact)
+    link_payload = { mainstream_browse_pages: [] }
+
+    artefact.tags.each do |tag|
+      if tag.tag_type == 'section'
+        link_payload[:mainstream_browse_pages] << tag.content_id
+      end
+    end
+
+    publishing_api.put_links( artefact.content_id, links: link_payload )
+  end
+
+  def artefacts_owned_by_app
+    Artefact.where(owning_app: @app_name)
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+  end
+end

--- a/lib/tasks/migrate_taggings.rake
+++ b/lib/tasks/migrate_taggings.rake
@@ -1,4 +1,11 @@
-desc "Migrate taggings for an app (rake migrate_taggings OWNING_APP=smartanswers)"
-task migrate_taggings: [:environment] do
-  TaggingMigrator.new(ENV.fetch('OWNING_APP')).migrate!
+namespace :taggings do
+  desc "Migrate taggings for an app (rake taggings:migrate_all OWNING_APP=smartanswers)"
+  task migrate_all: [:environment] do
+    TaggingMigrator.new(ENV.fetch('OWNING_APP')).migrate!
+  end
+
+  desc "Migrate mainstream browse taggings only (rake taggings:migrate_browse OWNING_APP=smartanswers)"
+  task migrate_browse: [:environment] do
+    MainstreamBrowseMigrator.new(ENV.fetch('OWNING_APP')).migrate!
+  end
 end

--- a/test/unit/mainstream_browse_migrator_test.rb
+++ b/test/unit/mainstream_browse_migrator_test.rb
@@ -1,0 +1,41 @@
+require_relative "../test_helper"
+
+class MainstreamBrowseMigratorTest < ActiveSupport::TestCase
+  test "sends section taggings as mainstream browse tags to the publishing-api" do
+    create(:live_tag, tag_id: "a-topic", tag_type: "specialist_sector", content_id: "A-TOPIC")
+    create(:live_tag, tag_id: "a-browse-page", tag_type: "section", content_id: "A-BROWSE-PAGE")
+    create(:live_tag, tag_id: "an-organisation", tag_type: "organisation", content_id: "AN-ORGANISATION")
+
+    create(:artefact,
+      content_id: "A",
+      slug: "item-a",
+      owning_app: "smartanswers",
+      sections: ["a-browse-page"],
+      specialist_sectors: ["a-topic"],
+    )
+    create(:artefact,
+      content_id: "B",
+      slug: "item-b",
+      owning_app: "smartanswers",
+      sections: ["a-browse-page"],
+      organisations: ["an-organisation"],
+    )
+    create(:artefact,
+      content_id: "C",
+      slug: "item-c",
+      owning_app: "smartanswers",
+    )
+
+    stub_request(:put, %r[#{Plek.find('publishing-api')}/v2/links/*]).
+      to_return(body: {}.to_json)
+
+    MainstreamBrowseMigrator.new("smartanswers").migrate!
+
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"]}}'
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/B",
+      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"]}}'
+    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/C",
+      body: '{"links":{"mainstream_browse_pages":[]}}'
+  end
+end


### PR DESCRIPTION
This adds a mainstream browse specific version of the existing
TaggingMigrator. There are cases where this is the only tagging field we
want to migrate so as not to overwrite values in the publishing API.

trello: https://trello.com/c/D7qargmC
