### PR TITLE
Update parent only when present in db

### DIFF
--- a/app/queue_consumers/tagging_updater.rb
+++ b/app/queue_consumers/tagging_updater.rb
@@ -53,7 +53,7 @@ private
       if content_item['links']['parent']
         parent = Tag.where(:content_id.in => content_item['links']['parent']).first
 
-        if parent.tag_type == 'section'
+        if parent && parent.tag_type == 'section'
           artefact.set_primary_tag_of_type('section', parent.tag_id)
         end
       end


### PR DESCRIPTION
'Quick fix' to get rid of the "NoMethodError: undefined method `tag_type' for
nil:NilClass" error, see here:
https://github.com/alphagov/panopticon/blob/master/app/queue_consumers/tagging_updater.rb#L56

We should investigate why the item is not present in Panopticon's db.
