### PR TITLE
Extract RelatedLinksPublisher

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -84,12 +84,7 @@ class ArtefactsController < ApplicationController
     @actions = build_actions
 
     if saved && @artefact.content_id
-      Rails.application.publishing_api_v2.patch_links(
-        @artefact.content_id,
-        links: {
-          ordered_related_items: @artefact.related_artefacts.map(&:content_id).compact
-        }
-      )
+      RelatedLinksPublisher.new(@artefact).publish!
     end
 
     respond_with @artefact, status: status_to_use do |format|

--- a/app/services/related_links_publisher.rb
+++ b/app/services/related_links_publisher.rb
@@ -1,0 +1,16 @@
+class RelatedLinksPublisher
+  attr_reader :artefact
+
+  def initialize(artefact)
+    @artefact = artefact
+  end
+
+  def publish!
+    Rails.application.publishing_api_v2.patch_links(
+      artefact.content_id,
+      links: {
+        ordered_related_items: artefact.ordered_related_artefacts.map(&:content_id).compact
+      }
+    )
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,12 +12,7 @@ namespace :publishing_api do
 
     artefacts.each do |artefact|
       print "."
-      Rails.application.publishing_api_v2.patch_links(
-        artefact.content_id,
-        links: {
-          ordered_related_items: artefact.ordered_related_artefacts.map(&:content_id).compact
-        }
-      )
+      RelatedLinksPublisher.new(artefact).publish!
     end
   end
 end

--- a/test/services/related_links_publisher_test.rb
+++ b/test/services/related_links_publisher_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require 'gds_api/test_helpers/publishing_api'
+
+class RelatedLinksPublisherTest < ActiveSupport::TestCase
+  def test_it_sends_related_links_properly
+    artefact = FactoryGirl.create(:artefact, content_id: "e0c8d0bf-823d-4466-9c81-8587d3318746")
+    FactoryGirl.create(:artefact, slug: "the-second-one", content_id: "d156631f-ef51-44b8-a0ef-0a7220b0e4fe")
+    FactoryGirl.create(:artefact, slug: "the-first-one", content_id: "72a369e2-4146-4ef2-aeee-7042a25f2a33")
+
+    artefact.related_artefact_slugs = ["the-first-one", "the-second-one"]
+    artefact.save!
+
+    request = stub_request(:patch, "http://publishing-api.dev.gov.uk/v2/links/e0c8d0bf-823d-4466-9c81-8587d3318746").
+      with(:body => { links: { ordered_related_items: ["72a369e2-4146-4ef2-aeee-7042a25f2a33", "d156631f-ef51-44b8-a0ef-0a7220b0e4fe" ] } }.to_json).
+        to_return(body: {}.to_json)
+
+    RelatedLinksPublisher.new(artefact).publish!
+
+    assert_requested(request)
+  end
+end


### PR DESCRIPTION
This class is responsible for sending related artefacts to the publishing-api. It solves a bug where we are sending the artefacts unordered to the API.

cc @rubenarakelyan 
