### PR TITLE
Add functionality to remove an artefact from search on withdraw

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -115,8 +115,9 @@ class ArtefactsController < ApplicationController
     if @artefact.update_attributes_as(
       current_user,
       state: "archived",
-      redirect_url: redirect_url)
-
+      redirect_url: redirect_url
+    )
+      RemoveFromSearch.call(@artefact.slug)
       respond_with(@artefact) do |format|
         format.json { head 200 }
         format.html { redirect_to artefacts_path }

--- a/app/services/remove_from_search.rb
+++ b/app/services/remove_from_search.rb
@@ -1,0 +1,33 @@
+class RemoveFromSearch
+  attr_reader :base_path
+
+  def self.call(slug)
+    new(slug).call
+  end
+
+  def initialize(slug)
+    @base_path = "/#{slug}"
+  end
+
+  def call
+    with_error_handling do
+      Rails.application.rummager.delete_content!(base_path)
+    end
+  end
+
+  def with_error_handling(&_block)
+    begin
+      tries ||= 2
+      yield
+    rescue => exception
+      if (tries -= 1).zero?
+        Airbrake.notify_or_ignore(
+          exception,
+          :parameters => { :failed_base_path => base_path }
+        )
+      else
+        retry
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require "sprockets/railtie"
 require 'kaminari' # has to be loaded before the models, otherwise the methods aren't added
 require "govuk_content_models"
 require "gds_api/publishing_api"
+require "gds_api/rummager"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -45,6 +46,10 @@ module Panopticon
         Plek.current.find('publishing-api'),
         bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
       )
+    end
+
+    def rummager
+      @rummager ||= GdsApi::Rummager.new(Plek.current.find('rummager'))
     end
   end
 end

--- a/features/editing.feature
+++ b/features/editing.feature
@@ -5,7 +5,6 @@ Feature: Editing artefacts
   Background:
     Given I am an admin
       And I have stubbed the router
-      And I have stubbed search
 
   Scenario: Editing an artefact and changing the slug
     Given two artefacts exist

--- a/features/registering_resources.feature
+++ b/features/registering_resources.feature
@@ -33,3 +33,4 @@ Feature: Registering resources
   Scenario: Deleting an item
     When I delete an artefact
     Then the artefact state should be archived
+      And it should be removed from search

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -2,10 +2,6 @@ Given /^I have stubbed the router$/ do
   stub_router
 end
 
-Given /^I have stubbed search$/ do
-  stub_search
-end
-
 Given /^I have stubbed publishing-api$/ do
   stub_publishing_api
 end

--- a/features/step_definitions/registration_steps.rb
+++ b/features/step_definitions/registration_steps.rb
@@ -83,3 +83,8 @@ end
 Then /^the artefact state should be archived$/ do
   assert_equal 'archived', Artefact.last.state
 end
+
+Then(/^it should be removed from search$/) do
+  assert_requested @fake_search_delete
+end
+

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -52,9 +52,10 @@ module RegistrationInfo
   end
 
   def stub_search_delete
-    @fake_search_delete = WebMock.stub_request(:delete, artefact_search_url(@artefact)).to_return(status: 200)
-    WebMock.stub_request(:post, "#{SEARCH_ROOT}/commit")
-           .to_return(:status => 200)
+    @fake_search_delete = WebMock.stub_request(
+      :delete,
+      "http://rummager.dev.gov.uk/content?link=/#{@artefact.slug}"
+    ).to_return(status: 200)
   end
 
   def artefact_search_url(artefact)

--- a/features/support/registration_info.rb
+++ b/features/support/registration_info.rb
@@ -3,8 +3,6 @@ require 'gds_api/test_helpers/publishing_api'
 module RegistrationInfo
   include GdsApi::TestHelpers::PublishingApi
 
-  SEARCH_ROOT = "http://search.dev.gov.uk/mainstream"
-
   def example_smart_answer
     {
       "need_ids"          => ["102012"],
@@ -35,7 +33,6 @@ module RegistrationInfo
 
   def prepare_registration_environment(artefact = example_smart_answer)
     setup_user
-    stub_search
   end
 
   def setup_user
@@ -46,22 +43,11 @@ module RegistrationInfo
     WebMock.stub_request(:any, %r{\A#{Plek.current.find('router-api')}/}).to_return(:status => 200)
   end
 
-  def stub_search
-    @fake_search = WebMock.stub_request(:post, "#{SEARCH_ROOT}/documents").to_return(status: 200)
-    @fake_search_amend = WebMock.stub_request(:post, %r{^#{Regexp.escape SEARCH_ROOT}/documents/.*$}).to_return(status: 200)
-  end
-
   def stub_search_delete
     @fake_search_delete = WebMock.stub_request(
       :delete,
       "http://rummager.dev.gov.uk/content?link=/#{@artefact.slug}"
     ).to_return(status: 200)
-  end
-
-  def artefact_search_url(artefact)
-    # The search URL to which amendment requests should be POSTed
-    link = "/#{artefact.slug}"
-    "#{SEARCH_ROOT}/documents/#{CGI.escape link}"
   end
 
   def setup_existing_artefact

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -548,6 +548,7 @@ class ArtefactsControllerTest < ActionController::TestCase
         context "for a relative path" do
           should "mark an artefact as archived" do
             stub_all_router_registration
+            RemoveFromSearch.expects(:call).with(@artefact.slug)
 
             delete :destroy, id: @artefact.id, format: :json,
                              artefact: { redirect_url: "/whenever" }
@@ -558,6 +559,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           end
 
           should "add a redirect route" do
+            RemoveFromSearch.expects(:call).with(@artefact.slug)
             redirect, commit = stub_redirect_registration "/whatever",
                                                           "exact",
                                                           "/whenever",
@@ -574,6 +576,7 @@ class ArtefactsControllerTest < ActionController::TestCase
         context "for a GOV.UK absolute URL path" do
           should "mark an artefact as archived" do
             stub_all_router_registration
+            RemoveFromSearch.expects(:call).with(@artefact.slug)
 
             delete :destroy, id: @artefact.id, format: :json,
                              artefact: { redirect_url: "https://gov.uk/whenever" }
@@ -584,6 +587,7 @@ class ArtefactsControllerTest < ActionController::TestCase
           end
 
           should "add a redirect route" do
+            RemoveFromSearch.expects(:call).with(@artefact.slug)
             redirect, commit = stub_redirect_registration "/whatever",
                                                           "exact",
                                                           "/whenever",
@@ -610,6 +614,7 @@ class ArtefactsControllerTest < ActionController::TestCase
 
       context "when a redirect is not requested" do
         should "mark an artefact as archived" do
+          RemoveFromSearch.expects(:call).with(@artefact.slug)
           stub_all_router_registration
 
           delete :destroy, id: @artefact.id, format: :json
@@ -620,6 +625,7 @@ class ArtefactsControllerTest < ActionController::TestCase
         end
 
         should "add a Gone route" do
+          RemoveFromSearch.expects(:call).with(@artefact.slug)
           gone, commit = stub_gone_route_registration "/whatever", "exact"
 
           delete :destroy, id: @artefact.id, format: :json

--- a/test/integration/artefact_withdraw_test.rb
+++ b/test/integration/artefact_withdraw_test.rb
@@ -49,6 +49,10 @@ class ArtefactWithdrawTest < ActionDispatch::IntegrationTest
       without_artefact_callbacks do
         @artefact = FactoryGirl.create(:live_artefact, paths: ["/foo"])
       end
+      WebMock.stub_request(
+        :delete,
+        "http://rummager.dev.gov.uk/content?link=/#{@artefact.slug}"
+      )
     end
 
     should "show the withdraw tab" do

--- a/test/services/remove_from_search_test.rb
+++ b/test/services/remove_from_search_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class RemoveFromSearchTest < ActiveSupport::TestCase
+  def test_it_asks_rummager_to_remove_an_artefact_from_search
+    Rails.application.rummager.expects(:delete_content!).with("/some-content")
+
+    RemoveFromSearch.call("some-content")
+  end
+
+  def test_it_handles_errors
+    Rails.application.rummager.expects(:delete_content!)
+      .with("/some-content")
+      .twice
+      .raises(ArgumentError)
+    Airbrake.expects(:notify_or_ignore).with(
+      instance_of(ArgumentError),
+      :parameters => { :failed_base_path => "/some-content" }
+    ).once
+
+    RemoveFromSearch.call("some-content")
+  end
+end


### PR DESCRIPTION
In 54a927e we removed Rummager as a dependency in Panopticon. We need to
add one piece of functionality back in - the deletion of content from
the search index when an artefact is withdrawn.

This commit adds a service object to handle this, invoking it from
ArtefactsController#destroy. Because the call is synchronous, the
service object implements some basic error handling. It tries contacting
Rummager twice and then reports to Airbrake in the event of any further
errors, leaving the destroy action to complete transparently for the
user.
