### PR TITLE
Only allow artefact withdrawal for publisher-artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -37,7 +37,7 @@ class ArtefactsController < ApplicationController
   end
 
   def withdraw
-    if @artefact.archived? || @artefact.owning_app == 'whitehall'
+    if @artefact.archived? || @artefact.owning_app != 'publisher'
       redirect_to root_path
     end
   end

--- a/app/views/artefacts/_artefact_header.html.erb
+++ b/app/views/artefacts/_artefact_header.html.erb
@@ -15,7 +15,7 @@
   <li class="<%= "active" if controller.action_name == "history" %>">
     <%= link_to "History", history_artefact_path(@artefact) %>
   </li>
-  <% unless @artefact.archived? || @artefact.owning_app == 'whitehall' %>
+  <% unless @artefact.archived? || @artefact.owning_app != 'publisher' %>
     <li class="<%= "active" if controller.action_name == "withdraw" %>">
       <%= link_to "Withdraw", withdraw_artefact_path(@artefact) %>
       </li>

--- a/test/integration/artefact_withdraw_test.rb
+++ b/test/integration/artefact_withdraw_test.rb
@@ -8,10 +8,10 @@ class ArtefactWithdrawTest < ActionDispatch::IntegrationTest
     create_test_user
   end
 
-  context "for a whitehall artefact" do
+  context "for an artefact not owned by publisher" do
     setup do
       without_artefact_callbacks do
-        @artefact = FactoryGirl.create(:whitehall_live_artefact, paths: ["/foo"])
+        @artefact = FactoryGirl.create(:artefact, owning_app: SecureRandom.hex, paths: ["/foo"])
       end
     end
 

--- a/test/integration/artefacts_edit_test.rb
+++ b/test/integration/artefacts_edit_test.rb
@@ -6,15 +6,21 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
     stub_all_router_api_requests
   end
 
-  context "when editing an artefact from a publishing app" do
+  context "when editing an artefact from the Publisher application" do
     setup do
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business", parent_id: nil, title: "Business")
       FactoryGirl.create(:live_tag, tag_type: "section", tag_id: "business/employing-people", parent_id: "business", title: "Employing people")
 
-      @artefact = FactoryGirl.create(:artefact,
-                                     name: "VAT Rates", slug: "vat-rates", kind: "answer", state: "live",
-                                     owning_app: "a-publishing-app", language: "en",
-                                     section_ids: ["business/employing-people"])
+      @artefact = FactoryGirl.create(
+        :artefact,
+        name: "VAT Rates",
+        slug: "vat-rates",
+        kind: "answer",
+        state: "live",
+        owning_app: "publisher",
+        language: "en",
+        section_ids: ["business/employing-people"]
+      )
     end
 
     should "display the artefact form" do
@@ -33,7 +39,7 @@ class ArtefactsEditTest < ActionDispatch::IntegrationTest
       end
 
       within ".owning-app" do
-        assert page.has_content? "This content is managed in A-publishing-app"
+        assert page.has_content? "This content is managed in Publisher"
       end
 
       within ".form-actions" do


### PR DESCRIPTION
It's currently possible for editors to "withdraw" artefacts owned by all applications except Whitehall in this app. We think that this could cause trouble. Things like manuals and travel advice have their
own withdrawal behaviour and interact with the publishing-api, unlike this application.

To prevent potential problems, we restrict withdrawal to artefacts owned by publisher. In the near future this feature will be moved to publisher outright.

cc @jennyd @h-lame 
