### PR TITLE
Index campaigns

### DIFF
--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -1,6 +1,6 @@
 class RummageableArtefact
 
-  FORMATS_NOT_TO_INDEX = %W(business_support completed_transaction campaign) +
+  FORMATS_NOT_TO_INDEX = %W(business_support completed_transaction) +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["whitehall"] +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["specialist-publisher"] +
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"]

--- a/app/models/rummageable_artefact.rb
+++ b/app/models/rummageable_artefact.rb
@@ -6,22 +6,9 @@ class RummageableArtefact
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["finder-api"]
 
   EXCEPTIONAL_SLUGS = %W(
-    gosuperfast
-    growthaccelerator
-    technology-strategy-board
-    enterprise-finance-guarantee
-    manufacturing-advisory-service-mas
-    research-development-tax-credit-smes
-    enterprise-investment-scheme
-    seed-enterprise-investment-scheme
-    designing-demand
-    business-mentoring-support
     start-up-loans
     new-enterprise-allowance
-    helping-your-business-grow-internationally
-    unimoney
     horizon-2020
-    civil-service-apprenticeships
   )
 
   def initialize(artefact)


### PR DESCRIPTION
ticket: https://trello.com/c/fAF7mZ2H/667-stop-excluding-campaigns-from-the-search-index

Campaigns are excluded from site search by default, but often do need to be found so we have to remove from the blacklist. 

I've also removed some non-needed exceptional slugs.

A truly exceptional slug:
![b3048336b3960d417fd85c49467be4c0](https://cloud.githubusercontent.com/assets/5038475/15829192/899bb11a-2c0a-11e6-8448-5b15eeba4ac0.jpg)
