### PR TITLE
Fix error when invalid URI in slug field

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -196,6 +196,9 @@ class ArtefactsController < ApplicationController
       return if @artefact.slug.blank? || parameters_to_use['owning_app'].blank?
 
       Rails.application.publishing_api.put_path("/#{@artefact.slug}", "publishing_app" => parameters_to_use['owning_app'])
+    rescue URI::InvalidURIError => e
+      message = e.message
+      render text: message, status: 400
     rescue GdsApi::HTTPClientError => e
       message = ""
       if e.error_details["errors"]

--- a/app/services/parameter_extractor.rb
+++ b/app/services/parameter_extractor.rb
@@ -58,6 +58,8 @@ private
       params[:state] = "live"
     end
 
+    params[:slug] = params[:slug].strip if params[:slug]
+
     params
   end
 end

--- a/test/unit/parameter_extractor_test.rb
+++ b/test/unit/parameter_extractor_test.rb
@@ -13,7 +13,7 @@ class ParameterExtractorTest < ActiveSupport::TestCase
         "need_ids" => "123123,321321",
         "owning_app" => "publisher",
         "related_artefact_slugs" => "",
-        "slug" => "my-super-test",
+        "slug" => "my-super-test ",
       },
       "commit" => "Save and continue editing" )
 


### PR DESCRIPTION
Fixes a problem when an invalid URI in the slug field would error out with a mysterious 500 exception.

This changes trims whitespace from the entered `slug` to ensure this specific error case is handled in the future. It also catches an Invalid URI errors, and renders an error message so editors have the information they need to figure out the problem for themselves.