### PR TITLE
Disallow route registration for migrated apps

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -93,7 +93,6 @@ class RoutableArtefact
 
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
-      OwningApp::BUSINESS_SUPPORT_FINDER,
       OwningApp::CALCULATORS,
       OwningApp::CALENDARS,
       OwningApp::LICENCE_FINDER,

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -93,7 +93,6 @@ class RoutableArtefact
 
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
-      OwningApp::CALCULATORS,
       OwningApp::PUBLISHER,
       OwningApp::SMART_ANSWERS,
     ])

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -94,7 +94,6 @@ class RoutableArtefact
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
       OwningApp::CALCULATORS,
-      OwningApp::LICENCE_FINDER,
       OwningApp::PUBLISHER,
       OwningApp::SMART_ANSWERS,
     ])

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -94,7 +94,6 @@ class RoutableArtefact
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
       OwningApp::CALCULATORS,
-      OwningApp::CALENDARS,
       OwningApp::LICENCE_FINDER,
       OwningApp::PUBLISHER,
       OwningApp::SMART_ANSWERS,


### PR DESCRIPTION
This is now done by the publishing-api.

Can be merged after the following are deployed:

- [ ] https://github.com/alphagov/calendars/pull/128
- [ ] https://github.com/alphagov/licence-finder/pull/91
- [ ] https://github.com/alphagov/business-support-finder/pull/129
- [ ] https://github.com/alphagov/calculators/pull/164

https://trello.com/c/6eOYmUnL/1-register-routes-via-the-publishing-api-for-publisher-formats