### PR TITLE
Remove section & related items columns from index

### DIFF
--- a/app/views/artefacts/index.html.erb
+++ b/app/views/artefacts/index.html.erb
@@ -17,9 +17,6 @@
             <th scope="col"><%= sortable "need_id", "Needs" %></th>
             <th scope="col"><%= sortable "name", "Title" %></th>
             <th scope="col"><%= sortable "kind", "Format" %></th>
-            <th scope="col">Primary section</th>
-            <th scope="col">Other sections</th>
-            <th scope="col">Related items</th>
             <th scope="col"><%= sortable "owning_app", "App" %></th>
             <th scope="col"><%= sortable "slug", "Slug" %></th>
           </tr>


### PR DESCRIPTION
We no longer manage sections and related items in this application.

Forgot to do this in https://github.com/alphagov/panopticon/pull/419.

https://trello.com/c/7u8M6zrg