### PR TITLE
Remove Smart Answers from the routes whitelist

### DIFF
--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -94,7 +94,6 @@ class RoutableArtefact
   def allowed_to_register_routes_here_even_though_it_should_use_the_publishing_api?
     artefact.owning_app.in?([
       OwningApp::PUBLISHER,
-      OwningApp::SMART_ANSWERS,
     ])
   end
 


### PR DESCRIPTION
We gradually whittling away at the list of apps that we register routes for in
Panopticon.  Once [this PR][1] is merged (so that Smart Answers uses the
publishing platform to register routes) we can remove it from this list.

[1]: https://github.com/alphagov/smart-answers/pull/2846