### PR TITLE
Allow removal of tags with archived content tagged to it

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -54,7 +54,7 @@ class TagsController < ApplicationController
   end
 
   def destroy
-    if Artefact.with_tags([@tag.tag_id]).any?
+    if Artefact.in_state("live").with_tags([@tag.tag_id]).any?
       render json: { error: 'Tag has documents tagged to it' }, status: 409
     else
       @tag.destroy

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -97,7 +97,9 @@ class TagsControllerTest < ActionController::TestCase
 
     should 'not remove tags with documents tagged to it' do
       tag = create(:draft_tag)
-      artefact = create(:artefact, tag_ids: [tag.tag_id])
+      without_artefact_callbacks do
+        artefact = create(:artefact, tag_ids: [tag.tag_id], state: "live")
+      end
 
       delete :destroy, id: tag.id, format: :json
 


### PR DESCRIPTION
This is fine, because we'll never display archived documents anyway.

https://trello.com/c/e6HG3PAR/72-browse-page-with-no-tags-not-able-to-redirect
