### PR TITLE
Set `bulk_publishing` for migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,7 @@ gem 'nested_form', '0.3.2'
 gem 'airbrake', '3.1.15'
 gem 'statsd-ruby', '~> 1.3.0'
 
-if ENV['API_DEV']
-  gem 'gds-api-adapters', :path => '../gds-api-adapters'
-else
-  gem 'gds-api-adapters', '25.1.0'
-end
-
+gem 'gds-api-adapters', '~> 30.7'
 gem 'govuk_message_queue_consumer', '~> 3.0.1'
 
 gem 'rails', '4.2.5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,11 +142,11 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (25.1.0)
+    gds-api-adapters (30.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (11.2.1)
@@ -222,7 +222,7 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     minitest-reporters (1.1.8)
@@ -425,7 +425,7 @@ DEPENDENCIES
   factory_girl_rails (= 3.3.0)
   formtastic (= 2.3.0.rc4)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 25.1.0)
+  gds-api-adapters (~> 30.7)
   gds-sso (~> 11.2.1)
   govuk_admin_template (= 3.0.0)
   govuk_content_models (= 35.0.0)

--- a/lib/tagging_migrator.rb
+++ b/lib/tagging_migrator.rb
@@ -41,7 +41,7 @@ private
 
   def migrate_tags_for_artefact(artefact)
     puts link_payload(artefact)
-    publishing_api.put_links(
+    publishing_api.patch_links(
       artefact.content_id,
       links: link_payload(artefact)
     )

--- a/lib/tagging_migrator.rb
+++ b/lib/tagging_migrator.rb
@@ -43,7 +43,8 @@ private
     puts link_payload(artefact)
     publishing_api.patch_links(
       artefact.content_id,
-      links: link_payload(artefact)
+      links: link_payload(artefact),
+      bulk_publishing: true
     )
   end
 

--- a/test/unit/tagging_migrator_test.rb
+++ b/test/unit/tagging_migrator_test.rb
@@ -38,9 +38,9 @@ class TaggingMigratorTest < ActiveSupport::TestCase
 
     TaggingMigrator.new("smartanswers").migrate!
 
-    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: ['A-TOPIC'], organisations: [], parent: ['A-BROWSE-PAGE']})
-    assert_publishing_api_patch_links('B', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: ['AN-ORGANISATION'], parent: ['A-BROWSE-PAGE']})
-    assert_publishing_api_patch_links('C', links: { mainstream_browse_pages: [], topics: [], organisations: []})
+    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: ['A-TOPIC'], organisations: [], parent: ['A-BROWSE-PAGE']}, bulk_publishing: true)
+    assert_publishing_api_patch_links('B', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: ['AN-ORGANISATION'], parent: ['A-BROWSE-PAGE']}, bulk_publishing: true)
+    assert_publishing_api_patch_links('C', links: { mainstream_browse_pages: [], topics: [], organisations: []}, bulk_publishing: true)
   end
 
   test "only sends requested link types to the publishing-api if specified" do
@@ -77,9 +77,9 @@ class TaggingMigratorTest < ActiveSupport::TestCase
 
     TaggingMigrator.new("smartanswers", link_types: [:topics, :organisations]).migrate!
 
-    assert_publishing_api_patch_links('A', links: { topics: ['A-TOPIC'], organisations: []})
-    assert_publishing_api_patch_links('B', links: { topics: [], organisations: ['AN-ORGANISATION']})
-    assert_publishing_api_patch_links('C', links: { topics: [], organisations: []})
+    assert_publishing_api_patch_links('A', links: { topics: ['A-TOPIC'], organisations: []}, bulk_publishing: true)
+    assert_publishing_api_patch_links('B', links: { topics: [], organisations: ['AN-ORGANISATION']}, bulk_publishing: true)
+    assert_publishing_api_patch_links('C', links: { topics: [], organisations: []}, bulk_publishing: true)
   end
 
   test "skips sending the parent tag for travel advice publisher" do
@@ -96,6 +96,6 @@ class TaggingMigratorTest < ActiveSupport::TestCase
 
     TaggingMigrator.new("travel-advice-publisher").migrate!
 
-    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: []})
+    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: []}, bulk_publishing: true)
   end
 end

--- a/test/unit/tagging_migrator_test.rb
+++ b/test/unit/tagging_migrator_test.rb
@@ -1,6 +1,9 @@
 require_relative "../test_helper"
+require "gds_api/test_helpers/publishing_api_v2"
 
 class TaggingMigratorTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::PublishingApiV2
+
   test "sends current migrations to publishing-api" do
     create(:live_tag, tag_id: "a-topic", tag_type: "specialist_sector", content_id: "A-TOPIC")
     create(:live_tag, tag_id: "a-browse-page", tag_type: "section", content_id: "A-BROWSE-PAGE")
@@ -31,17 +34,13 @@ class TaggingMigratorTest < ActiveSupport::TestCase
       owning_app: "whitehall",
     )
 
-    stub_request(:patch, %r[#{Plek.find('publishing-api')}/v2/links/*]).
-      to_return(body: {}.to_json)
+    stub_any_publishing_api_patch_links
 
     TaggingMigrator.new("smartanswers").migrate!
 
-    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/A",
-      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":["A-TOPIC"],"organisations":[],"parent":["A-BROWSE-PAGE"]}}'
-    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/B",
-      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":["AN-ORGANISATION"],"parent":["A-BROWSE-PAGE"]}}'
-    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/C",
-      body: '{"links":{"mainstream_browse_pages":[],"topics":[],"organisations":[]}}'
+    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: ['A-TOPIC'], organisations: [], parent: ['A-BROWSE-PAGE']})
+    assert_publishing_api_patch_links('B', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: ['AN-ORGANISATION'], parent: ['A-BROWSE-PAGE']})
+    assert_publishing_api_patch_links('C', links: { mainstream_browse_pages: [], topics: [], organisations: []})
   end
 
   test "only sends requested link types to the publishing-api if specified" do
@@ -74,17 +73,13 @@ class TaggingMigratorTest < ActiveSupport::TestCase
       owning_app: "whitehall",
     )
 
-    stub_request(:put, %r[#{Plek.find('publishing-api')}/v2/links/*]).
-      to_return(body: {}.to_json)
+    stub_any_publishing_api_patch_links
 
     TaggingMigrator.new("smartanswers", link_types: [:topics, :organisations]).migrate!
 
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
-      body: '{"links":{"topics":["A-TOPIC"],"organisations":[]}}'
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/B",
-      body: '{"links":{"topics":[],"organisations":["AN-ORGANISATION"]}}'
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/C",
-      body: '{"links":{"topics":[],"organisations":[]}}'
+    assert_publishing_api_patch_links('A', links: { topics: ['A-TOPIC'], organisations: []})
+    assert_publishing_api_patch_links('B', links: { topics: [], organisations: ['AN-ORGANISATION']})
+    assert_publishing_api_patch_links('C', links: { topics: [], organisations: []})
   end
 
   test "skips sending the parent tag for travel advice publisher" do
@@ -97,12 +92,10 @@ class TaggingMigratorTest < ActiveSupport::TestCase
       sections: ["a-browse-page"],
     )
 
-    stub_request(:patch, %r[#{Plek.find('publishing-api')}/v2/links/*]).
-      to_return(body: {}.to_json)
+    stub_any_publishing_api_patch_links
 
     TaggingMigrator.new("travel-advice-publisher").migrate!
 
-    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/A",
-      body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":[]}}'
+    assert_publishing_api_patch_links('A', links: { mainstream_browse_pages: ['A-BROWSE-PAGE'], topics: [], organisations: []})
   end
 end

--- a/test/unit/tagging_migrator_test.rb
+++ b/test/unit/tagging_migrator_test.rb
@@ -31,16 +31,16 @@ class TaggingMigratorTest < ActiveSupport::TestCase
       owning_app: "whitehall",
     )
 
-    stub_request(:put, %r[#{Plek.find('publishing-api')}/v2/links/*]).
+    stub_request(:patch, %r[#{Plek.find('publishing-api')}/v2/links/*]).
       to_return(body: {}.to_json)
 
     TaggingMigrator.new("smartanswers").migrate!
 
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
+    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/A",
       body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":["A-TOPIC"],"organisations":[],"parent":["A-BROWSE-PAGE"]}}'
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/B",
+    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/B",
       body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":["AN-ORGANISATION"],"parent":["A-BROWSE-PAGE"]}}'
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/C",
+    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/C",
       body: '{"links":{"mainstream_browse_pages":[],"topics":[],"organisations":[]}}'
   end
 
@@ -97,12 +97,12 @@ class TaggingMigratorTest < ActiveSupport::TestCase
       sections: ["a-browse-page"],
     )
 
-    stub_request(:put, %r[#{Plek.find('publishing-api')}/v2/links/*]).
+    stub_request(:patch, %r[#{Plek.find('publishing-api')}/v2/links/*]).
       to_return(body: {}.to_json)
 
     TaggingMigrator.new("travel-advice-publisher").migrate!
 
-    assert_requested :put, "http://publishing-api.dev.gov.uk/v2/links/A",
+    assert_requested :patch, "http://publishing-api.dev.gov.uk/v2/links/A",
       body: '{"links":{"mainstream_browse_pages":["A-BROWSE-PAGE"],"topics":[],"organisations":[]}}'
   end
 end


### PR DESCRIPTION
This will cause the publishing-api to deprioritise these requests, so that human-initiated publishings will not be delayed by bulk republishing (alphagov/publishing-api#329).

Also updates the tests to be more robust and easily changeable.
