### PR TITLE
Restrict external links

### DIFF
--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -21,7 +21,7 @@
           <%= render partial: "artefacts/form/core_attributes", locals: { f: f } %>
         <% end %>
 
-        <%= render partial: "artefacts/form/related_content", locals: { f: f } %>
+        <%= render partial: "artefacts/form/related_content", locals: { f: f, artefact: artefact } %>
         <%- unless f.object.app_without_tagging_support? %>
           <%= render partial: "artefacts/use_content_tagger", locals: { f: f, artefact: artefact } %>
         <% end %>

--- a/app/views/artefacts/form/_related_artefacts.html.erb
+++ b/app/views/artefacts/form/_related_artefacts.html.erb
@@ -1,0 +1,8 @@
+<div class="related-artefacts fieldset-section">
+  <%= f.label :related_artefact_slugs, class: "section-label" %>
+  <%= f.text_area :related_artefact_slugs, size: "75x3",
+        placeholder: "Fill-in slugs of arefacts to relate, " +
+          "separated by a comma. for example: benefits-calculators, child-tax-credit",
+        value: artefact.related_artefact_slugs.present? ? artefact.related_artefact_slugs.join(", ") : "",
+        data: { related_artefacts: related_artefacts_json(artefact.ordered_related_artefacts) } %>
+</div>

--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -1,33 +1,6 @@
 <div class="well">
   <%= f.inputs "Related content" do %>
-    <div class="related-artefacts fieldset-section">
-      <%= f.label :related_artefact_slugs, class: "section-label" %>
-      <%= f.text_area :related_artefact_slugs, size: "75x3",
-            placeholder: "Fill-in slugs of arefacts to relate, " +
-              "separated by a comma. for example: benefits-calculators, child-tax-credit",
-            value: f.object.related_artefact_slugs.present? ? f.object.related_artefact_slugs.join(", ") : "",
-            data: { related_artefacts: related_artefacts_json(f.object.ordered_related_artefacts) } %>
-    </div>
-
-    <div class="related-external-links fieldset-section">
-      <label class="section-label">Related external links</label><br />
-
-      <%= f.fields_for :external_links do |link| %>
-        <div class="nested-item">
-          <div class="row relative">
-            <div class="col-md-4">
-              <%= link.label :title, "Title" %>
-              <%= link.text_field :title, class: 'form-control' %>
-            </div>
-            <div class="col-md-5">
-              <%= link.label :url, "URL" %>
-              <%= link.text_field :url, class: 'form-control' %>
-            </div>
-            <%= link.link_to_remove "Remove this URL", :class => "remove-row remove-row-related" %>
-          </div>
-        </div>
-      <% end %>
-      <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-success" %>
-    </div>
+    <%= render "artefacts/form/related_artefacts", f: f, artefact: artefact %>
+    <%= render "artefacts/form/related_external_links", f: f, artefact: artefact %>
   <% end %>
 </div>

--- a/app/views/artefacts/form/_related_content.html.erb
+++ b/app/views/artefacts/form/_related_content.html.erb
@@ -1,6 +1,9 @@
 <div class="well">
   <%= f.inputs "Related content" do %>
     <%= render "artefacts/form/related_artefacts", f: f, artefact: artefact %>
-    <%= render "artefacts/form/related_external_links", f: f, artefact: artefact %>
+
+    <% if artefact.owning_app.in?(%w[publisher smartanswers]) %>
+      <%= render "artefacts/form/related_external_links", f: f, artefact: artefact %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/artefacts/form/_related_external_links.html.erb
+++ b/app/views/artefacts/form/_related_external_links.html.erb
@@ -1,0 +1,21 @@
+<div class="related-external-links fieldset-section">
+  <label class="section-label">Related external links</label><br />
+
+  <%= f.fields_for :external_links do |link| %>
+    <div class="nested-item">
+      <div class="row relative">
+        <div class="col-md-4">
+          <%= link.label :title, "Title" %>
+          <%= link.text_field :title, class: 'form-control' %>
+        </div>
+        <div class="col-md-5">
+          <%= link.label :url, "URL" %>
+          <%= link.text_field :url, class: 'form-control' %>
+        </div>
+        <%= link.link_to_remove "Remove this URL", :class => "remove-row remove-row-related" %>
+      </div>
+    </div>
+  <% end %>
+
+  <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-success" %>
+</div>


### PR DESCRIPTION
We are planning on moving the external links to another app so that panopticon can be retired. Currently this feature is used in 149 publisher-owned pages, and 1 smart-answers page.

A current plan is to move the functionality over to mainstream publisher and come up with a different solution for the one smart-answer.

By disabling it for all other applications we make sure that we don't have to implement this feature in other applications as well.

https://trello.com/c/4BbOkrM7
