### PR TITLE
Make the find-your-local-council artefact a prefix route

### DIFF
--- a/db/migrate/20160810095212_add_prefixes_to_find_your_local_council_transaction.rb
+++ b/db/migrate/20160810095212_add_prefixes_to_find_your_local_council_transaction.rb
@@ -1,0 +1,13 @@
+class AddPrefixesToFindYourLocalCouncilTransaction < Mongoid::Migration
+  def self.up
+    find_your_local_council = Artefact.find_by_slug('find-your-local-council')
+    # Remove the exact route for /find-your-local-council...
+    find_your_local_council.paths = ['/find-your-local-council.json']
+    # ...and add it as a prefix route instead
+    find_your_local_council.prefixes = ['/find-your-local-council']
+    find_your_local_council.save!
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This is to support the new interactive find-your-local-council being
built in frontend that replaces the local directgov version of the tool.

We update the find-your-local-council artefact to swap the
/find-your-local-council path from living in paths (this generates an
exact route in router) to living in prefixes (which generates a prefix
route in router). Saving the artefact sends the relevant messages to
router-api to propagate the change up through the stack.

See: https://trello.com/c/yoz4mg1B/436-3-of-3-build-find-my-local-council-3 and https://github.com/alphagov/frontend/pull/986 for more context.
