### PR TITLE
Allow tags to be cleared by tagging updater

### DIFF
--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -34,9 +34,11 @@ private
 
   def update_artefact_with_content_item(content_item, artefact)
     TAG_MAPPING.each do |publishing_api_tag_name, panopticon_tag_name|
-      next unless content_item['links'][publishing_api_tag_name]
-
-      new_tags = Tag.where(:content_id.in => content_item['links'][publishing_api_tag_name])
+      if content_item['links'][publishing_api_tag_name]
+        new_tags = Tag.where(:content_id.in => content_item['links'][publishing_api_tag_name])
+      else
+        new_tags = []
+      end
 
       artefact.set_tags_of_type(panopticon_tag_name, new_tags.map(&:tag_id))
     end

--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -45,8 +45,11 @@ private
 
     unless content_item.fetch('publishing_app') == 'travel-advice-publisher'
       if content_item['links']['parent']
-        parent = Tag.where(:content_id.in => content_item['links']['parent'])
-        artefact.set_primary_tag_of_type('section', parent.first.tag_id)
+        parent = Tag.where(:content_id.in => content_item['links']['parent']).first
+
+        if parent.tag_type == 'section'
+          artefact.set_primary_tag_of_type('section', parent.tag_id)
+        end
       end
     end
 

--- a/test/unit/queue_consumers/tagging_updater_test.rb
+++ b/test/unit/queue_consumers/tagging_updater_test.rb
@@ -26,6 +26,26 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
     assert message.acked?
   end
 
+  def test_links_are_cleared
+    create(:live_tag, tag_id: 'existing-tag', tag_type: 'section', content_id: 'EXISTING-TAG-CONTENT-ID')
+    artefact = create(:artefact,
+      slug: 'an-item-with-links',
+      sections: ["existing-tag"],
+    )
+    message = GovukMessageQueueConsumer::MockMessage.new({
+      "publishing_app" => "a-publishing-app",
+      "base_path" => "/an-item-with-links",
+      "links" => {
+      }
+    })
+
+    TaggingUpdater.new.process(message)
+
+    artefact.reload
+    assert_equal [], artefact.tags.map(&:tag_id)
+    assert message.acked?
+  end
+
   def test_when_no_artefact_found
     message = GovukMessageQueueConsumer::MockMessage.new({
       "publishing_app" => "a-publishing-app",

--- a/test/unit/queue_consumers/tagging_updater_test.rb
+++ b/test/unit/queue_consumers/tagging_updater_test.rb
@@ -35,8 +35,7 @@ class TaggingUpdaterTest < ActiveSupport::TestCase
     message = GovukMessageQueueConsumer::MockMessage.new({
       "publishing_app" => "a-publishing-app",
       "base_path" => "/an-item-with-links",
-      "links" => {
-      }
+      "links" => {}
     })
 
     TaggingUpdater.new.process(message)


### PR DESCRIPTION
The TaggingUpdater listens to the message queue and copies things from the `links` hash to this app's database. This is necessary to allow tags set in content-tagger to propagate to the frontend.

This commit allows us to clear out the links for an item. Because publishing-api never sends empty link sets this previously didn't happen.

https://trello.com/c/0FKSqAkK
