### PR TITLE
Remove find-local-council artefact

### DIFF
--- a/db/migrate/20160815135446_remove_find_local_council_artefact.rb
+++ b/db/migrate/20160815135446_remove_find_local_council_artefact.rb
@@ -1,0 +1,14 @@
+class RemoveFindLocalCouncilArtefact < Mongoid::Migration
+  def self.up
+    # Actually fully delete this artefact.
+    # It was created in error on launch day and immediately archived without
+    # publishing (or even completing the creation of the associated edition
+    # in publisher).  We want to reuse the route without leaving something
+    # lying around that could accidently be used to alter that route from
+    # panopticon.
+    Artefact.find_by(slug: 'find-local-council').destroy
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This artefact was created by mistake and immediately withdrawn without
publishing it or even completing the creation of the association editions
in publisher.  We want to reuse the slug, and would rather not have
something lying around in panopticon that looks like the owner.

For: https://trello.com/c/RXWWvAZk/461-use-publishing-api-to-manage-routes-and-tagging-for-find-local-council

See alphagov/frontend#986 for extra context on the new find-local-council path
