### PR TITLE
[DO NOT MERGE] Add search admin warning to withdraw screen

### DIFF
--- a/app/views/artefacts/withdraw.html.erb
+++ b/app/views/artefacts/withdraw.html.erb
@@ -8,24 +8,32 @@
   <div class="callout-body">
     Withdraw a page from GOV.UK. This can’t be undone.
   </div>
+  <br/>
+  <div class="callout-body">
+    You will also need to remove the search result for this page from
+    <%= link_to "Search Admin", "#{Plek.find("search-admin")}/results/result?base_path=%2F#{@artefact.slug}" %>.
+  </div>
 </div>
 
 <div class="well">
-  <%= semantic_bootstrap_nested_form_for(@artefact,
-                                         html: {
-                                           class: 'artefact',
-                                           id: 'withdraw_artefact',
-                                           method: "delete"
-                                         }) do |f| %>
+  <%= semantic_bootstrap_nested_form_for(
+    @artefact,
+    html: {
+      class: 'artefact',
+      id: 'withdraw_artefact',
+      method: "delete"
+    }
+  ) do |f| %>
+
     <h3 class="remove-top-margin add-bottom-margin">Withdraw</h3>
       <div class="form-group">
         <%= f.input :redirect_url, class: "form-control input-md-6",
           label: ('Redirect to <span class="normal">(optional)<br />' +
                   'For example: <code>/government/organisations/hm-revenue-customs</code></span>').html_safe%>
         <%= button_tag 'Withdraw',
-                       "data-module" => 'confirm',
-                       "data-message" => "This will remove ‘#{@artefact.name}’ from the website.\n\n Are you sure?",
-                       :class => "btn btn-danger" %>
+          "data-module" => 'confirm',
+          "data-message" => "This will remove ‘#{@artefact.name}’ from the website.\n\n Are you sure?",
+          :class => "btn btn-danger" %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
We're in the process of removing the Rummager dependency from
Panopticon (see #398 ). Once this is done, Panopticon will no longer tell Rummager
to delete withdrawn artefacts from search results. Editors will need to
do this manually in Search Admin. This commit adds some warning text to
the withdraw screen to remind the editor to do this.

Example withdraw screen:

![screen shot 2016-09-26 at 16 51 28](https://cloud.githubusercontent.com/assets/519250/18841409/89fbf712-8409-11e6-91be-a60863496d12.png)
