### PR TITLE
Disable form for Whitehall content

### DIFF
--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -28,8 +28,8 @@
       </div>
 
       <div class="col-md-4">
-        <% if f.object.persisted? && f.object.owning_app.present? %>
-          <%= render partial: "artefacts/form/owning_app", locals: { f: f } %>
+        <% if artefact.persisted? && artefact.owning_app.present? %>
+          <%= render partial: "artefacts/form/owning_app", locals: { artefact: artefact } %>
         <% end %>
 
         <%= render partial: "artefacts/form/need", locals: { f: f } %>

--- a/app/views/artefacts/_whitehall_form.html.erb
+++ b/app/views/artefacts/_whitehall_form.html.erb
@@ -1,45 +1,10 @@
-<% if flash[:notice].present? %>
-  <div class="alert alert-success"><%= flash[:notice] %></div>
-<% end %>
 
-<% if artefact.errors.count > 0 %>
-  <div class="alert alert-danger">
-    <ul>
-      <% artefact.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-      <% end %>
-    </ul>
+<div class="row">
+  <div class="col-md-8">
+    <%= render partial: "artefacts/use_content_tagger", locals: { artefact: artefact } %>
   </div>
-<% end %>
 
-<% if artefact.archived? %>
-  <div class="alert alert-danger">
-    <h2>Stop! You can’t edit this artefact because it has been withdrawn.</h2>
+  <div class="col-md-4">
+    <%= render partial: "artefacts/form/owning_app", locals: { artefact: artefact } %>
   </div>
-<% else %>
-  <%= semantic_bootstrap_nested_form_for(artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
-    <div class="well">
-      <%= f.input :name, :input_html => { :class => "input-md-6" } %>
-      <%= f.input :description, :input_html => { :class => "input-md-6", :rows => 6 }, :as => :text %>
-      <%= f.input :slug, :input_html => { :class => "input-md-6" }, :hint => "Inside government slugs are: <code>government/the-slug</code>. Detailed guides are simply: <code>the-slug</code>".html_safe %>
-    </div>
-
-    <%= render partial: "artefacts/use_content_tagger", locals: { f: f, artefact: artefact } %>
-    <%= f.input :owning_app, :as => :hidden %>
-    <%= f.input :state, :as => :hidden, :input_html => { :value => "live" } %>
-
-    <div class="form-actions">
-      <%= f.submit :value => "Save and continue editing", :class => "btn btn-primary" %>
-    </div>
-  <% end %>
-<% end %>
-
-<%= content_for :extra_javascript do %>
-  <script>
-    $(".chosen-select").chosen();
-
-    if ($('.artefact-section').size() == 1) {
-      $('.remove-section').hide();
-    }
-  </script>
-<% end %>
+</div>

--- a/app/views/artefacts/form/_owning_app.html.erb
+++ b/app/views/artefacts/form/_owning_app.html.erb
@@ -1,6 +1,7 @@
 <div class="well owning-app">
-  <p>This content is managed in <strong><%= f.object.owning_app.humanize %></strong>.</p>
-  <% if f.object.owning_app == "publisher" %>
-    <%= link_to "Edit in Publisher", admin_url_for_edition(f.object), :class => "btn btn-default" %>
+  <p>This content is managed in <strong><%= artefact.owning_app.humanize %></strong>.</p>
+
+  <% if artefact.owning_app == "publisher" %>
+    <%= link_to "Edit in Publisher", admin_url_for_edition(artefact), :class => "btn btn-default" %>
   <% end %>
 </div>


### PR DESCRIPTION
Editing artefacts in Panopticon has no purpose anymore, since Whitehall will override any changes made in this database. To make this clear to publishers and developers this commit removes the form for whitehall-owned artefacts entirely.
## Before

<img width="1174" alt="screen shot 2016-08-31 at 17 23 49" src="https://cloud.githubusercontent.com/assets/233676/18137371/f28badc8-6f9f-11e6-8d0e-6e504d769368.png">
## After

<img width="1174" alt="screen shot 2016-08-31 at 17 23 54" src="https://cloud.githubusercontent.com/assets/233676/18137373/f516c960-6f9f-11e6-849f-f32e99344781.png">
