### PR TITLE
Do not register backends

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -17,13 +17,6 @@ class RoutableArtefact
     @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
   end
 
-  # Ensure the backend app exists in the router so that the routes below
-  # can reference it.
-  def ensure_backend_exists
-    backend_url = Plek.current.find(rendering_app, :force_http => true) + "/"
-    router_api.add_backend(rendering_app, backend_url)
-  end
-
   def submit(options = {})
     unless allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
       return
@@ -47,7 +40,6 @@ class RoutableArtefact
   end
 
   def register
-    ensure_backend_exists
     prefixes.each do |path|
       logger.debug("Registering route #{path} (prefix) => #{rendering_app}")
       router_api.add_route(path, "prefix", rendering_app)

--- a/test/integration/artefact_router_registration_test.rb
+++ b/test/integration/artefact_router_registration_test.rb
@@ -18,7 +18,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
 
     @router_api_base = Plek.current.find('router-api')
     @route_commit_request = WebMock.stub_request(:post, "#{@router_api_base}/routes/commit").to_return(:status => 200)
-    @backend_request = WebMock.stub_request(:put, "#{@router_api_base}/backends/publisher").to_return(:status => 200)
     @route_add_request = WebMock.stub_request(:put, "#{@router_api_base}/routes").
       with(:body => {"route" => hash_including("incoming_path" => "/foo", "route_type" => "prefix")}).
       to_return(:status => 201)
@@ -29,7 +28,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "draft")
       assert_equal 201, response.code.to_i
 
-      assert_not_requested @backend_request
       assert_not_requested @route_add_request
       assert_not_requested @route_commit_request
     end
@@ -38,7 +36,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "live")
       assert_equal 201, response.code.to_i
 
-      assert_requested @backend_request
       assert_requested @route_add_request
       assert_requested @route_commit_request
     end
@@ -53,7 +50,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "draft")
       assert_equal 200, response.code.to_i
 
-      assert_not_requested @backend_request
       assert_not_requested @route_add_request
       assert_not_requested @route_commit_request
     end
@@ -62,7 +58,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "live")
       assert_equal 200, response.code.to_i
 
-      assert_requested @backend_request
       assert_requested @route_add_request
       assert_requested @route_commit_request
     end
@@ -78,7 +73,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "live", :paths => ["/foo.json"], :prefixes => ["/foo", "/bar"])
       assert_equal 200, response.code.to_i
 
-      assert_requested @backend_request
       assert_requested @route_add_request
       assert_requested r2
       assert_requested r3
@@ -96,7 +90,6 @@ class ArtefactRouterRegistrationTest < ActionDispatch::IntegrationTest
       put_json "/artefacts/foo.json", artefact_details_hash(:state => "archived")
       assert_equal 200, response.code.to_i
 
-      assert_not_requested @backend_request
       assert_requested delete_request
       assert_requested @route_commit_request
     end

--- a/test/integration/artefact_withdraw_test.rb
+++ b/test/integration/artefact_withdraw_test.rb
@@ -61,9 +61,6 @@ class ArtefactWithdrawTest < ActionDispatch::IntegrationTest
     end
 
     should "set a Gone route when archiving without a redirect" do
-      stub_router_backend_registration("publisher",
-        Plek.current.find("publisher", :force_http => true) + "/")
-
       gone_request, commit_request = stub_gone_route_registration("/foo", "exact")
 
       visit "/artefacts/#{@artefact.id}/withdraw"
@@ -74,9 +71,6 @@ class ArtefactWithdrawTest < ActionDispatch::IntegrationTest
     end
 
     should "set a Redirect route when archiving with a relative redirect" do
-      stub_router_backend_registration("publisher",
-        Plek.current.find("publisher", :force_http => true) + "/")
-
       redirect_request, commit_request = stub_redirect_registration("/foo",
                                                                     "exact",
                                                                     "/bar",
@@ -91,9 +85,6 @@ class ArtefactWithdrawTest < ActionDispatch::IntegrationTest
     end
 
     should "set a Redirect route when archiving with a GOV.UK redirect" do
-      stub_router_backend_registration("publisher",
-        Plek.current.find("publisher", :force_http => true) + "/")
-
       redirect_request, commit_request = stub_redirect_registration("/foo",
                                                                     "exact",
                                                                     "/bar",

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -12,7 +12,6 @@ class RoutableArtefactTest < ActiveSupport::TestCase
                                        owning_app: ["whitehall", SecureRandom.hex].sample,
                                        paths: ["/foo"])
         @routable = RoutableArtefact.new(@artefact)
-        @routable.stubs(:ensure_backend_exists).returns true
       end
 
       should "not register the route" do
@@ -30,7 +29,6 @@ class RoutableArtefactTest < ActiveSupport::TestCase
                                        owning_app: "publisher",
                                        paths: ["/foo"])
         @routable = RoutableArtefact.new(@artefact)
-        @routable.stubs(:ensure_backend_exists).returns true
       end
 
       should "register the route" do
@@ -63,33 +61,9 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "registering routes for an artefact" do
     setup do
-      stub_router_backend_registration("publisher", "http://publisher.dev.gov.uk/")
       @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
       @routable = RoutableArtefact.new(@artefact)
       stub_all_router_registration
-    end
-
-    context "ensuring the backend exists in the router" do
-      should "use the rendering_app if set" do
-        @artefact.rendering_app = "fooey"
-        request = stub_router_backend_registration("fooey", "http://fooey.dev.gov.uk/")
-        @routable.register
-        assert_requested request
-      end
-
-      should "use the owning_app if rendering_app not set" do
-        @artefact.rendering_app = nil
-        request = stub_router_backend_registration("publisher", "http://publisher.dev.gov.uk/")
-        @routable.register
-        assert_requested request
-      end
-
-      should "use the owning_app if rendering_app is blank" do
-        @artefact.rendering_app = ""
-        request = stub_router_backend_registration("publisher", "http://publisher.dev.gov.uk/")
-        @routable.register
-        assert_requested request
-      end
     end
 
     should "add all defined prefix routes" do
@@ -132,7 +106,6 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "deleting routes for an artefact" do
     setup do
-      stub_router_backend_registration("publisher", "http://publisher.dev.gov.uk/")
       @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
       @routable = RoutableArtefact.new(@artefact)
     end
@@ -205,7 +178,6 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "redirecting routes for an artefact" do
     setup do
-      stub_router_backend_registration("publisher", "http://publisher.dev.gov.uk/")
       @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
       @routable = RoutableArtefact.new(@artefact)
     end


### PR DESCRIPTION
We are (slowly) removing the route registration functionality from this application. While the routing should stay for now, @jennyd and I think its not necessary for panopticon to ever register new backends.

This would've prevented the /trade-tariff backend-override incident. 
