### PR TITLE
Stop stubbing an imminence data set URL in all tests

### DIFF
--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -8,6 +8,4 @@ Before do
 
   # Mock out all publisher URLs
   stub_request(:get, %r{^#{Regexp.escape Plek.current.find('publisher')}/}).to_return(status: 200)
-
-  stub_request(:get, "#{Plek.current.find('imminence')}/data_sets/public_bodies.json").to_return(body: [].to_json)
 end


### PR DESCRIPTION
For: https://trello.com/c/PKAohBzb/468-stop-adding-slugs-to-areas-returned-from-mapit-by-imminence-2

Removing the stub doesn't seem to cause a problem and it looks like this
stub hasn't been needed since 2011 (see:
b3e0c8aefa2cb3b6c85d67c384f31dcb746ff268).

See https://github.com/alphagov/imminence/pull/136 for the imminence change that lead us to this.
