### PR TITLE
Fix error with rake routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,16 @@ Panopticon::Application.routes.draw do
   # This is necessary to support some whitehall artefacts with a locale extension on the end
   # of the slug.  If we just blanket allow . in the slug, this interferes with the formatted
   # routes, so this instead special cases the 3 variants of locale extensions (.fr, .zh-hk, .es-419)
+  # The following regex matches these requirements:
+  # - 1 or more non-dot characters
+  # - optionally dot followed by a basic locale (eg 'fr')
+  # - optionally followed by a locale extension
   artefact_id_regex = %r{
-    [^\.]+                # 1 or more non-dot characters
-    (\.[a-z]{2}           # optionally dot followed by a basic locale (eg 'fr')
-      (                     # optionally followed by a locale extension
-        -[a-z]{2} |           # eg zh-hk
-        -\d{3}                # eg es-419
+    [^\.]+
+    (\.[a-z]{2}
+      (
+        -[a-z]{2} |
+        -\d{3}
       )?
     )?
   }x
@@ -29,5 +33,7 @@ Panopticon::Application.routes.draw do
 
   root :to => redirect("/artefacts")
 
-  mount GovukAdminTemplate::Engine, at: "/style-guide"
+  if Rails.env.development?
+    mount GovukAdminTemplate::Engine, at: "/style-guide"
+  end
 end


### PR DESCRIPTION
This fixes the error identified in [mainstream migration discovery][1]
where running `rake routes` results in the following error:

It looks like this broke when we bumped Rails from 3 - 4 (https://github.com/alphagov/panopticon/commit/7073925ac24faacb5c1cd68e7457cd873aafb863).

`RegexpError: end pattern with unmatched parenthesis: /^\/artefacts\/((?x-mi:[^\.]+#1ormorenon-dotcharacters(\.[a-z]{2}#optionallydotfollowedbyabasiclocale(eg'fr')(#optionallyfollowedbyalocaleextension-[a-z]{2}|#egzh-hk-\d{3}#eges-419)?)?))\/history(?:\.([^\/.?]+))?$/
/usr/lib/rbenv/versions/2.2.3/bin/bundle:23:in 'load'
/usr/lib/rbenv/versions/2.2.3/bin/bundle:23:in '<main>'`

It looks like [free spacing mode][2] isn't working properly anymore for
`rake routes`.  It works OK in Rails 3.2 which was when the constraint was
added.

I found two options that worked:
- Moving the comments to outside the regex (what I did)
- Using the non-freespace comment style inline:
  - (?# This is a comment)

I chose not to use the inline comment style as it looks slightly like it might
still be code.

I've also wrapped the styleguide in a conditional as there is no need for this
to be present in a production environment.

[1]: https://trello.com/c/WvBbjT89/87-panopticon-s-rake-routes-errors-with-a-regex-unmatched-parenthesis-error
[2]: https://ruby-doc.org/core-2.1.1/Regexp.html#class-Regexp-label-Free-Spacing+Mode+and+Comments