### PR TITLE
[WIP] - Stop Publisher registering routes

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -93,7 +93,6 @@ class RoutableArtefact
 
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
-      OwningApp::PUBLISHER,
       OwningApp::SMART_ANSWERS,
     ])
   end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -26,7 +26,7 @@ class RoutableArtefactTest < ActiveSupport::TestCase
       setup do
         stub_artefact_callbacks
         @artefact = FactoryGirl.create(:live_artefact,
-                                       owning_app: "publisher",
+                                       owning_app: "smart-answers",
                                        paths: ["/foo"])
         @routable = RoutableArtefact.new(@artefact)
       end
@@ -61,16 +61,16 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "registering routes for an artefact" do
     setup do
-      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers")
       @routable = RoutableArtefact.new(@artefact)
       stub_all_router_registration
     end
 
     should "add all defined prefix routes" do
       requests = [
-        stub_route_registration("/foo", "prefix", "publisher"),
-        stub_route_registration("/bar", "prefix", "publisher"),
-        stub_route_registration("/baz", "prefix", "publisher")
+        stub_route_registration("/foo", "prefix", "smart-answers"),
+        stub_route_registration("/bar", "prefix", "smart-answers"),
+        stub_route_registration("/baz", "prefix", "smart-answers")
       ]
 
       @artefact.prefixes = ["/foo", "/bar", "/baz"]
@@ -83,8 +83,8 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
     should "add all defined exact routes" do
       requests = [
-        stub_route_registration("/foo.json", "exact", "publisher"),
-        stub_route_registration("/bar", "exact", "publisher")
+        stub_route_registration("/foo.json", "exact", "smart-answers"),
+        stub_route_registration("/bar", "exact", "smart-answers")
       ]
 
       @artefact.paths = ["/foo.json", "/bar"]
@@ -106,7 +106,7 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "deleting routes for an artefact" do
     setup do
-      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers")
       @routable = RoutableArtefact.new(@artefact)
     end
 
@@ -178,7 +178,7 @@ class RoutableArtefactTest < ActiveSupport::TestCase
 
   context "redirecting routes for an artefact" do
     setup do
-      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @artefact = FactoryGirl.create(:artefact, owning_app: "smart-answers")
       @routable = RoutableArtefact.new(@artefact)
     end
 


### PR DESCRIPTION
Publisher now uses the Publishing API to register routes for all it's formats.

Merge after:

- [ ] - https://github.com/alphagov/govuk-content-schemas/pull/465
- [ ] - https://github.com/alphagov/publisher/pull/520

[Trello card](https://trello.com/c/sZyeX2Ul/570-preparatory-work-fix-content-item-routes-for-publisher-formats-3)