### PR TITLE
Send related items in order to publishing-api

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -15,7 +15,7 @@ namespace :publishing_api do
       Rails.application.publishing_api_v2.patch_links(
         artefact.content_id,
         links: {
-          ordered_related_items: artefact.related_artefacts.map(&:content_id).compact
+          ordered_related_items: artefact.ordered_related_artefacts.map(&:content_id).compact
         }
       )
     end


### PR DESCRIPTION
The ordering is important because the user has specified it in the UI.

https://trello.com/c/mOeDK914
