### PR TITLE
Don't show content-tagger link on "new" page

### DIFF
--- a/app/models/enhancements/artefact.rb
+++ b/app/models/enhancements/artefact.rb
@@ -1,12 +1,6 @@
 require "artefact"
 
 class Artefact
-  APPS_WITHOUT_TAGGING_SUPPORT = %w(
-    finder-api
-    frontend
-    planner
-  ).freeze
-
   # Add a non-field attribute so we can pass indexable content over to Rummager
   # without persisting it
   attr_accessor :indexable_content
@@ -90,10 +84,6 @@ class Artefact
         a.save
       end
     end
-  end
-
-  def app_without_tagging_support?
-    APPS_WITHOUT_TAGGING_SUPPORT.include?(self.owning_app)
   end
 
   def as_json(options={})

--- a/app/views/artefacts/_form.html.erb
+++ b/app/views/artefacts/_form.html.erb
@@ -22,7 +22,8 @@
         <% end %>
 
         <%= render partial: "artefacts/form/related_content", locals: { f: f, artefact: artefact } %>
-        <%- unless f.object.app_without_tagging_support? %>
+
+        <% if f.object.content_id %>
           <%= render partial: "artefacts/use_content_tagger", locals: { f: f, artefact: artefact } %>
         <% end %>
       </div>


### PR DESCRIPTION
Currently the "new artefact" page has a link to content-tagger. Because new artefacts don't have a content_id yet, the link goes nowhere and the user will see a 404.

This adds a check if there's a `content_id` for the artefact. It also allows us to remove old code which had the same purpose (content by finder-api, frontend and planner didn't have a content_id).
