### PR TITLE
Don't register routes for Whitehall

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -25,14 +25,10 @@ class RoutableArtefact
   end
 
   def submit(options = {})
+    return if artefact.owning_app == "whitehall"
+
     if artefact.live?
       register
-    elsif artefact.owning_app == "whitehall"
-      if artefact.kind == "detailed_guide" && artefact.archived?
-        register
-      else
-        return
-      end
     elsif artefact.archived? && artefact.redirect_url.present?
       redirect(artefact.redirect_url)
     elsif artefact.archived?

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -15,38 +15,9 @@ class RoutableArtefactTest < ActiveSupport::TestCase
         @routable.stubs(:ensure_backend_exists).returns true
       end
 
-      should "register the route" do
-        @routable.expects(:register)
-        @routable.expects(:commit)
-
-        @routable.submit
-      end
-
-      should "register the route for an archived detailed guide" do
-        @routable.expects(:register)
-        @routable.expects(:commit)
-
-        @artefact.kind = "detailed_guide"
-        @artefact.state = "archived"
-
-        @routable.submit
-      end
-
-      should "not set an archived route as Gone" do
-        @routable.expects(:delete).never
-        @routable.expects(:commit).never
-
-        @artefact.state = "archived"
-
-        @routable.submit
-      end
-
-      should "not add a redirect" do
-        @routable.expects(:redirect).never
-        @routable.expects(:commit).never
-
-        @artefact.state = "archived"
-        @artefact.redirect_url = "/bar"
+      should "not register the route" do
+        @routable.expects(:register).times(0)
+        @routable.expects(:commit).times(0)
 
         @routable.submit
       end


### PR DESCRIPTION
`/government` routes pass through router anyway and the `/guidance` path is handled within Whitehall via content store -> router-api now so we no longer need to register routes via Panopticon.

/cc @tijmenb @boffbowsh 
