### PR TITLE
Send related links to publishing-api

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -85,6 +85,15 @@ class ArtefactsController < ApplicationController
 
     @actions = build_actions
 
+    if saved && @artefact.content_id
+      Rails.application.publishing_api_v2.patch_links(
+        @artefact.content_id,
+        links: {
+          ordered_related_items: @artefact.related_artefacts.map(&:content_id).compact
+        }
+      )
+    end
+
     respond_with @artefact, status: status_to_use do |format|
       format.html do
         continue_editing = (params[:commit] == 'Save and continue editing')

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'kaminari' # has to be loaded before the models, otherwise the methods a
 require "govuk_content_models"
 require "gds_api/publishing_api"
 require "gds_api/rummager"
+require "gds_api/publishing_api_v2"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -43,6 +44,13 @@ module Panopticon
 
     def publishing_api
       @publishing_api ||= GdsApi::PublishingApi.new(
+        Plek.current.find('publishing-api'),
+        bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+      )
+    end
+
+    def publishing_api_v2
+      @publishing_api_v2 ||= GdsApi::PublishingApiV2.new(
         Plek.current.find('publishing-api'),
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
       )

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -1,5 +1,6 @@
 Then /^the API should say that the artefacts are related$/ do
   check_artefact_has_related_artefact_in_api @artefact, @related_artefact
+  assert_requested @request_to_patch_links
 end
 
 Then /^the API should say that the artefacts are not related$/ do

--- a/features/step_definitions/artefact_steps.rb
+++ b/features/step_definitions/artefact_steps.rb
@@ -30,6 +30,8 @@ When /^I change the slug of the first artefact to "([^"]*)"$/ do |slug|
 end
 
 When /^I save$/ do
+  stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
+
   click_button 'Save and continue editing'
 end
 
@@ -38,6 +40,7 @@ Then /^I should be redirected back to the edit page$/ do
 end
 
 When /^I save, indicating that I want to continue editing afterwards$/ do
+  stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
   click_button 'Save and continue editing'
 end
 
@@ -54,6 +57,9 @@ Then /^I should see an indication that the save worked$/ do
 end
 
 When /^I create a relationship between them$/ do
+  @request_to_patch_links = stub_request(:patch, "http://publishing-api.dev.gov.uk/v2/links/#{@artefact.content_id}").
+    to_return(body: {}.to_json)
+
   visit edit_artefact_path(@artefact)
   select_related_artefact @related_artefact
 end

--- a/features/support/artefacts.rb
+++ b/features/support/artefacts.rb
@@ -1,7 +1,13 @@
 require 'govuk_content_models/test_helpers/factories'
 
 def create_artefact(owning_app="a-publishing-app")
-  FactoryGirl.create :artefact, :name => 'Child Benefit rates', :need_ids => ['100001'], owning_app: owning_app
+  FactoryGirl.create(
+    :artefact,
+    name: 'Child Benefit rates',
+    need_ids: ['100001'],
+    owning_app: owning_app,
+    content_id: SecureRandom.uuid,
+  )
 end
 
 def create_two_artefacts(owning_app="a-publishing-app")

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -33,6 +33,7 @@ module RegistrationInfo
 
   def prepare_registration_environment(artefact = example_smart_answer)
     setup_user
+    stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
   end
 
   def setup_user

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -5,6 +5,7 @@ require 'gds_api/test_helpers/router'
 class ArtefactsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
+    stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
   end
 
   context "GET search_relatable_items" do

--- a/test/integration/artefacts_api_test.rb
+++ b/test/integration/artefacts_api_test.rb
@@ -5,6 +5,7 @@ class ArtefactsAPITest < ActiveSupport::TestCase
   setup do
     create_test_user
     header "Content-Type", "application/json"
+    stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
   end
 
   context "artefacts index" do

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -159,8 +159,10 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
   context "relating artefacts" do
     context "without javascript" do
       setup do
-        @artefact = FactoryGirl.create(:artefact)
+        @artefact = FactoryGirl.create(:artefact, content_id: SecureRandom.uuid)
         @artefacts_to_relate = *FactoryGirl.create_list(:artefact, 2)
+        @request_to_patch_links = stub_request(:patch, "http://publishing-api.dev.gov.uk/v2/links/#{@artefact.content_id}").
+          to_return(body: {}.to_json)
       end
 
       should "be done by entering slugs of artefacts to relate" do
@@ -170,6 +172,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
         click_on "Save and continue editing"
 
         assert_equal @artefacts_to_relate.map(&:slug).join(", "), find_field("Related artefact slugs").value
+        assert_requested @request_to_patch_links
       end
     end
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -9,6 +9,10 @@ class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include ArtefactNeedIdsFormFiller
 
+  setup do
+    stub_request(:patch, %r[http://publishing-api.dev.gov.uk/v2/links/*]).to_return(body: {}.to_json)
+  end
+
   teardown do
     Capybara.use_default_driver
   end


### PR DESCRIPTION
This commit makes sure that we send the related links of an item to the publishing-api every time it is saved. This will allow us to start rendering the sidebar in frontend apps from the content-store.

A follow up PR will create a rake task to republish all existing artefacts.

https://trello.com/c/M2BMJ1JT
