### PR TITLE
Add rake task to republish all related links

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,23 @@
+namespace :publishing_api do
+  desc "Send all related items to the publishing-api again"
+  task republish_related_links: [:environment] do
+    artefacts = Artefact.where(
+      # Whitehall artefacts can't have related artefacts (the form is hidden).
+      :owning_app.nin => ["whitehall"],
+
+      # Artefacts without content_id are so old that they're not in the
+      # publishing-api and don't need to be.
+      :content_id.nin => [nil]
+    )
+
+    artefacts.each do |artefact|
+      print "."
+      Rails.application.publishing_api_v2.patch_links(
+        artefact.content_id,
+        links: {
+          ordered_related_items: artefact.related_artefacts.map(&:content_id).compact
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Since https://github.com/alphagov/panopticon/pull/396 we're sending the related artefacts in the links hash to the publishing-api. This commit adds a rake task that republishes all the related links, so that the publishing-api is up to date.
